### PR TITLE
Unify remaining specs onto the testData fixture

### DIFF
--- a/app/src/Bootstrapper.tsx
+++ b/app/src/Bootstrapper.tsx
@@ -8,7 +8,6 @@ import { AuthStorage } from "./serverApi/authentication/AuthStorage";
 import { ApiError } from "./serverApi/ApiError";
 import { CircularProgress, styled, Typography } from "@mui/material";
 import { knownQueryParams } from "./components/common/actions/searchParamHooks";
-import { JournalType } from "./serverApi/JournalType";
 import { CredentialResponse } from "google-one-tap";
 
 const storage = new AuthStorage();
@@ -31,17 +30,9 @@ export const Bootstrapper: React.FC = () => {
 
     const searchParams = new URLSearchParams(window.location.search);
     if (searchParams.has(knownQueryParams.testUser)) {
-      ServerApi.setUpForTests(
-        searchParams.get(knownQueryParams.testUser)!,
-        searchParams.get(knownQueryParams.testJournalName) ?? undefined,
-        searchParams.get(knownQueryParams.testJournalType) as JournalType,
-      )
-        .then(async (r) => {
+      ServerApi.setUpForTests(searchParams.get(knownQueryParams.testUser)!)
+        .then((r) => {
           setUser(r.user);
-
-          if (r.journalId) {
-            window.location.href = `${window.location.origin}/journals/details/${r.journalId}`;
-          }
         })
         .finally(() => setIsNotVisible(false));
       return;

--- a/app/src/components/common/actions/searchParamHooks.ts
+++ b/app/src/components/common/actions/searchParamHooks.ts
@@ -7,8 +7,6 @@ export const knownQueryParams = {
   favoritesOnly: "favorites-only",
   query: "q",
   testUser: "test-user",
-  testJournalName: "test-journal-name",
-  testJournalType: "test-journal-type",
 } as const;
 
 const actionKeys = [

--- a/app/src/serverApi/IAuthResult.ts
+++ b/app/src/serverApi/IAuthResult.ts
@@ -4,7 +4,3 @@ export interface IAuthResult {
   jwtToken: string;
   user: IUser;
 }
-
-export interface ITestAuthResult extends IAuthResult {
-  journalId?: string;
-}

--- a/app/src/serverApi/ServerApi.ts
+++ b/app/src/serverApi/ServerApi.ts
@@ -8,7 +8,7 @@ import { IEditJournalCommand } from "./commands/IEditJournalCommand";
 import { envSettings } from "../env/envSettings";
 import { IApiError } from "./IApiError";
 import { ICommandResult } from "./ICommandResult";
-import { IAuthResult, ITestAuthResult } from "./IAuthResult";
+import { IAuthResult } from "./IAuthResult";
 import { IUser } from "./IUser";
 import { AuthStorage } from "./authentication/AuthStorage";
 import { ApiError } from "./ApiError";
@@ -94,32 +94,18 @@ export class ServerApi {
     return await ServerApi.executeRequest<IUser>("/user");
   }
 
-  static async setUpForTests(
-    jwtToken: string,
-    testJournalName?: string,
-    testJournalType?: JournalType,
-  ): Promise<ITestAuthResult> {
+  static async setUpForTests(jwtToken: string): Promise<IAuthResult> {
     ServerApi._jwtToken = jwtToken;
 
     ServerApi._isE2eTest = true;
     ServerApi.e2eStorage.setValue("isE2eTest", true);
 
-    const authResult = await ServerApi.executeRequest<ITestAuthResult>(
+    const authResult = await ServerApi.executeRequest<IAuthResult>(
       "/auth/e2e",
       "POST",
     );
 
     this.handleAuthenticated(authResult);
-
-    if (testJournalName) {
-      const createJournalResult = await ServerApi.addJournal(
-        testJournalName,
-        "This journal is created for E2E tests and can be deleted.",
-        testJournalType || JournalType.Gauge,
-      );
-
-      authResult.journalId = createJournalResult.entityId;
-    }
 
     return authResult;
   }

--- a/tests/src/utils/login.ts
+++ b/tests/src/utils/login.ts
@@ -17,18 +17,11 @@ function getDateTimeString() {
     .replace(/:/g, "");
 }
 
-export async function login(
-  page: Page,
-  testName: string,
-  journalType?: "Counter" | "Gauge" | "Timer" | "Scraps",
-  journalName?: string,
-) {
+export async function login(page: Page, testName: string) {
   const userName = getUserName(testName);
   console.log(`Using username '${userName}'`);
 
-  await page.goto(
-    `/?test-user=${userName}&test-journal-name=${journalName ?? ""}&test-journal-type=${journalType ?? ""}`,
-  );
+  await page.goto(`/?test-user=${userName}`);
 
   await page.getByTestId("page-actions").waitFor({ state: "visible" });
 

--- a/tests/tests/goTo.spec.ts
+++ b/tests/tests/goTo.spec.ts
@@ -1,13 +1,16 @@
-import { test } from "@playwright/test";
-import { login } from "../src/utils/login";
+import { test } from "../src/fixtures";
 import { addNewJournal } from "../src/utils/addNewJournal";
 import { navigateToHome } from "../src/utils/navigateTo";
 import { ScrapsJournalPage } from "../src/poms/scrapsJournalPage";
 
 test("search in go to, use cursor down, use enter to navigate to scrap", async ({
   page,
+  testData,
 }) => {
-  await login(page, "goto", "Scraps", "List of QBs");
+  const { journals } = await testData.seed({
+    journals: [{ name: "List of QBs", type: "Scraps" }],
+  });
+  await page.goto(`/journals/details/${journals[0].journalId}`);
 
   const scrapsJournalPage = new ScrapsJournalPage(page);
   await scrapsJournalPage.addMarkdownWithTitle("QB 1: Pat Mahomes");
@@ -27,8 +30,6 @@ test("search in go to, use cursor down, use enter to navigate to scrap", async (
 test("initially shows recent journals, navigates with click", async ({
   page,
 }) => {
-  await login(page, "goto");
-
   await addNewJournal(page, "Scraps", "Kansas City Chiefs");
   await navigateToHome(page);
 

--- a/tests/tests/journals.spec.ts
+++ b/tests/tests/journals.spec.ts
@@ -1,12 +1,7 @@
-import { test } from "@playwright/test";
-import { login } from "../src/utils/login";
+import { test } from "../src/fixtures";
 import { addNewJournal } from "../src/utils/addNewJournal";
 import { navigateToHome } from "../src/utils/navigateTo";
 import { JournalsPage } from "../src/poms/journalsPage";
-
-test.beforeEach(async ({ page }) => {
-  await login(page, "journals");
-});
 
 test("add journal, update journal", async ({ page }) => {
   const journalName = "My First Value Journal";

--- a/tests/tests/notes.spec.ts
+++ b/tests/tests/notes.spec.ts
@@ -1,12 +1,16 @@
-import { expect, test } from "@playwright/test";
-import { login } from "../src/utils/login";
+import { expect } from "@playwright/test";
+import { test } from "../src/fixtures";
 import { ScrapsJournalPage } from "../src/poms/scrapsJournalPage";
 import { ScrapMarkdownComponent } from "../src/poms/scrapMarkdownComponent";
 
 test("auto-saves markdown note changes when focus leaves the scrap", async ({
   page,
+  testData,
 }) => {
-  await login(page, "notes-autosave", "Scraps", "My Notes");
+  const { journals } = await testData.seed({
+    journals: [{ name: "My Notes", type: "Scraps" }],
+  });
+  await page.goto(`/journals/details/${journals[0].journalId}`);
 
   const scrapsJournalPage = new ScrapsJournalPage(page);
   await scrapsJournalPage.expectIsEmpty();

--- a/tests/tests/quickScraps.spec.ts
+++ b/tests/tests/quickScraps.spec.ts
@@ -1,15 +1,18 @@
-import { test } from "@playwright/test";
-import { login } from "../src/utils/login";
+import { test } from "../src/fixtures";
 import { navigateToEntriesPage, navigateToHome } from "../src/utils/navigateTo";
 import { JournalsPage } from "../src/poms/journalsPage";
 
 const scrapTitle = "Quick Scrap Title";
 const scrapContent = "This is my content...";
 
-test("Quick add", async ({ page }) => {
-  await login(page, "quickScraps", "Scraps", "My Manual Quick Scraps");
+test("Quick add", async ({ page, testData }) => {
+  await testData.seed({
+    journals: [{ name: "My Manual Quick Scraps", type: "Scraps" }],
+  });
 
   await navigateToHome(page);
+  await page.reload();
+
   const journalsPage = new JournalsPage(page);
 
   const quickScrapDialog = await journalsPage.clickAddQuickScrapAction();

--- a/tests/tests/schedule.spec.ts
+++ b/tests/tests/schedule.spec.ts
@@ -1,5 +1,6 @@
-import { expect, test } from "@playwright/test";
-import { login } from "../src/utils/login";
+import { expect, Page } from "@playwright/test";
+import { test } from "../src/fixtures";
+import { TestData } from "../src/api/testData";
 import {
   navigateToEntriesPage,
   navigateToHome,
@@ -10,10 +11,19 @@ import { isAndroidTest } from "../src/utils/isAndroidTest";
 import { ScrapsJournalPage } from "../src/poms/scrapsJournalPage";
 import { ScrapMarkdownComponent } from "../src/poms/scrapMarkdownComponent";
 
-test("add schedule to entry and mark as done", async ({ page }) => {
-  await login(page, "schedule", "Scraps", "My Journal");
+async function seedScrapsJournal(
+  page: Page,
+  testData: TestData,
+): Promise<ScrapsJournalPage> {
+  const { journals } = await testData.seed({
+    journals: [{ name: "My Journal", type: "Scraps" }],
+  });
+  await page.goto(`/journals/details/${journals[0].journalId}`);
+  return new ScrapsJournalPage(page);
+}
 
-  const journalPage = new ScrapsJournalPage(page);
+test("add schedule to entry and mark as done", async ({ page, testData }) => {
+  const journalPage = await seedScrapsJournal(page, testData);
 
   const quickNotificationDialog = await journalPage.clickAddQuickScrapAction();
 
@@ -45,10 +55,8 @@ test("add schedule to entry and mark as done", async ({ page }) => {
   await entriesPage.expectToShowEntity(entityId);
 });
 
-test("auto-save keeps an existing schedule", async ({ page }) => {
-  await login(page, "schedule-autosave", "Scraps", "My Journal");
-
-  const journalPage = new ScrapsJournalPage(page);
+test("auto-save keeps an existing schedule", async ({ page, testData }) => {
+  const journalPage = await seedScrapsJournal(page, testData);
 
   // create a scheduled note (the date in the title sets the schedule)
   const quickAdd = await journalPage.clickAddQuickScrapAction();
@@ -77,10 +85,11 @@ test("auto-save keeps an existing schedule", async ({ page }) => {
   await expect(scheduledPage.getEntityElement(entityId)).toBeVisible();
 });
 
-test("editing the title keeps an existing schedule", async ({ page }) => {
-  await login(page, "schedule-title-edit", "Scraps", "My Journal");
-
-  const journalPage = new ScrapsJournalPage(page);
+test("editing the title keeps an existing schedule", async ({
+  page,
+  testData,
+}) => {
+  const journalPage = await seedScrapsJournal(page, testData);
 
   const quickAdd = await journalPage.clickAddQuickScrapAction();
   await quickAdd.selectJournal("My Journal");

--- a/tests/tests/scrapList.spec.ts
+++ b/tests/tests/scrapList.spec.ts
@@ -1,4 +1,6 @@
-import { expect, Page, test } from "@playwright/test";
+import { expect, Page } from "@playwright/test";
+import { test } from "../src/fixtures";
+import { TestData } from "../src/api/testData";
 import { addNewJournal } from "../src/utils/addNewJournal";
 import { login } from "../src/utils/login";
 import { ScrapsJournalPage } from "../src/poms/scrapsJournalPage";
@@ -9,12 +11,23 @@ const firstItemText = "My First Item";
 const secondItemText = "My Second Item";
 const thirdItemText = "My Third Item";
 
+async function openScrapsJournal(
+  page: Page,
+  testData: TestData,
+  name = "My Scraps Journal",
+): Promise<ScrapsJournalPage> {
+  const { journals } = await testData.seed({
+    journals: [{ name, type: "Scraps" }],
+  });
+  await page.goto(`/journals/details/${journals[0].journalId}`);
+  return new ScrapsJournalPage(page);
+}
+
 test("add scrap journal, add list entry and add/delete/modify", async ({
   page,
+  testData,
 }) => {
-  await login(page, "scrapsList-basic", "Scraps", "My First Scraps Journal");
-
-  const scrapsJournalPage = new ScrapsJournalPage(page);
+  const scrapsJournalPage = await openScrapsJournal(page, testData);
   await scrapsJournalPage.expectIsEmpty();
 
   const scrapList = await scrapsJournalPage.addList();
@@ -39,10 +52,9 @@ test("add scrap journal, add list entry and add/delete/modify", async ({
 
 test("add scrap journal, add list entries and mark as checked in non-edit mode", async ({
   page,
+  testData,
 }) => {
-  await login(page, "scrapsList-non-edit", "Scraps", "Random Scraps");
-
-  const scrapsJournalPage = new ScrapsJournalPage(page);
+  const scrapsJournalPage = await openScrapsJournal(page, testData);
   await scrapsJournalPage.expectIsEmpty();
 
   const scrapList = await scrapsJournalPage.addList();
@@ -74,10 +86,9 @@ test("add scrap journal, add list entries and mark as checked in non-edit mode",
 
 test("auto-saves list changes when focus leaves the scrap", async ({
   page,
+  testData,
 }) => {
-  await login(page, "scrapsList-autosave", "Scraps", "Random Scraps");
-
-  const scrapsJournalPage = new ScrapsJournalPage(page);
+  const scrapsJournalPage = await openScrapsJournal(page, testData);
   await scrapsJournalPage.expectIsEmpty();
 
   const scrapList = await scrapsJournalPage.addList();
@@ -107,10 +118,9 @@ test("auto-saves list changes when focus leaves the scrap", async ({
 
 test("does not auto-save when auto-save is disabled for the scrap", async ({
   page,
+  testData,
 }) => {
-  await login(page, "scrapsList-autosave-off", "Scraps", "Random Scraps");
-
-  const scrapsJournalPage = new ScrapsJournalPage(page);
+  const scrapsJournalPage = await openScrapsJournal(page, testData);
   await scrapsJournalPage.expectIsEmpty();
 
   const scrapList = await scrapsJournalPage.addList();
@@ -138,10 +148,8 @@ test("does not auto-save when auto-save is disabled for the scrap", async ({
   await expect(await scrapList.getListItemByText(firstItemText)).toBeVisible();
 });
 
-test("Enter only adds one empty line", async ({ page }) => {
-  await login(page, "scrapsList-entry", "Scraps", "Random Scraps");
-
-  const scrapsJournalPage = new ScrapsJournalPage(page);
+test("Enter only adds one empty line", async ({ page, testData }) => {
+  const scrapsJournalPage = await openScrapsJournal(page, testData);
   await scrapsJournalPage.expectIsEmpty();
 
   const scrapList = await scrapsJournalPage.addList();
@@ -161,10 +169,8 @@ test("Enter only adds one empty line", async ({ page }) => {
   expect(await scrapList.getItemCount()).toBe(2);
 });
 
-test("Backspace on empty item removes item", async ({ page }) => {
-  await login(page, "scrapsList-backspace", "Scraps", "Random Scraps");
-
-  const scrapsJournalPage = new ScrapsJournalPage(page);
+test("Backspace on empty item removes item", async ({ page, testData }) => {
+  const scrapsJournalPage = await openScrapsJournal(page, testData);
   await scrapsJournalPage.expectIsEmpty();
 
   const scrapList = await scrapsJournalPage.addList();
@@ -221,6 +227,8 @@ async function pressBackspace(page: Page) {
   await page.keyboard.press("Backspace");
 }
 
+// This test drives its own browser context/pages, so it logs in those pages
+// explicitly via login() rather than relying on the single-page fixtures.
 test("modify list items in multiple tabs, handle updates accordingly", async ({
   browser,
 }) => {
@@ -289,10 +297,9 @@ test("modify list items in multiple tabs, handle updates accordingly", async ({
 
 test("perform common scrap list operations using shortcuts", async ({
   page,
+  testData,
 }) => {
-  await login(page, "scrapsList-shortcuts", "Scraps", "Scraps with shortcuts");
-
-  const scrapsJournalPage = new ScrapsJournalPage(page);
+  const scrapsJournalPage = await openScrapsJournal(page, testData);
   await scrapsJournalPage.expectIsEmpty();
 
   const scrapList = await scrapsJournalPage.addList();


### PR DESCRIPTION
## What & why

Final stylistic cleanup for #2809. Every **single-user** spec now uses the same setup mechanism (the `test` fixtures + `testData.seed()`) instead of the older `login()` journal-bootstrap — one consistent way to arrange data across the whole suite. **No behavioural changes**; only the *arrange* step moved.

## Spec unification

- **journals**, **goTo** (recents test): drop the explicit `login()`; the `auto` login fixture handles it. UI journal creation (`addNewJournal`) stays — that is what those tests verify.
- **notes**, **schedule**, **quickScraps**, **goTo** (scrap test), **scrapList**: seed the precondition journal and navigate to it, then build the scraps/lists through the UI exactly as before.

### Intentional exceptions (drive their own contexts/pages)
- `permissions.spec` — two users (joe + bob).
- the multi-tab test in `scrapList.spec` — two tabs in one context.

## Removing the now-dead journal-bootstrap (follow-on commit)

Once no spec passes a journal to `login()`, those parameters and the whole client-side journal-creation path are dead, so they are removed too:

- `login()` → just `(page, testName)`, navigates to `/?test-user=...`.
- `ServerApi.setUpForTests()` → drops `testJournalName`/`testJournalType` and the `addJournal()` call; returns `IAuthResult`.
- `Bootstrapper` → stops reading the `test-journal-*` params and the `journalId` redirect (and the now-unused `JournalType` import).
- `searchParamHooks` → drop `testJournalName`/`testJournalType`.
- Remove the now-unused `ITestAuthResult` interface.

Net effect: **seeding is the single mechanism** to initialise test data.

## Verification
app `types:check`, tests `types:check`, root `knip`, root `lint` all clean.

Refs #2809

🤖 Generated with [Claude Code](https://claude.com/claude-code)