### PR TITLE
Use all CPU cores for Playwright workers on CI

### DIFF
--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -20,7 +20,7 @@ const isCi = process.env.CI;
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
-  workers: isCi ? undefined : 3,
+  workers: isCi ? "100%" : 3,
   forbidOnly: !!isCi,
   retries: 0,
   reporter: isCi ? [["list"], ["html"], ["github"]] : [["list"], ["html"]],


### PR DESCRIPTION
On CI Playwright defaulted to "undefined", i.e. half the available cores (~2 on a standard GitHub runner). Set workers to "100%" so each runner uses one worker per core, increasing intra-job parallelism on top of the existing chromium/android matrix split.

Refs #2809