### PR TITLE
Migrate search.spec to API seeding

### DIFF
--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -19,16 +19,22 @@ interface EngravedFixtures {
 }
 
 export const test = base.extend<EngravedFixtures>({
-  userName: async ({ page }, use, testInfo) => {
-    const testName = testInfo.title
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "")
-      .slice(0, 40);
+  // `auto` so every test logs in (and creates its user) up front, mirroring the
+  // per-spec `beforeEach(login)` it replaces. Tests that need the value can
+  // still request `userName`.
+  userName: [
+    async ({ page }, use, testInfo) => {
+      const testName = testInfo.title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 40);
 
-    const userName = await login(page, testName);
-    await use(userName);
-  },
+      const userName = await login(page, testName);
+      await use(userName);
+    },
+    { auto: true },
+  ],
 
   testData: async ({ playwright, userName }, use) => {
     const request = await playwright.request.newContext();

--- a/tests/tests/search.spec.ts
+++ b/tests/tests/search.spec.ts
@@ -1,68 +1,77 @@
-import { Page, test } from "@playwright/test";
-import { login } from "../src/utils/login";
-import { addNewJournal } from "../src/utils/addNewJournal";
+import { test } from "../src/fixtures";
 import { navigateToSearchPage } from "../src/utils/navigateTo";
-import { ScrapsJournalPage } from "../src/poms/scrapsJournalPage";
 
-type Entry = { title: string; content?: string };
-
-async function createScrapsJournalWithEntries(
-  page: Page,
-  journalName: string,
-  entries: Entry[],
-  journalDescription?: string,
-): Promise<void> {
-  await addNewJournal(page, "Scraps", journalName, journalDescription);
-  const journalPage = new ScrapsJournalPage(page);
-  for (const entry of entries) {
-    await journalPage.addEntry(entry.title, entry.content);
-  }
-}
-
-test.beforeEach(async ({ page }) => {
-  await login(page, "search");
-});
-
-test("finds entry by title match", async ({ page }) => {
-  await createScrapsJournalWithEntries(page, "My Journal", [
-    { title: "Alpine Trek" },
-  ]);
+test("finds entry by title match", async ({ page, testData }) => {
+  await testData.seed({
+    journals: [
+      {
+        name: "My Journal",
+        type: "Scraps",
+        entries: [{ title: "Alpine Trek" }],
+      },
+    ],
+  });
 
   const searchPage = await navigateToSearchPage(page);
   await searchPage.search("Alpine");
   await searchPage.expectResultVisible("Alpine Trek");
 });
 
-test("finds entry by content match", async ({ page }) => {
-  await createScrapsJournalWithEntries(page, "My Journal", [
-    { title: "Walk notes", content: "unexplored canyon route" },
-  ]);
+test("finds entry by content match", async ({ page, testData }) => {
+  await testData.seed({
+    journals: [
+      {
+        name: "My Journal",
+        type: "Scraps",
+        entries: [{ title: "Walk notes", notes: "unexplored canyon route" }],
+      },
+    ],
+  });
 
   const searchPage = await navigateToSearchPage(page);
   await searchPage.search("canyon");
   await searchPage.expectResultVisible("Walk notes");
 });
 
-test("finds journal by name match", async ({ page }) => {
-  await addNewJournal(page, "Scraps", "Birding Log");
+test("finds journal by name match", async ({ page, testData }) => {
+  await testData.seed({
+    journals: [{ name: "Birding Log", type: "Scraps" }],
+  });
 
   const searchPage = await navigateToSearchPage(page);
   await searchPage.search("Birding");
   await searchPage.expectResultVisible("Birding Log");
 });
 
-test("finds journal by description match", async ({ page }) => {
-  await addNewJournal(page, "Scraps", "Field Journal", "wetland observations");
+test("finds journal by description match", async ({ page, testData }) => {
+  await testData.seed({
+    journals: [
+      {
+        name: "Field Journal",
+        type: "Scraps",
+        description: "wetland observations",
+      },
+    ],
+  });
 
   const searchPage = await navigateToSearchPage(page);
   await searchPage.search("wetland");
   await searchPage.expectResultVisible("Field Journal");
 });
 
-test("returns both entries and journals when both match", async ({ page }) => {
-  await createScrapsJournalWithEntries(page, "Geology Study", [
-    { title: "Geology Study notes" },
-  ]);
+test("returns both entries and journals when both match", async ({
+  page,
+  testData,
+}) => {
+  await testData.seed({
+    journals: [
+      {
+        name: "Geology Study",
+        type: "Scraps",
+        entries: [{ title: "Geology Study notes" }],
+      },
+    ],
+  });
 
   const searchPage = await navigateToSearchPage(page);
   await searchPage.search("Geology Study");
@@ -76,12 +85,23 @@ test("shows no results for non-matching search", async ({ page }) => {
   await searchPage.expectNoResults();
 });
 
-test("narrows and widens search updates results", async ({ page }) => {
-  await createScrapsJournalWithEntries(page, "Wildlife Journal", [
-    { title: "Red Fox" },
-    { title: "Red Kite" },
-    { title: "Blue Jay" },
-  ]);
+test("narrows and widens search updates results", async ({
+  page,
+  testData,
+}) => {
+  await testData.seed({
+    journals: [
+      {
+        name: "Wildlife Journal",
+        type: "Scraps",
+        entries: [
+          { title: "Red Fox" },
+          { title: "Red Kite" },
+          { title: "Blue Jay" },
+        ],
+      },
+    ],
+  });
 
   const searchPage = await navigateToSearchPage(page);
 


### PR DESCRIPTION
## What & why

Follow-up to #2813 / #2814, part of #2809.

The seven tests in `search.spec.ts` each built a scraps journal (and its entries) **through the UI** purely as a precondition before exercising search.

## Change

- Each test seeds its journal/entries with `testData.seed()` and uses the fixtures; the per-spec `beforeEach(login)` is gone.
- **No backend change needed**: a scrap''s body maps to the entry `Notes` field, which the seed facade already sets, so content matches still work (search queries `Notes`).
- Made the `userName` fixture **`auto`** so every test logs in up front (mirroring the old `beforeEach(login)`). This is required for the "shows no results" test, which seeds nothing but still needs an authenticated session.

## Coverage

Search behavior is unchanged; only the *arrange* step moved off the UI. Scrap creation via the UI remains covered by `scrapList.spec` / `notes.spec` (deliberately not migrated, since building the scrap is the subject there).

Refs #2809

🤖 Generated with [Claude Code](https://claude.com/claude-code)