### PR TITLE
Fix negative timer duration formatting for #2826

### DIFF
--- a/app/src/util/getDurationAsHhMmSs.test.ts
+++ b/app/src/util/getDurationAsHhMmSs.test.ts
@@ -1,4 +1,7 @@
-import { getDurationAsHhMmSs } from "./getDurationAsHhMmSs";
+import {
+  getDurationAsHhMmSs,
+  getDurationAsHhMmSsFromSeconds,
+} from "./getDurationAsHhMmSs";
 
 describe("getDurationAsHhMmSs", () => {
   it("should parse two digit time", () => {
@@ -44,6 +47,29 @@ describe("getDurationAsHhMmSs", () => {
         createDateFromTime(16, 17, 18),
       ),
     ).toBe("06:17:18");
+  });
+
+  it("should format a negative duration (start in the future)", () => {
+    expect(
+      getDurationAsHhMmSs(
+        createDateFromTime(10, 5, 0),
+        createDateFromTime(10, 0, 0),
+      ),
+    ).toBe("-00:05:00");
+  });
+});
+
+describe("getDurationAsHhMmSsFromSeconds", () => {
+  it("should format positive seconds", () => {
+    expect(getDurationAsHhMmSsFromSeconds(300)).toBe("00:05:00");
+  });
+
+  it("should format negative seconds without overflowing into minutes/hours", () => {
+    expect(getDurationAsHhMmSsFromSeconds(-300)).toBe("-00:05:00");
+  });
+
+  it("should format zero", () => {
+    expect(getDurationAsHhMmSsFromSeconds(0)).toBe("00:00:00");
   });
 });
 

--- a/app/src/util/getDurationAsHhMmSs.ts
+++ b/app/src/util/getDurationAsHhMmSs.ts
@@ -2,11 +2,16 @@ import { differenceInSeconds } from "date-fns";
 import { round } from "./utils";
 
 export function getDurationAsHhMmSsFromSeconds(totalSeconds: number): string {
-  const hours = Math.floor(totalSeconds / (60 * 60));
-  const minutes = Math.floor((totalSeconds - hours * 60 * 60) / 60);
-  const seconds = round(totalSeconds - hours * 60 * 60 - minutes * 60, 3);
+  const isNegative = totalSeconds < 0;
+  const absoluteSeconds = Math.abs(totalSeconds);
 
-  return `${padZeros(hours)}:${padZeros(minutes)}:${padZeros(seconds)}`;
+  const hours = Math.floor(absoluteSeconds / (60 * 60));
+  const minutes = Math.floor((absoluteSeconds - hours * 60 * 60) / 60);
+  const seconds = round(absoluteSeconds - hours * 60 * 60 - minutes * 60, 3);
+
+  const sign = isNegative ? "-" : "";
+
+  return `${sign}${padZeros(hours)}:${padZeros(minutes)}:${padZeros(seconds)}`;
 }
 
 export function getDurationAsHhMmSs(start: Date, end: Date): string {

--- a/tests/src/poms/timerJournalPage.ts
+++ b/tests/src/poms/timerJournalPage.ts
@@ -36,4 +36,18 @@ export class TimerJournalPage extends JournalPage {
   async validateNumberOfTableRows(expected: number) {
     await expect(this.tableRows).toHaveCount(expected);
   }
+
+  async openAddEntryFullForm() {
+    await this.clickPageAction("Add entry");
+    await this.page.getByLabel("Show full form").click();
+  }
+
+  async moveStartDateFiveMinutesIntoFuture() {
+    // the start date is the first date selector in the timer form
+    await this.page.getByRole("button", { name: "+5min" }).first().click();
+  }
+
+  async expectDurationToMatch(pattern: RegExp) {
+    await expect(this.page.getByText(pattern)).toBeVisible();
+  }
 }

--- a/tests/tests/entries.spec.ts
+++ b/tests/tests/entries.spec.ts
@@ -63,3 +63,23 @@ test("start and stop a timer, edit entry", async ({ page, testData }) => {
   await journalPage.resetEndDateToNow(0);
   await journalPage.validateNumberOfTableRows(1);
 });
+
+test("show a negative duration when the start date is in the future", async ({
+  page,
+  testData,
+}) => {
+  const { journals } = await testData.seed({
+    journals: [{ name: "Journal with timer", type: "Timer" }],
+  });
+
+  await page.goto(`/journals/details/${journals[0].journalId}`);
+
+  const journalPage = new TimerJournalPage(page);
+
+  await journalPage.openAddEntryFullForm();
+  await journalPage.moveStartDateFiveMinutesIntoFuture();
+
+  // start is ~5min in the future, so the duration must be a small negative
+  // value (e.g. -00:04:59), not the timezone-offset bug that showed -01:55:00
+  await journalPage.expectDurationToMatch(/^-00:0[45]:\d\d$/);
+});


### PR DESCRIPTION
When a timer entry's start date is in the future the duration is negative. getDurationAsHhMmSsFromSeconds applied Math.floor directly to the negative seconds, producing e.g. "-1:55:00" for -5min instead of "-00:05:00". Compute the components from the absolute value and prepend the sign.

Add unit tests for the negative/zero cases and an e2e test that pushes the start date into the future and asserts a small negative duration.