### PR TITLE
Fix Android PWA notification handling (#2822)

### DIFF
--- a/api/Engraved.Notifications.OneSignal/Source/OneSignalNotificationService.cs
+++ b/api/Engraved.Notifications.OneSignal/Source/OneSignalNotificationService.cs
@@ -37,8 +37,14 @@ public class OneSignalNotificationService(IOptions<OneSignalConfig> config) : IN
       url: clientNotification.OnClickUrl,
       smallIcon: "/icons/icon-transparent-bg.svg",
       chromeWebBadge: "/icons/icon-transparent-bg.svg",
-      androidVisibility: 1, // 1 = Public: show full notification on lock screen
-      priority: 10, // 10 = High priority: wake device from doze mode (FCM high-priority)
+      // 10 = high priority. For web push (Android PWA = "ChromeWeb") this raises the
+      // delivery urgency so the device is woken from doze mode. This is the only
+      // server-side delivery lever that applies to web push.
+      // Note: "androidVisibility" was tried (PR #2772) but only affects the native
+      // Android SDK, not web push, so it is intentionally omitted here. The remaining
+      // unreliability on Android is device-side (battery optimization suspending the
+      // browser/PWA) and cannot be overridden from the payload. See issue #2822.
+      priority: 10,
       webButtons: clientNotification.Buttons
         .Select(b => new WebButton
           {

--- a/app/src/pwa/SettingsPage.tsx
+++ b/app/src/pwa/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { Page } from "../components/layout/pages/Page";
 import { PageSection } from "../components/layout/pages/PageSection";
-import { Button } from "@mui/material";
+import { Alert, AlertTitle, Button } from "@mui/material";
 import { ServerApi } from "../serverApi/ServerApi";
 import { optInPushNotifications, setUpOneSignal } from "../util/oneSignal";
 import { useAppContext } from "../AppContext";
@@ -55,6 +55,18 @@ export const SettingsPage: React.FC = () => {
             Show test notification via OneSignal.
           </Button>
         </p>
+
+        {isAndroid() ? (
+          <Alert severity="info">
+            <AlertTitle>Not receiving notifications on Android?</AlertTitle>
+            Android battery optimization can stop the browser/installed app from
+            receiving push notifications in the background, even though they are
+            sent successfully. To fix this, open your system settings and set
+            battery usage for your browser (or the installed engraved. app) to{" "}
+            <strong>Unrestricted</strong> (Settings → Apps → your browser →
+            Battery), and make sure background data is allowed.
+          </Alert>
+        ) : null}
       </PageSection>
 
       <PageSection title="Export your data">
@@ -68,6 +80,10 @@ export const SettingsPage: React.FC = () => {
       </PageSection>
     </Page>
   );
+
+  function isAndroid() {
+    return /android/i.test(navigator.userAgent);
+  }
 
   async function clearBackendCache() {
     try {


### PR DESCRIPTION
@
Closes #2822.

## Background
Notifications are reliably delivered by OneSignal but not always *displayed* on Android PWAs. PR #2772 tried to fix this with `androidVisibility`/`priority` flags, but `androidVisibility` only applies to the **native Android SDK** — not web push, which is what a PWA receives (OneSignals "ChromeWeb" platform). `priority: 10` is the only server-side lever that applies to web push, and it was already in place.

Since OneSignal reports the messages as delivered, the remaining inconsistency is **device-side**: Android battery optimization suspending the browser/PWAs background process. No payload field can override that — the real remedy is a device setting.

## Changes
- **`OneSignalNotificationService.cs`** — remove the no-op `androidVisibility` flag and document why `priority: 10` is the relevant web-push delivery lever.
- **`SettingsPage.tsx`** — add an info banner (shown on Android) telling users to set their browser/PWA battery usage to **Unrestricted**, which is the actual fix.

## Notes
- Left the `webPushTopic`/`collapseId` collapse behavior untouched (intentional per-entity dedup).
- Frontend `tsc --noEmit` passes. Backend couldnt be built locally (installed .NET SDK 10.0.204 < pinned 10.0.300), but the change is a named-argument removal plus comments, so CI will compile it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@