### PR TITLE
Speed up e2e tests: Cache Playwright browsers and parallelize by project

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,9 +5,14 @@ on:
 
 jobs:
   test:
-    name: Run Tests
+    name: Run Tests (${{ matrix.project }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [chromium, android]
 
     services:
       mongo:
@@ -51,17 +56,30 @@ jobs:
         working-directory: tests
         run: npm run types:check
 
-      - name: Install Playwright dependencies and chromium browser
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('tests/package-lock.json') }}
+
+      - name: Install Playwright chromium browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: tests
         run: npx playwright install --with-deps chromium
 
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: tests
+        run: npx playwright install-deps chromium
+
       - name: Run Playwright tests
         working-directory: tests
-        run: npm run e2e:run-tests
+        run: npm run e2e:run-tests -- --project=${{ matrix.project }}
 
       - name: Prepare artifact name suffix
         if: failure()
-        run: echo "ARTIFACT_SUFFIX=${{ github.run_id }}-$(date -u +%Y-%m-%d-%H%M%S)" >> $GITHUB_ENV
+        run: echo "ARTIFACT_SUFFIX=${{ matrix.project }}-${{ github.run_id }}-$(date -u +%Y-%m-%d-%H%M%S)" >> $GITHUB_ENV
 
       - name: Upload playwright-report
         if: failure()


### PR DESCRIPTION
- Cache ~/.cache/ms-playwright keyed on tests/package-lock.json so the slow "playwright install" step is skipped on cache hit (only OS deps are installed in that case).
- Split the chromium and android Playwright projects into a parallel GitHub Actions matrix so the two runs execute concurrently on separate runners instead of serially in one job.
- Make failure-artifact names unique per matrix project to avoid upload collisions.

Refs #2809