### PR TITLE
Set Renovate minimum release age to 10 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "ignorePaths": [],
+  "minimumReleaseAge": "10 days",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
Sets `minimumReleaseAge` to `10 days` in `renovate.json` to prevent freshly published (potentially compromised) dependency versions from being auto-merged too early.

See https://docs.renovatebot.com/key-concepts/minimum-release-age/

Closes #2799

🤖 Generated with [Claude Code](https://claude.com/claude-code)