### PR TITLE
Make routing tag-detail test deterministic (seed a user tag)

### DIFF
--- a/api/Engraved.Api/Source/Controllers/TestDataController.cs
+++ b/api/Engraved.Api/Source/Controllers/TestDataController.cs
@@ -6,6 +6,7 @@ using Engraved.Core.Application.Commands.Entries.Upsert.Counter;
 using Engraved.Core.Application.Commands.Entries.Upsert.Gauge;
 using Engraved.Core.Application.Commands.Entries.Upsert.Scraps;
 using Engraved.Core.Application.Commands.Journals.Add;
+using Engraved.Core.Application.Commands.Users.UpdateTags;
 using Engraved.Core.Domain.Journals;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -64,6 +65,16 @@ public class TestDataController(
       seededJournals.Add(new SeededJournal { JournalId = journalId, EntryIds = entryIds.ToArray() });
     }
 
+    if (dto.Tags.Length > 0)
+    {
+      await dispatcher.Command(
+        new UpdateUserTagsCommand
+        {
+          TagNames = dto.Tags.ToDictionary(tag => tag.Id, tag => tag.Label)
+        }
+      );
+    }
+
     return new SeedResult { Journals = seededJournals.ToArray() };
   }
 
@@ -91,6 +102,15 @@ public class TestDataController(
 public class SeedTestDataDto
 {
   public SeedJournalDto[] Journals { get; set; } = [];
+
+  public SeedTagDto[] Tags { get; set; } = [];
+}
+
+public class SeedTagDto
+{
+  public string Id { get; set; } = null!;
+
+  public string Label { get; set; } = null!;
 }
 
 public class SeedJournalDto

--- a/tests/src/api/testData.ts
+++ b/tests/src/api/testData.ts
@@ -17,8 +17,14 @@ interface SeedJournal {
   entries?: SeedEntry[];
 }
 
+interface SeedTag {
+  id: string;
+  label: string;
+}
+
 export interface Scenario {
-  journals: SeedJournal[];
+  journals?: SeedJournal[];
+  tags?: SeedTag[];
 }
 
 interface SeededJournal {

--- a/tests/tests/routing.spec.ts
+++ b/tests/tests/routing.spec.ts
@@ -159,28 +159,18 @@ test.describe("routing", () => {
 
   test("navigates to tag detail page — URL contains tagId", async ({
     page,
+    testData,
   }) => {
-    await navigateToHome(page);
+    const tagId = "routing-tag";
+    await testData.seed({ tags: [{ id: tagId, label: "Routing Tag" }] });
 
-    // Go to tags page first
-    await page.getByRole("button", { name: "Menu" }).click();
-    await page.getByRole("link", { name: "Tags" }).click();
-    await page.waitForURL((url) => url.pathname === "/tags");
+    // load /tags fresh so the user (with the seeded tag) is fetched
+    await page.goto("/tags");
 
-    // If there are tags, click the first one
-    const firstTag = page.locator("a[href^='/tags/']").first();
-    const tagCount = await firstTag.count();
+    await page.getByRole("link", { name: "Routing Tag" }).click();
 
-    if (tagCount > 0) {
-      await firstTag.click();
-      await page.waitForURL((url) => url.pathname.startsWith("/tags/"));
-      const url = new URL(page.url());
-      expect(url.pathname).toMatch(/^\/tags\/.+/);
-    }
-    // If no tags, just verify we're on the tags page correctly
-    else {
-      await expect(page).toHaveURL(/\/tags/);
-    }
+    await page.waitForURL((url) => url.pathname.startsWith("/tags/"));
+    expect(new URL(page.url()).pathname).toContain(tagId);
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The `/tags/:tagId` routing test asserted the URL **only if a tag happened to exist**:

```ts
if (tagCount > 0) { /* assert */ } else { /* just check we are on /tags */ }
```

A fresh test user has no tags, so this branch typically took the `else` path and the test could pass **without ever exercising the tag-detail route** — green with no real coverage.

## Fix

Since we control the data, seed a known user tag and assert unconditionally:

- Extended the seed facade with **user tags**, dispatching the existing `UpdateUserTagsCommand` — keeping everything on the single seeding mechanism (no direct API call).
- The test seeds a tag, loads `/tags` fresh (so the user, now with the tag, is fetched), clicks it, and asserts the detail URL contains the known `tagId`.

A bare tag (`{ id, label }`) is enough to render a `/tags/:id` link, so no journal assignment is needed.

## Verification
`tsc` + `knip` clean; API compiles (no `CS` errors).

Refs #2809

🤖 Generated with [Claude Code](https://claude.com/claude-code)