### PR TITLE
Add e2e test-data seeding endpoint + migrate entries.spec (PoC)

### DIFF
--- a/api/Engraved.Api/Source/Controllers/TestDataController.cs
+++ b/api/Engraved.Api/Source/Controllers/TestDataController.cs
@@ -1,0 +1,126 @@
+using Engraved.Api.Authentication;
+using Engraved.Api.Settings;
+using Engraved.Core.Application;
+using Engraved.Core.Application.Commands;
+using Engraved.Core.Application.Commands.Entries.Upsert.Counter;
+using Engraved.Core.Application.Commands.Entries.Upsert.Gauge;
+using Engraved.Core.Application.Commands.Entries.Upsert.Scraps;
+using Engraved.Core.Application.Commands.Journals.Add;
+using Engraved.Core.Domain.Journals;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Engraved.Api.Controllers;
+
+/// <summary>
+/// Endpoint to seed an entire test scenario (journals + entries) in a single
+/// call. It is a thin batching facade over the very same command handlers the
+/// real controllers use, so seeded data is identical to data created through
+/// the UI. Only active in e2e-test mode - returns 404 otherwise.
+/// </summary>
+[ApiController]
+[Route("api/test")]
+[Authorize]
+public class TestDataController(
+  Dispatcher dispatcher,
+  ILoginHandler loginHandler,
+  ICurrentUserService currentUserService,
+  E2ETestMode testMode
+) : ControllerBase
+{
+  [HttpPost("seed")]
+  public async Task<ActionResult<SeedResult>> Seed([FromBody] SeedTestDataDto dto)
+  {
+    if (!testMode.IsEnabled)
+    {
+      return NotFound();
+    }
+
+    // Ensure the user exists before dispatching commands - the user is not
+    // auto-created on first command (UserLoader throws for unknown users).
+    // This is the same path the app's e2e login uses.
+    await loginHandler.LoginForTests(currentUserService.GetUserName());
+
+    var seededJournals = new List<SeededJournal>();
+
+    foreach (SeedJournalDto journalDto in dto.Journals)
+    {
+      string journalId = (await dispatcher.Command(
+        new AddJournalCommand
+        {
+          Name = journalDto.Name,
+          Description = journalDto.Description,
+          Type = journalDto.Type
+        }
+      )).EntityId;
+
+      var entryIds = new List<string>();
+      foreach (SeedEntryDto entryDto in journalDto.Entries)
+      {
+        CommandResult result = await DispatchEntryCommand(journalId, journalDto.Type, entryDto);
+        entryIds.Add(result.EntityId);
+      }
+
+      seededJournals.Add(new SeededJournal { JournalId = journalId, EntryIds = entryIds.ToArray() });
+    }
+
+    return new SeedResult { Journals = seededJournals.ToArray() };
+  }
+
+  private async Task<CommandResult> DispatchEntryCommand(string journalId, JournalType type, SeedEntryDto entry)
+  {
+    // Dispatch with the concrete command type so the right executor resolves.
+    return type switch
+    {
+      JournalType.Gauge => await dispatcher.Command(
+        new UpsertGaugeEntryCommand { JournalId = journalId, Value = entry.Value, Notes = entry.Notes }
+      ),
+      JournalType.Counter => await dispatcher.Command(
+        new UpsertCounterEntryCommand { JournalId = journalId, Notes = entry.Notes }
+      ),
+      JournalType.Scraps => await dispatcher.Command(
+        new UpsertScrapsEntryCommand { JournalId = journalId, Title = entry.Title ?? "", Notes = entry.Notes }
+      ),
+      _ => throw new InvalidOperationException(
+        $"Seeding entries for journal type '{type}' is not supported yet."
+      )
+    };
+  }
+}
+
+public class SeedTestDataDto
+{
+  public SeedJournalDto[] Journals { get; set; } = [];
+}
+
+public class SeedJournalDto
+{
+  public string Name { get; set; } = null!;
+
+  public string? Description { get; set; }
+
+  public JournalType Type { get; set; }
+
+  public SeedEntryDto[] Entries { get; set; } = [];
+}
+
+public class SeedEntryDto
+{
+  public double? Value { get; set; }
+
+  public string? Title { get; set; }
+
+  public string? Notes { get; set; }
+}
+
+public class SeedResult
+{
+  public SeededJournal[] Journals { get; set; } = [];
+}
+
+public class SeededJournal
+{
+  public string JournalId { get; set; } = null!;
+
+  public string[] EntryIds { get; set; } = [];
+}

