### PR TITLE
Never remove a scrap schedule on save (only set/change it)

### DIFF
--- a/app/src/components/details/scraps/ScrapContextProvider.tsx
+++ b/app/src/components/details/scraps/ScrapContextProvider.tsx
@@ -11,7 +11,10 @@ import {
   ScrapContext,
 } from "./ScrapContext";
 import { IParsedDate } from "../edit/parseDate";
-import { getScheduleDefinition } from "../../overview/scheduled/scheduleUtils";
+import {
+  getScheduleDefinitionForUpsert,
+  getScheduleForUser,
+} from "../../overview/scheduled/scheduleUtils";
 import { ActionFactory } from "../../common/actions/ActionFactory";
 import { useDialogContext } from "../../layout/dialogs/DialogContext";
 import { IJournal } from "../../../serverApi/IJournal";
@@ -51,7 +54,7 @@ export const ScrapContextProvider: React.FC<{
   isQuickAdd,
   changeTypeWithoutConfirmation,
 }) => {
-  const { setAppAlert } = useAppContext();
+  const { setAppAlert, user } = useAppContext();
   const { renderDialog } = useDialogContext();
 
   const [scrapToRender, setScrapToRender] = useState(initialScrap);
@@ -366,8 +369,11 @@ export const ScrapContextProvider: React.FC<{
         dateTime: scrapToRender.dateTime
           ? new Date(scrapToRender.dateTime)
           : new Date(),
-        schedule: getScheduleDefinition(
-          parsedDate ?? { input: "" },
+        // Preserve an existing schedule when the title (and therefore the date)
+        // was not touched - otherwise auto-save would clear it.
+        schedule: getScheduleDefinitionForUpsert(
+          parsedDate,
+          getScheduleForUser(initialScrap, user?.id ?? ""),
           journalId,
           scrapToRender?.id ?? "new-entry-id",
         ),

--- a/app/src/components/overview/scheduled/scheduleUtils.test.ts
+++ b/app/src/components/overview/scheduled/scheduleUtils.test.ts
@@ -1,0 +1,101 @@
+import { getScheduleDefinitionForUpsert } from "./scheduleUtils";
+import { IParsedDate } from "../../details/edit/parseDate";
+import { ISchedule } from "../../../serverApi/ISchedule";
+
+describe("getScheduleDefinitionForUpsert", () => {
+  const journalId = "journal-1";
+  const entryId = "entry-1";
+
+  it("uses the date typed into the title when the title was edited", () => {
+    const date = new Date(2030, 0, 1, 9, 0, 0);
+    const parsedDate: IParsedDate = { input: "in 2h", date };
+
+    const result = getScheduleDefinitionForUpsert(
+      parsedDate,
+      undefined,
+      journalId,
+      entryId,
+    );
+
+    expect(result.nextOccurrence).toEqual(date);
+    expect(result.onClickUrl).toContain(journalId);
+  });
+
+  it("changes an existing schedule when a new date is typed", () => {
+    const existing: ISchedule = {
+      nextOccurrence: new Date(2030, 0, 1, 9, 0, 0).toISOString(),
+    };
+    const newDate = new Date(2031, 5, 15, 8, 0, 0);
+    const parsedDate: IParsedDate = { input: "tomorrow", date: newDate };
+
+    const result = getScheduleDefinitionForUpsert(
+      parsedDate,
+      existing,
+      journalId,
+      entryId,
+    );
+
+    expect(result.nextOccurrence).toEqual(newDate);
+  });
+
+  // This is the regression that auto-save introduced: saving without touching
+  // the title must keep an already existing schedule instead of clearing it.
+  it("preserves an existing schedule when the title was not touched", () => {
+    const existing: ISchedule = {
+      nextOccurrence: new Date(2030, 0, 1, 9, 0, 0).toISOString(),
+      recurrence: { dateString: "every monday" },
+    };
+
+    const result = getScheduleDefinitionForUpsert(
+      undefined,
+      existing,
+      journalId,
+      entryId,
+    );
+
+    expect(result.nextOccurrence).toEqual(new Date(existing.nextOccurrence!));
+    expect(result.recurrence).toEqual(existing.recurrence);
+    expect(result.onClickUrl).toContain(journalId);
+  });
+
+  it("clears the schedule when nothing was typed and nothing exists", () => {
+    const result = getScheduleDefinitionForUpsert(
+      undefined,
+      undefined,
+      journalId,
+      entryId,
+    );
+
+    expect(result.nextOccurrence).toBeNull();
+    expect(result.onClickUrl).toBeNull();
+  });
+
+  it("does not preserve an existing schedule without a next occurrence", () => {
+    const result = getScheduleDefinitionForUpsert(
+      undefined,
+      {},
+      journalId,
+      entryId,
+    );
+
+    expect(result.nextOccurrence).toBeNull();
+  });
+
+  it("keeps an existing schedule even when the title is edited without a date", () => {
+    // editing the title to a non-date value must NOT remove the schedule - a
+    // save can never remove a schedule, only the edit-schedule action can.
+    const parsedDate: IParsedDate = { input: "groceries", text: "groceries" };
+    const existing: ISchedule = {
+      nextOccurrence: new Date(2030, 0, 1).toISOString(),
+    };
+
+    const result = getScheduleDefinitionForUpsert(
+      parsedDate,
+      existing,
+      journalId,
+      entryId,
+    );
+
+    expect(result.nextOccurrence).toEqual(new Date(existing.nextOccurrence!));
+  });
+});

--- a/app/src/components/overview/scheduled/scheduleUtils.tsx
+++ b/app/src/components/overview/scheduled/scheduleUtils.tsx
@@ -65,6 +65,38 @@ export function getScheduleDefinition(
     : { nextOccurrence: null, onClickUrl: null };
 }
 
+// Resolves the schedule definition to persist when saving an entry.
+//
+// A save may only set or change a schedule, never remove one. The schedule is
+// derived from a date typed into the title: when a new date is present it is
+// applied; otherwise (auto-save, body/list edits, or a title edit without a
+// date) any existing schedule is kept untouched. Removing a schedule is done
+// exclusively through the dedicated "edit schedule" action.
+export function getScheduleDefinitionForUpsert(
+  parsedDate: IParsedDate | undefined,
+  existingSchedule: ISchedule | undefined,
+  journalId: string | undefined,
+  entryId: string,
+): IScheduleDefinition {
+  if (parsedDate?.date) {
+    return getScheduleDefinition(parsedDate, journalId, entryId);
+  }
+
+  if (existingSchedule?.nextOccurrence) {
+    return getScheduleDefinition(
+      {
+        input: "",
+        date: new Date(existingSchedule.nextOccurrence),
+        recurrence: existingSchedule.recurrence,
+      },
+      journalId,
+      entryId,
+    );
+  }
+
+  return { nextOccurrence: null, onClickUrl: null };
+}
+
 export function sortEntitiesByDates(
   entities: IEntity[],
   userId: string,

--- a/tests/tests/schedule.spec.ts
+++ b/tests/tests/schedule.spec.ts
@@ -3,10 +3,12 @@ import { login } from "../src/utils/login";
 import {
   navigateToEntriesPage,
   navigateToHome,
+  navigateToJournalPage,
   navigateToScheduledPage,
 } from "../src/utils/navigateTo";
 import { isAndroidTest } from "../src/utils/isAndroidTest";
 import { ScrapsJournalPage } from "../src/poms/scrapsJournalPage";
+import { ScrapMarkdownComponent } from "../src/poms/scrapMarkdownComponent";
 
 test("add schedule to entry and mark as done", async ({ page }) => {
   await login(page, "schedule", "Scraps", "My Journal");
@@ -41,4 +43,67 @@ test("add schedule to entry and mark as done", async ({ page }) => {
 
   const entriesPage = await navigateToEntriesPage(page);
   await entriesPage.expectToShowEntity(entityId);
+});
+
+test("auto-save keeps an existing schedule", async ({ page }) => {
+  await login(page, "schedule-autosave", "Scraps", "My Journal");
+
+  const journalPage = new ScrapsJournalPage(page);
+
+  // create a scheduled note (the date in the title sets the schedule)
+  const quickAdd = await journalPage.clickAddQuickScrapAction();
+  await quickAdd.selectJournal("My Journal");
+  await quickAdd.typeTitle("Buy milk tom at 17:30");
+  await quickAdd.typeContent("remember");
+  const entityId = await quickAdd.clickSave();
+
+  // it shows up on the scheduled page
+  await navigateToHome(page);
+  let scheduledPage = await navigateToScheduledPage(page);
+  await expect(scheduledPage.getEntityElement(entityId)).toBeVisible();
+
+  // edit the note's body and trigger auto-save by clicking outside the scrap
+  await navigateToHome(page);
+  await navigateToJournalPage(page, "My Journal");
+
+  const note = new ScrapMarkdownComponent(page);
+  await note.dblClickToEdit();
+  await note.typeAtEnd(" and bread");
+  await note.blurToAutoSave(true);
+
+  // the schedule must survive the auto-save: still on the scheduled page
+  await navigateToHome(page);
+  scheduledPage = await navigateToScheduledPage(page);
+  await expect(scheduledPage.getEntityElement(entityId)).toBeVisible();
+});
+
+test("editing the title keeps an existing schedule", async ({ page }) => {
+  await login(page, "schedule-title-edit", "Scraps", "My Journal");
+
+  const journalPage = new ScrapsJournalPage(page);
+
+  const quickAdd = await journalPage.clickAddQuickScrapAction();
+  await quickAdd.selectJournal("My Journal");
+  await quickAdd.typeTitle("Buy milk tom at 17:30");
+  await quickAdd.typeContent("remember");
+  const entityId = await quickAdd.clickSave();
+
+  await navigateToHome(page);
+  let scheduledPage = await navigateToScheduledPage(page);
+  await expect(scheduledPage.getEntityElement(entityId)).toBeVisible();
+
+  // change the title to a value without a date, then auto-save by clicking out.
+  await navigateToHome(page);
+  await navigateToJournalPage(page, "My Journal");
+
+  const note = new ScrapMarkdownComponent(page);
+  await note.dblClickToEdit();
+  await page.getByTestId("placeholder-Title").click();
+  await page.getByTestId("placeholder-Title").fill("Buy groceries");
+  await note.blurToAutoSave(true);
+
+  // a save never removes a schedule: it is still on the scheduled page.
+  await navigateToHome(page);
+  scheduledPage = await navigateToScheduledPage(page);
+  await expect(scheduledPage.getEntityElement(entityId)).toBeVisible();
 });


### PR DESCRIPTION
The scrap schedule is derived from a date typed into the title (parsedDate). On save the command sent getScheduleDefinition(parsedDate ?? {input:""}), which returns a *clearing* definition whenever no date is present - so auto-save, body /list edits, and even editing the title to a non-date value all wiped an existing schedule.

A save must only ever set or change a schedule, never remove one (removing is done exclusively via the dedicated "edit schedule" action). Add getScheduleDefinitionForUpsert: apply a newly typed date, otherwise keep any existing schedule untouched.

Covered by unit tests (scheduleUtils.test.ts) and e2e regression tests (auto-save and title edits keep an existing schedule).