### PR TITLE
Migrate overviewListNavigation.spec to API seeding

### DIFF
--- a/tests/tests/overviewListNavigation.spec.ts
+++ b/tests/tests/overviewListNavigation.spec.ts
@@ -1,7 +1,6 @@
-import { expect, Page, test } from "@playwright/test";
-import { login } from "../src/utils/login";
-import { addNewJournal } from "../src/utils/addNewJournal";
-import { navigateToHome } from "../src/utils/navigateTo";
+import { expect, Page } from "@playwright/test";
+import { test } from "../src/fixtures";
+import { TestData } from "../src/api/testData";
 import { JournalsPage } from "../src/poms/journalsPage";
 
 // Three journals are seeded for every test. Navigation tests assert focus by
@@ -10,41 +9,48 @@ import { JournalsPage } from "../src/poms/journalsPage";
 // matches all three.
 const journalNames = ["Apple", "Apricot", "Avocado"];
 
-async function seedJournals(page: Page): Promise<JournalsPage> {
-  for (const name of journalNames) {
-    await addNewJournal(page, "Value", name);
-    await navigateToHome(page);
-  }
+async function seedJournals(
+  page: Page,
+  testData: TestData,
+): Promise<JournalsPage> {
+  await testData.seed({
+    journals: journalNames.map((name) => ({ name, type: "Gauge" })),
+  });
+
+  // load the home overview so the freshly seeded journals are fetched
+  await page.goto("/");
 
   const journalsPage = new JournalsPage(page);
   await journalsPage.expectToShowNEntities(journalNames.length);
   return journalsPage;
 }
 
-test.beforeEach(async ({ page }) => {
-  await login(page, "overview-list-nav");
-});
-
 // --- arrow navigation ---
 
-test("ArrowDown with no selection focuses the first item", async ({ page }) => {
-  const list = await seedJournals(page);
+test("ArrowDown with no selection focuses the first item", async ({
+  page,
+  testData,
+}) => {
+  const list = await seedJournals(page, testData);
 
   await list.arrowDown();
 
   await list.expectFocusedItem(0);
 });
 
-test("ArrowUp with no selection focuses the last item", async ({ page }) => {
-  const list = await seedJournals(page);
+test("ArrowUp with no selection focuses the last item", async ({
+  page,
+  testData,
+}) => {
+  const list = await seedJournals(page, testData);
 
   await list.arrowUp();
 
   await list.expectFocusedItem(2);
 });
 
-test("ArrowDown moves focus to the next item", async ({ page }) => {
-  const list = await seedJournals(page);
+test("ArrowDown moves focus to the next item", async ({ page, testData }) => {
+  const list = await seedJournals(page, testData);
 
   await list.arrowDown();
   await list.expectFocusedItem(0);
@@ -53,8 +59,8 @@ test("ArrowDown moves focus to the next item", async ({ page }) => {
   await list.expectFocusedItem(1);
 });
 
-test("ArrowUp moves focus to the previous item", async ({ page }) => {
-  const list = await seedJournals(page);
+test("ArrowUp moves focus to the previous item", async ({ page, testData }) => {
+  const list = await seedJournals(page, testData);
 
   await list.arrowDown();
   await list.arrowDown();
@@ -64,8 +70,11 @@ test("ArrowUp moves focus to the previous item", async ({ page }) => {
   await list.expectFocusedItem(0);
 });
 
-test("ArrowDown wraps from the last item to the first", async ({ page }) => {
-  const list = await seedJournals(page);
+test("ArrowDown wraps from the last item to the first", async ({
+  page,
+  testData,
+}) => {
+  const list = await seedJournals(page, testData);
 
   await list.arrowUp();
   await list.expectFocusedItem(2);
@@ -74,8 +83,11 @@ test("ArrowDown wraps from the last item to the first", async ({ page }) => {
   await list.expectFocusedItem(0);
 });
 
-test("ArrowUp wraps from the first item to the last", async ({ page }) => {
-  const list = await seedJournals(page);
+test("ArrowUp wraps from the first item to the last", async ({
+  page,
+  testData,
+}) => {
+  const list = await seedJournals(page, testData);
 
   await list.arrowDown();
   await list.expectFocusedItem(0);
@@ -86,8 +98,11 @@ test("ArrowUp wraps from the first item to the last", async ({ page }) => {
 
 // --- item actions ---
 
-test("alt+enter navigates into the focused journal", async ({ page }) => {
-  const list = await seedJournals(page);
+test("alt+enter navigates into the focused journal", async ({
+  page,
+  testData,
+}) => {
+  const list = await seedJournals(page, testData);
 
   await list.arrowDown();
   await list.expectFocusedItem(0);
@@ -101,8 +116,11 @@ test("alt+enter navigates into the focused journal", async ({ page }) => {
   await expect(page.getByTestId("journal")).toBeVisible();
 });
 
-test("alt+e opens the focused journal's edit page", async ({ page }) => {
-  const list = await seedJournals(page);
+test("alt+e opens the focused journal's edit page", async ({
+  page,
+  testData,
+}) => {
+  const list = await seedJournals(page, testData);
 
   await list.arrowDown();
   const journalId = await list.getFocusedItemId();
@@ -117,8 +135,11 @@ test("alt+e opens the focused journal's edit page", async ({ page }) => {
 
 // --- type-to-filter ---
 
-test("typing narrows the list to matching items", async ({ page }) => {
-  const list = await seedJournals(page);
+test("typing narrows the list to matching items", async ({
+  page,
+  testData,
+}) => {
+  const list = await seedJournals(page, testData);
 
   await list.typeToFilter("ap");
 
@@ -128,8 +149,8 @@ test("typing narrows the list to matching items", async ({ page }) => {
   await list.expectItemHidden("Avocado");
 });
 
-test("backspace widens the filtered list again", async ({ page }) => {
-  const list = await seedJournals(page);
+test("backspace widens the filtered list again", async ({ page, testData }) => {
+  const list = await seedJournals(page, testData);
 
   await list.typeToFilter("ap");
   await list.expectToShowNEntities(2);
@@ -142,8 +163,9 @@ test("backspace widens the filtered list again", async ({ page }) => {
 
 test("escape clears the filter and restores the full list", async ({
   page,
+  testData,
 }) => {
-  const list = await seedJournals(page);
+  const list = await seedJournals(page, testData);
 
   await list.typeToFilter("ap");
   await list.expectToShowNEntities(2);


### PR DESCRIPTION
## What & why

Follow-up to the seeding PoC (#2813), part of #2809.

`overviewListNavigation.spec.ts` has 11 tests, each of which built **three journals through the UI** (`addNewJournal` + `navigateToHome` per journal) purely as a precondition before testing list navigation and filtering. That repeated UI setup is exactly what the seeding endpoint is for.

## Change

- Each test now seeds its three journals with a single `testData.seed()` call and uses the `userName` / `testData` fixtures (the per-test `beforeEach(login)` is gone — the fixture handles it).
- `seedJournals` reloads `/` so the freshly seeded journals are fetched, then returns the `JournalsPage`.

## Why this is safe / no coverage loss

- Seeded journals go through the **same `AddJournalCommand`** as UI-created ones, so they are indistinguishable in the overview.
- The home Journals list defaults to `favoritesOnly=false`, so all journals show (same as today; `routing.spec` already relies on API-created journals appearing on home).
- Journal creation **via the UI** is still covered by `journals.spec`, so nothing is lost here — this spec only ever cared about navigation/filtering.

Expecting a solid per-test speedup since three sequential UI create+navigate cycles collapse into one API call.

Refs #2809

🤖 Generated with [Claude Code](https://claude.com/claude-code)