### PR TITLE
Prevent concurrency issues in QueryCache

### DIFF
--- a/api/Engraved.Core.Tests/Source/Application/DispatcherShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/DispatcherShould.cs
@@ -108,7 +108,7 @@ public class DispatcherShould
 
     Dispatcher dispatcher1 = CreateDispatcher("user_one");
     Guid resultFirstExecution = await dispatcher1.Query<Guid, FakeQuery>(query);
-    await dispatcher1.Command(new FakeCommand { AffectedUsers = new List<string> { "user_zero", "user_one" } });
+    await dispatcher1.Command(new FakeCommand { AffectedUsers = ["user_zero", "user_one"] });
 
     Guid resultSecondExecution = await dispatcher1.Query<Guid, FakeQuery>(query);
     resultFirstExecution.Should().NotBe(resultSecondExecution);

--- a/api/Engraved.Core.Tests/Source/Application/DispatcherShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/DispatcherShould.cs
@@ -108,7 +108,7 @@ public class DispatcherShould
 
     Dispatcher dispatcher1 = CreateDispatcher("user_one");
     Guid resultFirstExecution = await dispatcher1.Query<Guid, FakeQuery>(query);
-    await dispatcher1.Command(new FakeCommand { AffectedUsers = ["user_zero", "user_one"] });
+    await dispatcher1.Command(new FakeCommand { AffectedUsers = new List<string> { "user_zero", "user_one" } });
 
     Guid resultSecondExecution = await dispatcher1.Query<Guid, FakeQuery>(query);
     resultFirstExecution.Should().NotBe(resultSecondExecution);
@@ -117,10 +117,39 @@ public class DispatcherShould
     firstResultOtherUser.Should().NotBe(secondResultOtherUser);
   }
 
-  private Dispatcher CreateDispatcher(string userName)
+  [Test]
+  public async Task Parallel()
+  {
+    // we use the same queryCache instance to simulate multiple request from the
+    // same user at the same time.
+    var currentUser = new Lazy<IUser>(() => new User { Id = "user_one", Name = "user_one" });
+    var queryCache = new QueryCache(NullLogger<QueryCache>.Instance, _memoryCache, currentUser);
+
+    var parallelTaskCount = 10;
+    var actionPerTaskCount = 100;
+    
+    var tasks = new Task[parallelTaskCount];
+
+    for (var taskIndex = 0; taskIndex < parallelTaskCount; taskIndex++)
+    {
+      tasks[taskIndex] = Task.Run(async () =>
+      {
+        for (var actionIndex = 0; actionIndex < actionPerTaskCount; actionIndex++)
+        {
+          Dispatcher dispatcher = CreateDispatcher("user_one", queryCache);
+          await dispatcher.Query<Guid, FakeQuery>(new FakeQuery());
+          await dispatcher.Command(new FakeCommand { AffectedUsers = ["user_zero", "user_one"] });
+        }
+      });
+    }
+
+    await Task.WhenAll(tasks);
+  }
+
+  private Dispatcher CreateDispatcher(string userName, QueryCache? queryCache = null)
   {
     var currentUser = new Lazy<IUser>(() => new User { Id = userName, Name = userName });
-    var queryCache = new QueryCache(NullLogger<QueryCache>.Instance, _memoryCache, currentUser);
+    queryCache ??= new QueryCache(NullLogger<QueryCache>.Instance, _memoryCache, currentUser);
 
     return new Dispatcher(
       NullLogger<Dispatcher>.Instance,
@@ -133,7 +162,7 @@ public class DispatcherShould
 
 public class FakeCommand : ICommand
 {
-  public List<string> AffectedUsers { get; set; } = [];
+  public List<string> AffectedUsers { get; set; } = new List<string>();
 }
 
 public class FakeCommandExecutor : ICommandExecutor<FakeCommand>

--- a/api/Engraved.Core/Source/Application/Queries/QueryCache.cs
+++ b/api/Engraved.Core/Source/Application/Queries/QueryCache.cs
@@ -11,7 +11,10 @@ public class QueryCache(ILogger<QueryCache> logger, IMemoryCache memoryCache, La
   private const string KeysByUserId = "___keysByUserId";
 
   private ConcurrentDictionary<string, ConcurrentDictionary<string, byte>> QueryKeysByUser
-    => memoryCache.GetOrCreate(KeysByUserId, _ => new ConcurrentDictionary<string, ConcurrentDictionary<string, byte>>())!;
+    => memoryCache.GetOrCreate(
+      KeysByUserId,
+      _ => new ConcurrentDictionary<string, ConcurrentDictionary<string, byte>>()
+    )!;
 
   public void Set<TValue, TQuery>(IQueryExecutor<TValue, TQuery> queryExecutor, TQuery query, TValue value)
     where TQuery : IQuery
@@ -92,9 +95,9 @@ public class QueryCache(ILogger<QueryCache> logger, IMemoryCache memoryCache, La
 
   private void RememberQueryKeyForUser(string queryKey)
   {
-    var userId = GetUserId();
-    var set = QueryKeysByUser.GetOrAdd(userId, _ => new ConcurrentDictionary<string, byte>());
-    set.TryAdd(queryKey, 0);
+    QueryKeysByUser
+      .GetOrAdd(GetUserId(), _ => new ConcurrentDictionary<string, byte>())
+      .TryAdd(queryKey, 0);
   }
 
   private string GetUserId()


### PR DESCRIPTION
This should prevent `Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct`-errors.