### PR TITLE
CI: fix Node 20 cache deprecation + add concurrency control

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('tests/package-lock.json') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,12 @@ on:
         type: boolean
         default: false
 
+# Cancel superseded runs on the same branch (e.g. quick successive pushes to a
+# feature branch), but never cancel a run on main so deployments finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   # Detect which parts of the application changed
   detect-changes:


### PR DESCRIPTION
## Fixes the Node 20 deprecation warning

`actions/cache@v4` runs on the deprecated Node 20 runtime, producing:

> Node.js 20 actions are deprecated. ... actions/cache@v4 ...

Bumped to **`actions/cache@v5`**, which runs on Node 24. (The warning showed up **twice** because the cache step runs in both e2e matrix jobs - chromium and android. It is the only standalone cache action; `setup-node`/`setup-dotnet` manage their own caching internally.)

## Quick win: concurrency control

Added a concurrency group to the pipeline:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != ''refs/heads/main'' }}
```

When several commits are pushed to a feature branch in quick succession, the older in-flight run is cancelled instead of running to completion - saving CI minutes. Runs on `main` are never cancelled, so deployments always finish.

## Other observations (not changed here)

- `main.yml` `detect-changes` has an `elif pull_request` branch, but the workflow only triggers on `push`/`workflow_dispatch` - that branch is currently unreachable. Harmless/defensive; left as-is.
- No workflow sets an explicit least-privilege `permissions:` block. Could be a small security-hardening follow-up, but risks breaking token-dependent steps, so left for a deliberate pass.