### PR TITLE
Add backend unit tests + fix demo-mode journal deletion (#2823)

### DIFF
--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Delete/DeleteEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Delete/DeleteEntryCommandExecutorShould.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Threading.Tasks;
+using Engraved.Core.Application.Persistence.Demo;
+using Engraved.Core.Domain.Entries;
+using Engraved.Core.Domain.Journals;
+using Engraved.Core.Domain.Permissions;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Engraved.Core.Application.Commands.Entries.Delete;
+
+public class DeleteEntryCommandExecutorShould
+{
+  private FakeDateService _dateService = null!;
+  private InMemoryRepository _repo = null!;
+
+  [SetUp]
+  public void SetUp()
+  {
+    _repo = new InMemoryRepository();
+    _dateService = new FakeDateService(DateTime.UtcNow.AddDays(-10));
+  }
+
+  [Test]
+  public async Task DeleteEntry_And_BumpJournalEditedOn()
+  {
+    // given
+    _repo.Journals.Add(
+      new CounterJournal
+      {
+        Id = "journal-id",
+        Permissions = new UserPermissions { { "user-id", new PermissionDefinition { Kind = PermissionKind.Read } } }
+      }
+    );
+    _repo.Entries.Add(
+      new CounterEntry
+      {
+        Id = "entry-id",
+        ParentId = "journal-id",
+        DateTime = _dateService.UtcNow
+      }
+    );
+
+    // when
+    CommandResult result = await new DeleteEntryCommandExecutor(_repo, _dateService).Execute(
+      new DeleteEntryCommand { Id = "entry-id" }
+    );
+
+    // then
+    (await _repo.GetEntry("entry-id")).Should().BeNull();
+
+    IJournal journal = (await _repo.GetJournal("journal-id"))!;
+    journal.EditedOn.Should().Be(_dateService.UtcNow);
+
+    result.EntityId.Should().Be("entry-id");
+    result.AffectedUserIds.Should().Contain("user-id");
+  }
+
+  [Test]
+  public async Task ReturnEmptyResult_When_EntryDoesNotExist()
+  {
+    // when
+    CommandResult result = await new DeleteEntryCommandExecutor(_repo, _dateService).Execute(
+      new DeleteEntryCommand { Id = "does-not-exist" }
+    );
+
+    // then
+    result.EntityId.Should().BeNull();
+    result.AffectedUserIds.Should().BeEmpty();
+  }
+}

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Journals/Delete/DeleteJournalCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Journals/Delete/DeleteJournalCommandExecutorShould.cs
@@ -1,0 +1,56 @@
+﻿using System.Threading.Tasks;
+using Engraved.Core.Application.Persistence.Demo;
+using Engraved.Core.Domain.Journals;
+using Engraved.Core.Domain.Permissions;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Engraved.Core.Application.Commands.Journals.Delete;
+
+public class DeleteJournalCommandExecutorShould
+{
+  private InMemoryRepository _repo = null!;
+
+  [SetUp]
+  public void SetUp()
+  {
+    _repo = new InMemoryRepository();
+  }
+
+  [Test]
+  public async Task DeleteJournal_And_ReturnAffectedUsers()
+  {
+    // given
+    _repo.Journals.Add(
+      new CounterJournal
+      {
+        Id = "journal-id",
+        Permissions = new UserPermissions { { "user-id", new PermissionDefinition { Kind = PermissionKind.Write } } }
+      }
+    );
+
+    // when
+    CommandResult result = await new DeleteJournalCommandExecutor(_repo).Execute(
+      new DeleteJournalCommand { JournalId = "journal-id" }
+    );
+
+    // then
+    (await _repo.GetJournal("journal-id")).Should().BeNull();
+
+    result.EntityId.Should().Be("journal-id");
+    result.AffectedUserIds.Should().Contain("user-id");
+  }
+
+  [Test]
+  public async Task ReturnEmptyResult_When_JournalDoesNotExist()
+  {
+    // when
+    CommandResult result = await new DeleteJournalCommandExecutor(_repo).Execute(
+      new DeleteJournalCommand { JournalId = "does-not-exist" }
+    );
+
+    // then
+    result.EntityId.Should().BeNull();
+    result.AffectedUserIds.Should().BeEmpty();
+  }
+}

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Journals/Edit/KeyNormalizerShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Journals/Edit/KeyNormalizerShould.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Engraved.Core.Application.Commands.Journals.Edit;
+
+public class KeyNormalizerShould
+{
+  [TestCase(",")]
+  [TestCase(";")]
+  [TestCase("?")]
+  [TestCase(":")]
+  [TestCase("=")]
+  public void ReplaceInvalidChar_With_Underscore(string invalidChar)
+  {
+    Dictionary<string, int> result = KeyNormalizer.Normalize(
+      new Dictionary<string, int> { { $"a{invalidChar}b", 1 } }
+    );
+
+    result.Should().ContainKey("a_b").WhoseValue.Should().Be(1);
+  }
+
+  [Test]
+  public void ReplaceMultipleInvalidChars_InSameKey()
+  {
+    Dictionary<string, int> result = KeyNormalizer.Normalize(
+      new Dictionary<string, int> { { "a,b;c=d", 42 } }
+    );
+
+    result.Should().ContainKey("a_b_c_d").WhoseValue.Should().Be(42);
+  }
+
+  [Test]
+  public void LeaveCleanKeysUntouched()
+  {
+    Dictionary<string, string> result = KeyNormalizer.Normalize(
+      new Dictionary<string, string> { { "clean-key", "value" } }
+    );
+
+    result.Should().ContainKey("clean-key").WhoseValue.Should().Be("value");
+  }
+}

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Journals/EditPermissions/EditJournalPermissionsCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Journals/EditPermissions/EditJournalPermissionsCommandExecutorShould.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Engraved.Core.Application.Persistence.Demo;
+using Engraved.Core.Domain.Journals;
+using Engraved.Core.Domain.Permissions;
+using Engraved.Core.Domain.Users;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Engraved.Core.Application.Commands.Journals.EditPermissions;
+
+public class EditJournalPermissionsCommandExecutorShould
+{
+  private InMemoryRepository _repo = null!;
+
+  [SetUp]
+  public void SetUp()
+  {
+    _repo = new InMemoryRepository();
+  }
+
+  [Test]
+  public async Task Throw_When_JournalIdIsEmpty()
+  {
+    Func<Task> act = () => new EditJournalPermissionsCommandExecutor(_repo).Execute(
+      new EditJournalPermissionsCommand { JournalId = "" }
+    );
+
+    await act.Should().ThrowAsync<InvalidCommandException>();
+  }
+
+  [Test]
+  public async Task AddPermission_And_ReturnUnionOfBeforeAndAfterUsers()
+  {
+    // given: a journal owned by an existing user and a second user to grant access to
+    _repo.Users.Add(new User { Id = "owner-id", Name = "owner@foo.ch" });
+    _repo.Users.Add(new User { Id = "new-id", Name = "new@foo.ch" });
+
+    _repo.Journals.Add(
+      new CounterJournal
+      {
+        Id = "journal-id",
+        Permissions = new UserPermissions { { "owner-id", new PermissionDefinition { Kind = PermissionKind.Write } } }
+      }
+    );
+
+    // when
+    CommandResult result = await new EditJournalPermissionsCommandExecutor(_repo).Execute(
+      new EditJournalPermissionsCommand
+      {
+        JournalId = "journal-id",
+        Permissions = new Dictionary<string, PermissionKind> { { "new@foo.ch", PermissionKind.Read } }
+      }
+    );
+
+    // then
+    IJournal journal = (await _repo.GetJournal("journal-id"))!;
+    journal.Permissions.Should().ContainKey("owner-id");
+    journal.Permissions.Should().ContainKey("new-id");
+
+    result.EntityId.Should().Be("journal-id");
+    result.AffectedUserIds.Should().BeEquivalentTo("owner-id", "new-id");
+  }
+
+  [Test]
+  public async Task LeavePermissionsUnchanged_When_NoPermissionsProvided()
+  {
+    // given
+    _repo.Journals.Add(
+      new CounterJournal
+      {
+        Id = "journal-id",
+        Permissions = new UserPermissions { { "owner-id", new PermissionDefinition { Kind = PermissionKind.Write } } }
+      }
+    );
+
+    // when
+    CommandResult result = await new EditJournalPermissionsCommandExecutor(_repo).Execute(
+      new EditJournalPermissionsCommand { JournalId = "journal-id" }
+    );
+
+    // then
+    IJournal journal = (await _repo.GetJournal("journal-id"))!;
+    journal.Permissions.Should().ContainKey("owner-id");
+    result.AffectedUserIds.Should().BeEquivalentTo("owner-id");
+  }
+}

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Users/AddJournalToFavorites/AddJournalToFavoritesCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Users/AddJournalToFavorites/AddJournalToFavoritesCommandExecutorShould.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Threading.Tasks;
+using Engraved.Core.Application.Persistence.Demo;
+using Engraved.Core.Domain.Users;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Engraved.Core.Application.Commands.Users.AddJournalToFavorites;
+
+public class AddJournalToFavoritesCommandExecutorShould
+{
+  private UserScopedInMemoryRepository _repo = null!;
+
+  private const string UserId = "max";
+
+  [SetUp]
+  public void SetUp()
+  {
+    var inMemoryRepository = new InMemoryRepository();
+    inMemoryRepository.Users.Add(new User { Id = UserId, Name = UserId });
+    _repo = new UserScopedInMemoryRepository(inMemoryRepository, new FakeCurrentUserService(UserId));
+  }
+
+  [Test]
+  public async Task AddJournalToFavorites()
+  {
+    // when
+    await new AddJournalToFavoritesCommandExecutor(_repo).Execute(
+      new AddJournalToFavoritesCommand { JournalId = "journal-id" }
+    );
+
+    // then
+    _repo.Users[0].FavoriteJournalIds.Should().Contain("journal-id");
+  }
+
+  [Test]
+  public async Task NotAddDuplicate_When_AlreadyFavorite()
+  {
+    // given
+    _repo.Users[0].FavoriteJournalIds.Add("journal-id");
+
+    // when
+    await new AddJournalToFavoritesCommandExecutor(_repo).Execute(
+      new AddJournalToFavoritesCommand { JournalId = "journal-id" }
+    );
+
+    // then
+    _repo.Users[0].FavoriteJournalIds.Should().ContainSingle().Which.Should().Be("journal-id");
+  }
+
+  [Test]
+  public async Task Throw_When_JournalIdIsEmpty()
+  {
+    Func<Task> act = () => new AddJournalToFavoritesCommandExecutor(_repo).Execute(
+      new AddJournalToFavoritesCommand { JournalId = "" }
+    );
+
+    await act.Should().ThrowAsync<InvalidCommandException>();
+  }
+}

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Users/RemoveJournalFromFavorites/RemoveJournalFromFavoritesCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Users/RemoveJournalFromFavorites/RemoveJournalFromFavoritesCommandExecutorShould.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Threading.Tasks;
+using Engraved.Core.Application.Persistence.Demo;
+using Engraved.Core.Domain.Users;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Engraved.Core.Application.Commands.Users.RemoveJournalFromFavorites;
+
+public class RemoveJournalFromFavoritesCommandExecutorShould
+{
+  private UserScopedInMemoryRepository _repo = null!;
+
+  private const string UserId = "max";
+
+  [SetUp]
+  public void SetUp()
+  {
+    var inMemoryRepository = new InMemoryRepository();
+    inMemoryRepository.Users.Add(new User { Id = UserId, Name = UserId });
+    _repo = new UserScopedInMemoryRepository(inMemoryRepository, new FakeCurrentUserService(UserId));
+  }
+
+  [Test]
+  public async Task RemoveJournalFromFavorites()
+  {
+    // given
+    _repo.Users[0].FavoriteJournalIds.Add("journal-id");
+
+    // when
+    await new RemoveJournalFromFavoritesCommandExecutor(_repo).Execute(
+      new RemoveJournalFromFavoritesCommand { JournalId = "journal-id" }
+    );
+
+    // then
+    _repo.Users[0].FavoriteJournalIds.Should().NotContain("journal-id");
+  }
+
+  [Test]
+  public async Task DoNothing_When_NotAFavorite()
+  {
+    // given
+    _repo.Users[0].FavoriteJournalIds.Add("other-journal-id");
+
+    // when
+    await new RemoveJournalFromFavoritesCommandExecutor(_repo).Execute(
+      new RemoveJournalFromFavoritesCommand { JournalId = "journal-id" }
+    );
+
+    // then
+    _repo.Users[0].FavoriteJournalIds.Should().ContainSingle().Which.Should().Be("other-journal-id");
+  }
+
+  [Test]
+  public async Task Throw_When_JournalIdIsEmpty()
+  {
+    Func<Task> act = () => new RemoveJournalFromFavoritesCommandExecutor(_repo).Execute(
+      new RemoveJournalFromFavoritesCommand { JournalId = "" }
+    );
+
+    await act.Should().ThrowAsync<InvalidCommandException>();
+  }
+}

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Users/UpdateTags/UpdateUserTagsCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Users/UpdateTags/UpdateUserTagsCommandExecutorShould.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Engraved.Core.Application.Persistence.Demo;
+using Engraved.Core.Domain.Users;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Engraved.Core.Application.Commands.Users.UpdateTags;
+
+public class UpdateUserTagsCommandExecutorShould
+{
+  private UserScopedInMemoryRepository _repo = null!;
+
+  private const string UserId = "max";
+
+  [SetUp]
+  public void SetUp()
+  {
+    var inMemoryRepository = new InMemoryRepository();
+    inMemoryRepository.Users.Add(new User { Id = UserId, Name = UserId });
+    _repo = new UserScopedInMemoryRepository(inMemoryRepository, new FakeCurrentUserService(UserId));
+  }
+
+  [Test]
+  public async Task AddNewTag()
+  {
+    // when
+    await new UpdateUserTagsCommandExecutor(_repo).Execute(
+      new UpdateUserTagsCommand { TagNames = new Dictionary<string, string> { { "tag-id", "Label" } } }
+    );
+
+    // then
+    UserTag tag = _repo.Users[0].Tags.Should().ContainSingle().Subject;
+    tag.Id.Should().Be("tag-id");
+    tag.Label.Should().Be("Label");
+  }
+
+  [Test]
+  public async Task UpdateLabelOfExistingTag()
+  {
+    // given
+    _repo.Users[0].Tags.Add(new UserTag { Id = "tag-id", Label = "Old" });
+
+    // when
+    await new UpdateUserTagsCommandExecutor(_repo).Execute(
+      new UpdateUserTagsCommand { TagNames = new Dictionary<string, string> { { "tag-id", "New" } } }
+    );
+
+    // then
+    UserTag tag = _repo.Users[0].Tags.Should().ContainSingle().Subject;
+    tag.Id.Should().Be("tag-id");
+    tag.Label.Should().Be("New");
+  }
+
+  [Test]
+  public async Task RemoveTagsNoLongerInCommand()
+  {
+    // given
+    _repo.Users[0].Tags.Add(new UserTag { Id = "keep", Label = "Keep" });
+    _repo.Users[0].Tags.Add(new UserTag { Id = "remove", Label = "Remove" });
+
+    // when
+    await new UpdateUserTagsCommandExecutor(_repo).Execute(
+      new UpdateUserTagsCommand { TagNames = new Dictionary<string, string> { { "keep", "Keep" } } }
+    );
+
+    // then
+    _repo.Users[0].Tags.Select(t => t.Id).Should().BeEquivalentTo("keep");
+  }
+}

--- a/api/Engraved.Core/Source/Application/Persistence/Demo/InMemoryRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/Demo/InMemoryRepository.cs
@@ -142,7 +142,8 @@ public class InMemoryRepository : IRepository
       return;
     }
 