--- a/api/Engraved.Api/Source/Program.cs
+++ b/api/Engraved.Api/Source/Program.cs
@@ -131,6 +131,7 @@ builder.Services.AddTransient<Lazy<IUser>>(provider => provider.GetService<IUser
 builder.Services.AddTransient<IRepository>(provider => provider.GetService<IUserScopedRepository>()!
 );
 
+builder.Services.AddSingleton(new E2ETestMode(isE2ETests));
 builder.Services.AddMemoryCache();
 builder.Services.AddTransient<QueryCache>();
 builder.Services.AddTransient<Dispatcher>();

--- a/api/Engraved.Api/Source/Settings/E2ETestMode.cs
+++ b/api/Engraved.Api/Source/Settings/E2ETestMode.cs
@@ -1,0 +1,12 @@
+namespace Engraved.Api.Settings;
+
+/// <summary>
+/// Flag indicating whether the API was started in e2e-test mode (i.e. with the
+/// "e2e-tests" command line argument). Registered as a singleton so endpoints
+/// that must only exist for e2e tests (e.g. the test-data seeding endpoint) can
+/// hard-guard themselves and stay inert in production.
+/// </summary>
+public class E2ETestMode(bool isEnabled)
+{
+  public bool IsEnabled { get; } = isEnabled;
+}

--- a/tests/src/api/testData.ts
+++ b/tests/src/api/testData.ts
@@ -2,15 +2,15 @@ import { APIRequestContext } from "@playwright/test";
 
 const API_BASE_URL = "http://localhost:5072";
 
-export type SeedJournalType = "Counter" | "Gauge" | "Timer" | "Scraps";
+type SeedJournalType = "Counter" | "Gauge" | "Timer" | "Scraps";
 
-export interface SeedEntry {
+interface SeedEntry {
   value?: number;
   title?: string;
   notes?: string;
 }
 
-export interface SeedJournal {
+interface SeedJournal {
   name: string;
   description?: string;
   type: SeedJournalType;
@@ -21,7 +21,7 @@ export interface Scenario {
   journals: SeedJournal[];
 }
 
-export interface SeededJournal {
+interface SeededJournal {
   journalId: string;
   entryIds: string[];
 }

--- a/tests/src/api/testData.ts
+++ b/tests/src/api/testData.ts
@@ -1,0 +1,59 @@
+import { APIRequestContext } from "@playwright/test";
+
+const API_BASE_URL = "http://localhost:5072";
+
+export type SeedJournalType = "Counter" | "Gauge" | "Timer" | "Scraps";
+
+export interface SeedEntry {
+  value?: number;
+  title?: string;
+  notes?: string;
+}
+
+export interface SeedJournal {
+  name: string;
+  description?: string;
+  type: SeedJournalType;
+  entries?: SeedEntry[];
+}
+
+export interface Scenario {
+  journals: SeedJournal[];
+}
+
+export interface SeededJournal {
+  journalId: string;
+  entryIds: string[];
+}
+
+export interface SeedResult {
+  journals: SeededJournal[];
+}
+
+/**
+ * Test-data builder. The ONLY place aware of how setup data is created on the
+ * backend. Tests express a scenario in domain language; this seeds it in a
+ * single call to the e2e-only `/api/test/seed` endpoint. Authentication in e2e
+ * mode is just the username sent as a bearer token (no real token to manage).
+ */
+export class TestData {
+  constructor(
+    private request: APIRequestContext,
+    private userName: string,
+  ) {}
+
+  async seed(scenario: Scenario): Promise<SeedResult> {
+    const response = await this.request.post(`${API_BASE_URL}/api/test/seed`, {
+      headers: { Authorization: "Bearer " + this.userName },
+      data: scenario,
+    });
+
+    if (!response.ok()) {
+      throw new Error(
+        `Failed to seed test data: ${response.status()} ${await response.text()}`,
+      );
+    }
+
+    return response.json();
+  }
+}

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -1,0 +1,40 @@
+import { test as base } from "@playwright/test";
+import { login } from "./utils/login";
+import { TestData } from "./api/testData";
+
+interface EngravedFixtures {
+  /**
+   * An authenticated e2e test user. Logging in via the app establishes the
+   * browser session (persisted in localStorage) and creates the user on the
+   * backend. The returned value is the username, which doubles as the bearer
+   * token in e2e mode.
+   */
+  userName: string;
+
+  /**
+   * Domain-level test-data builder. Seeds journals/entries via the backend in a
+   * single call, scoped to the authenticated `userName`.
+   */
+  testData: TestData;
+}
+
+export const test = base.extend<EngravedFixtures>({
+  userName: async ({ page }, use, testInfo) => {
+    const testName = testInfo.title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 40);
+
+    const userName = await login(page, testName);
+    await use(userName);
+  },
+
+  testData: async ({ playwright, userName }, use) => {
+    const request = await playwright.request.newContext();
+    await use(new TestData(request, userName));
+    await request.dispose();
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -36,5 +36,3 @@ export const test = base.extend<EngravedFixtures>({
     await request.dispose();
   },
 });
-
-export { expect } from "@playwright/test";

--- a/tests/tests/entries.spec.ts
+++ b/tests/tests/entries.spec.ts
@@ -1,20 +1,24 @@
-import { test } from "@playwright/test";
-import { login } from "../src/utils/login";
+import { test } from "../src/fixtures";
 import { MetricJournalPage } from "../src/poms/metricJournalPage";
 import { TimerJournalPage } from "../src/poms/timerJournalPage";
 
 const value1 = "23";
 const value2 = "19.5";
 
-test("add new value journal, add some entries, delete entry", async ({
-  page,
-}) => {
-  await login(page, "entries", "Gauge", "Journal with values");
+test("delete an entry from a value journal", async ({ page, testData }) => {
+  const { journals } = await testData.seed({
+    journals: [
+      {
+        name: "Journal with values",
+        type: "Gauge",
+        entries: [{ value: Number(value1) }, { value: Number(value2) }],
+      },
+    ],
+  });
+
+  await page.goto(`/journals/details/${journals[0].journalId}`);
 
   const journalPage = new MetricJournalPage(page);
-
-  await journalPage.addValue(value1);
-  await journalPage.addValue(value2);
 
   await journalPage.validateNumberOfTableRows(3);
   await journalPage.expectTableCellToHaveValue(value1);
@@ -26,10 +30,29 @@ test("add new value journal, add some entries, delete entry", async ({
   await journalPage.validateNumberOfTableRows(2);
 });
 
-test("add new timer journal, start and stop a timer, edit entry", async ({
+test("add a value to a value journal via the UI", async ({
   page,
+  testData,
 }) => {
-  await login(page, "entries", "Timer", "Journal with timer");
+  const { journals } = await testData.seed({
+    journals: [{ name: "Journal with values", type: "Gauge" }],
+  });
+
+  await page.goto(`/journals/details/${journals[0].journalId}`);
+
+  const journalPage = new MetricJournalPage(page);
+
+  await journalPage.addValue(value1);
+
+  await journalPage.expectTableCellToHaveValue(value1);
+});
+
+test("start and stop a timer, edit entry", async ({ page, testData }) => {
+  const { journals } = await testData.seed({
+    journals: [{ name: "Journal with timer", type: "Timer" }],
+  });
+
+  await page.goto(`/journals/details/${journals[0].journalId}`);
 
   const journalPage = new TimerJournalPage(page);
 


### PR DESCRIPTION
## What & why

Part of #2809 (make e2e tests faster). Most e2e tests spend the bulk of their time building setup data through the UI. This introduces a faster, cleaner way to arrange test state and migrates `entries.spec.ts` as a proof of concept.

## Approach

**Backend — a gated seeding facade**
- New `POST /api/test/seed` endpoint (`TestDataController`) creates a whole scenario (journals + entries) in a single call.
- It is a **thin batching facade over the existing command handlers** (`AddJournalCommand`, `UpsertGaugeEntryCommand`, ...), so seeded data is identical to data created through the UI — no parallel write path.
- Gated behind a new `E2ETestMode` singleton: returns **404 unless the API runs in e2e-tests mode**, so there is zero production surface.

**Test side — encapsulated, domain-language setup**
- `TestData` (`tests/src/api/testData.ts`) is the only place aware of the seed endpoint; tests express scenarios in domain language.
- `fixtures.ts` provides `userName` (logs the browser in + creates the user) and `testData` fixtures.
- `entries.spec.ts` migrated: setup data is seeded via the API instead of clicked through the UI. A dedicated "add a value via the UI" test is kept to preserve that UI-creation coverage.

## Notes
- In e2e mode auth is just the username sent as a bearer token, so there is nothing to store/manage client-side.
- The browser session persists via localStorage, so navigating straight to `/journals/details/:id` after login renders the seeded data.

## Next steps (not in this PR)
Roll out the migration incrementally, one spec per PR, expanding the seed DTO as needed (scraps body, timer entries, schedules, permissions).

Refs #2809

🤖 Generated with [Claude Code](https://claude.com/claude-code)