### PR TITLE
Migrate charts.spec to API seeding

### DIFF
--- a/tests/tests/charts.spec.ts
+++ b/tests/tests/charts.spec.ts
@@ -1,14 +1,20 @@
-import { test } from "@playwright/test";
-import { login } from "../src/utils/login";
+import { test } from "../src/fixtures";
 import { MetricJournalPage } from "../src/poms/metricJournalPage";
 
-test("verify chart is displayed when toggled", async ({ page }) => {
-  await login(page, "charts", "Gauge", "Journal for charts");
+test("verify chart is displayed when toggled", async ({ page, testData }) => {
+  const { journals } = await testData.seed({
+    journals: [
+      {
+        name: "Journal for charts",
+        type: "Gauge",
+        entries: [{ value: 10 }, { value: 20 }],
+      },
+    ],
+  });
+
+  await page.goto(`/journals/details/${journals[0].journalId}`);
 
   const journalPage = new MetricJournalPage(page);
-
-  await journalPage.addValue("10");
-  await journalPage.addValue("20");
 
   await journalPage.toggleChart();
 


### PR DESCRIPTION
## What & why

Follow-up to #2813 / #2814 / #2815, part of #2809.

The chart test added two gauge values **through the UI** purely to have data to plot. The actual subject is toggling and rendering the chart, so the two entries are pure precondition.

## Change

- Seed the two gauge entries with `testData.seed()` and navigate straight to the journal.
- No backend change needed (gauge entries already supported).

UI value-entry coverage remains in `entries.spec` (the dedicated "add a value via the UI" test).

Refs #2809

🤖 Generated with [Claude Code](https://claude.com/claude-code)