-    Journals.Remove(journal);
+    // note: GetJournal returns a copy, so we must remove by id rather than by reference.
+    RemoveJournal(journal);
   }
 
   public async Task ModifyJournalPermissions(string journalId, Dictionary<string, PermissionKind> permissions)


### PR DESCRIPTION
@
Addresses #2823 — identify low backend coverage and add unit tests.

## What

`Engraved.Core` had ~28 command/query executors but only ~9 covered by unit tests. This adds a focused first batch targeting the most branch-rich, untested command executors plus one pure utility:

- `DeleteEntryCommandExecutor` — delete + parent-journal `EditedOn` bump + affected users; no-op when entry missing
- `DeleteJournalCommandExecutor` — delete + affected users; no-op when missing
- `EditJournalPermissionsCommandExecutor` — throws on empty id; applies permissions; affected-user list is union of before/after holders
- `AddJournalToFavoritesCommandExecutor` / `RemoveJournalFromFavoritesCommandExecutor` — add/remove, idempotency, validation
- `UpdateUserTagsCommandExecutor` — add new tag, update existing label, remove dropped tags
- `KeyNormalizer` — invalid-char replacement (parameterized)

19 new test cases; full Core suite passes (75/75) locally.

## Bonus bug fix

Covering `DeleteJournal` surfaced a real defect: `InMemoryRepository.DeleteJournal` removed the *copy* returned by `GetJournal` by reference, so it never actually deleted — **demo-mode journal deletion silently failed**. Now reuses the existing `RemoveJournal` helper (removes by id). The new DeleteJournal test guards this.

## Notes

- All tests use the existing in-memory fakes (`InMemoryRepository`, `UserScopedInMemoryRepository`, `FakeDateService`, `FakeCurrentUserService`) and follow the established `*Should` / FluentAssertions / NUnit style.
- Remaining untested executors (most queries, `AddJournal`, `UpsertScraps`, `AddSchedule*`, `UpdateJournalUserTags`) are good follow-up candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@