### PR TITLE
Add e2e tests for search page

### DIFF
--- a/app/src/components/common/search/SearchBox.tsx
+++ b/app/src/components/common/search/SearchBox.tsx
@@ -34,6 +34,7 @@ export const SearchBox: React.FC<{
             endAdornment: (
               <>
                 <IconButton
+                  aria-label="Clear search"
                   sx={{ visibility: currentFieldValue ? "visible" : "hidden" }}
                   onClick={() => {
                     setSearchText("");

--- a/tests/src/poms/scrapsJournalPage.ts
+++ b/tests/src/poms/scrapsJournalPage.ts
@@ -31,17 +31,32 @@ export class ScrapsJournalPage extends JournalPage {
     return new ScrapListComponent(this.page);
   }
 
-  async addMarkdownWithTitle(title: string) {
+  async addEntry(title: string, content?: string) {
     await this.clickPageAction("Add entry");
 
     await this.getTitleBox().click();
     await this.getTitleBox().fill(title);
-    await this.getTitleBox().press("Alt+s");
+
+    if (content) {
+      const contentEditor = this.page
+        .getByTestId("add-new-scrap")
+        .locator(".tiptap")
+        .last();
+      await contentEditor.click();
+      await contentEditor.fill(content);
+      await contentEditor.press("Alt+s");
+    } else {
+      await this.getTitleBox().press("Alt+s");
+    }
 
     const appBar = this.page.getByTestId("app-alert-bar");
     await expect(appBar).toContainText("Added entry");
     await appBar.getByRole("button", { name: "Close" }).click();
     await expect(appBar).toBeHidden({ timeout: 2000 });
+  }
+
+  async addMarkdownWithTitle(title: string) {
+    return this.addEntry(title);
   }
 
   private async isMarkdown() {

--- a/tests/src/poms/scrapsJournalPage.ts
+++ b/tests/src/poms/scrapsJournalPage.ts
@@ -37,7 +37,7 @@ export class ScrapsJournalPage extends JournalPage {
     await this.getTitleBox().click();
     await this.getTitleBox().fill(title);
 
-    if (content) {
+    if (content !== undefined) {
       const contentEditor = this.page
         .getByTestId("add-new-scrap")
         .locator(".tiptap")

--- a/tests/src/poms/searchPage.ts
+++ b/tests/src/poms/searchPage.ts
@@ -1,0 +1,26 @@
+import { expect } from "@playwright/test";
+import { BasePage } from "./basePage";
+
+export class SearchPage extends BasePage {
+  async search(text: string) {
+    const searchInput = this.page.getByRole("textbox", { name: "Search" });
+    await searchInput.fill(text);
+    await searchInput.press("Enter");
+  }
+
+  async clearSearch() {
+    await this.page.getByRole("button", { name: "Clear search" }).click();
+  }
+
+  async expectResultVisible(title: string) {
+    await expect(this.page.getByText(title).first()).toBeVisible();
+  }
+
+  async expectResultNotVisible(title: string) {
+    await expect(this.page.getByText(title)).toBeHidden();
+  }
+
+  async expectNoResults() {
+    await expect(this.page.getByText(/Nothing found/)).toBeVisible();
+  }
+}

--- a/tests/src/poms/searchPage.ts
+++ b/tests/src/poms/searchPage.ts
@@ -12,12 +12,8 @@ export class SearchPage extends BasePage {
     await this.page.getByRole("button", { name: "Clear search" }).click();
   }
 
-  async expectResultVisible(title: string) {
-    await expect(this.page.getByText(title).first()).toBeVisible();
-  }
-
   async expectResultNotVisible(title: string) {
-    await expect(this.page.getByText(title)).toBeHidden();
+    await expect(this.page.getByText(title).first()).toBeHidden();
   }
 
   async expectNoResults() {

--- a/tests/src/poms/searchPage.ts
+++ b/tests/src/poms/searchPage.ts
@@ -12,6 +12,10 @@ export class SearchPage extends BasePage {
     await this.page.getByRole("button", { name: "Clear search" }).click();
   }
 
+  async expectResultVisible(title: string) {
+    await expect(this.page.getByText(title).first()).toBeVisible();
+  }
+
   async expectResultNotVisible(title: string) {
     await expect(this.page.getByText(title).first()).toBeHidden();
   }

--- a/tests/src/utils/navigateTo.ts
+++ b/tests/src/utils/navigateTo.ts
@@ -2,6 +2,7 @@ import { expect, Page } from "@playwright/test";
 import { EntriesPage } from "../poms/entriesPage";
 import { ScheduledPage } from "../poms/scheduledPage";
 import { MetricJournalPage } from "../poms/metricJournalPage";
+import { SearchPage } from "../poms/searchPage";
 import { isAndroidTest } from "./isAndroidTest";
 
 export async function navigateToHome(page: Page) {
@@ -32,4 +33,11 @@ export async function navigateToJournalPage(page: Page, journalName: string) {
   // this could also be a ScrapJournalPage, but for the moment
   // a MetricJournalPage is enough.
   return new MetricJournalPage(page);
+}
+
+export async function navigateToSearchPage(page: Page) {
+  await page
+    .getByRole("link", { name: "Search anything", exact: true })
+    .click();
+  return new SearchPage(page);
 }

--- a/tests/tests/search.spec.ts
+++ b/tests/tests/search.spec.ts
@@ -1,0 +1,101 @@
+import { Page, test } from "@playwright/test";
+import { login } from "../src/utils/login";
+import { addNewJournal } from "../src/utils/addNewJournal";
+import { navigateToSearchPage } from "../src/utils/navigateTo";
+import { ScrapsJournalPage } from "../src/poms/scrapsJournalPage";
+
+type Entry = { title: string; content?: string };
+
+async function createScrapsJournalWithEntries(
+  page: Page,
+  journalName: string,
+  entries: Entry[],
+  journalDescription?: string,
+): Promise<void> {
+  await addNewJournal(page, "Scraps", journalName, journalDescription);
+  const journalPage = new ScrapsJournalPage(page);
+  for (const entry of entries) {
+    await journalPage.addEntry(entry.title, entry.content);
+  }
+}
+
+test.beforeEach(async ({ page }) => {
+  await login(page, "search");
+});
+
+test("finds entry by title match", async ({ page }) => {
+  await createScrapsJournalWithEntries(page, "My Journal", [
+    { title: "Alpine Trek" },
+  ]);
+
+  const searchPage = await navigateToSearchPage(page);
+  await searchPage.search("Alpine");
+  await searchPage.expectResultVisible("Alpine Trek");
+});
+
+test("finds entry by content match", async ({ page }) => {
+  await createScrapsJournalWithEntries(page, "My Journal", [
+    { title: "Walk notes", content: "unexplored canyon route" },
+  ]);
+
+  const searchPage = await navigateToSearchPage(page);
+  await searchPage.search("canyon");
+  await searchPage.expectResultVisible("Walk notes");
+});
+
+test("finds journal by name match", async ({ page }) => {
+  await addNewJournal(page, "Scraps", "Birding Log");
+
+  const searchPage = await navigateToSearchPage(page);
+  await searchPage.search("Birding");
+  await searchPage.expectResultVisible("Birding Log");
+});
+
+test("finds journal by description match", async ({ page }) => {
+  await addNewJournal(page, "Scraps", "Field Journal", "wetland observations");
+
+  const searchPage = await navigateToSearchPage(page);
+  await searchPage.search("wetland");
+  await searchPage.expectResultVisible("Field Journal");
+});
+
+test("returns both entries and journals when both match", async ({ page }) => {
+  await createScrapsJournalWithEntries(page, "Geology Study", [
+    { title: "Geology Study notes" },
+  ]);
+
+  const searchPage = await navigateToSearchPage(page);
+  await searchPage.search("Geology Study");
+  await searchPage.expectResultVisible("Geology Study");
+  await searchPage.expectResultVisible("Geology Study notes");
+});
+
+test("shows no results for non-matching search", async ({ page }) => {
+  const searchPage = await navigateToSearchPage(page);
+  await searchPage.search("zzznomatch999");
+  await searchPage.expectNoResults();
+});
+
+test("narrows and widens search updates results", async ({ page }) => {
+  await createScrapsJournalWithEntries(page, "Wildlife Journal", [
+    { title: "Red Fox" },
+    { title: "Red Kite" },
+    { title: "Blue Jay" },
+  ]);
+
+  const searchPage = await navigateToSearchPage(page);
+
+  await searchPage.search("Red");
+  await searchPage.expectResultVisible("Red Fox");
+  await searchPage.expectResultVisible("Red Kite");
+  await searchPage.expectResultNotVisible("Blue Jay");
+
+  await searchPage.search("Red Fox");
+  await searchPage.expectResultVisible("Red Fox");
+  await searchPage.expectResultNotVisible("Red Kite");
+
+  await searchPage.clearSearch();
+  await searchPage.search("Red");
+  await searchPage.expectResultVisible("Red Fox");
+  await searchPage.expectResultVisible("Red Kite");
+});


### PR DESCRIPTION
Adds 7 test cases covering entry/journal title and content matching, mixed results, no-results state, and progressive narrowing/widening of search terms.