### PR TITLE
Show weekday in date pickers (#2828)

### DIFF
--- a/app/src/components/common/LazyDateSelector.tsx
+++ b/app/src/components/common/LazyDateSelector.tsx
@@ -27,6 +27,7 @@ const LazyDateSelector: React.FC<IDateSelectorProps> = ({
             sx={{ width: "100%" }}
             autoFocus={hasFocus}
             label={label}
+            format="EEE dd.MM.yyyy"
             value={date || null}
             showDaysOutsideCurrentMonth={true}
             onChange={(d) => {

--- a/app/src/components/common/LazySimpleDateSelector.tsx
+++ b/app/src/components/common/LazySimpleDateSelector.tsx
@@ -20,6 +20,7 @@ const LazySimpleDateSelector: React.FC<ISimpleDateSelectorProps> = ({
         sx={{ width: "100%" }}
         autoFocus={hasFocus}
         label={label}
+        format="EEE dd.MM.yyyy"
         value={date || null}
         showDaysOutsideCurrentMonth={true}
         onChange={(d) => {


### PR DESCRIPTION
@
Closes #2828

Date pickers now show the short weekday alongside the date.

## Change

Added `format="EEE dd.MM.yyyy"` to the `DesktopDatePicker` in both shared date selector components:

- `app/src/components/common/LazyDateSelector.tsx`
- `app/src/components/common/LazySimpleDateSelector.tsx`

Since every date picker in the app funnels through these two components, this covers all usages (entry add/edit, timer start/end, entries table, date filters, schedule, logbook).

The `EEE` token renders the short weekday in the active German locale (e.g. `Mo. 15.06.2026`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@