### PR TITLE
Prevent multiple LogBook entries on the same day

### DIFF
--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertLogBookEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertLogBookEntryCommandExecutorShould.cs
@@ -93,6 +93,24 @@ public class UpsertLogBookEntryCommandExecutorShould
   }
 
   [Test]
+  public async Task StoreDateOnly_StrippingTimeComponent()
+  {
+    var command = new UpsertLogBookEntryCommand
+    {
+      JournalId = JournalId,
+      Notes = "some notes",
+      DateTime = new DateTime(2026, 4, 9, 13, 37, 42, DateTimeKind.Utc)
+    };
+
+    await new UpsertLogBookEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
+
+    IEntry entry = _testRepository.Entries.Single();
+    entry.DateTime.Should().Be(new DateTime(2026, 4, 9, 0, 0, 0, DateTimeKind.Utc));
+    entry.DateTime!.Value.TimeOfDay.Should().Be(TimeSpan.Zero);
+    entry.DateTime!.Value.Kind.Should().Be(DateTimeKind.Utc);
+  }
+
+  [Test]
   public void Throw_WhenEntryForSameDayAlreadyExists()
   {
     var existingDate = new DateTime(2026, 4, 9, 10, 0, 0, DateTimeKind.Utc);

--- a/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/LogBook/UpsertLogBookEntryCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/LogBook/UpsertLogBookEntryCommandExecutor.cs
@@ -48,5 +48,10 @@ public class UpsertLogBookEntryCommandExecutor(IRepository repository, IDateServ
     return entriesOnSameDay.Any(e => e.DateTime?.Date == entryDate && e.Id != command.Id);
   }
 
-  protected override void SetTypeSpecificValues(UpsertLogBookEntryCommand command, LogBookEntry entry) { }
+  protected override void SetTypeSpecificValues(UpsertLogBookEntryCommand command, LogBookEntry entry)
+  {
+    // LogBook entries are date-only: strip the time component so that at most one entry can exist
+    // per day, regardless of the time the client happens to send.
+    entry.DateTime = DateTime.SpecifyKind(command.DateTime!.Value.Date, DateTimeKind.Utc);
+  }
 }

--- a/app/src/components/common/DateSelector.tsx
+++ b/app/src/components/common/DateSelector.tsx
@@ -6,6 +6,7 @@ export interface ISimpleDateSelectorProps {
   date: Date | undefined;
   label?: string;
   hasFocus?: boolean;
+  shouldDisableDate?: (date: Date) => boolean;
 }
 
 const LazySimpleDateSelector = React.lazy(

--- a/app/src/components/common/LazySimpleDateSelector.tsx
+++ b/app/src/components/common/LazySimpleDateSelector.tsx
@@ -13,6 +13,7 @@ const LazySimpleDateSelector: React.FC<ISimpleDateSelectorProps> = ({
   setDate,
   date,
   label,
+  shouldDisableDate,
 }) => {
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={de}>
@@ -23,6 +24,7 @@ const LazySimpleDateSelector: React.FC<ISimpleDateSelectorProps> = ({
         format="EEE dd.MM.yyyy"
         value={date || null}
         showDaysOutsideCurrentMonth={true}
+        shouldDisableDate={shouldDisableDate}
         onChange={(d) => {
           setDate(stripTime(d));
         }}

--- a/app/src/components/details/scraps/LogBookInner.tsx
+++ b/app/src/components/details/scraps/LogBookInner.tsx
@@ -6,7 +6,7 @@ import { Markdown } from "./markdown/Markdown";
 import { SimpleDateSelector } from "../../common/DateSelector";
 import { format } from "date-fns";
 import { useJournalContext } from "../JournalContext";
-import { utcToDateOnly } from "../../../util/utils";
+import { getDayKey, utcToDateOnly } from "../../../util/utils";
 
 export const LogBookInner: React.FC = () => {
   const { isEditMode, setIsEditMode, date, setDate, scrapToRender, hasFocus } =
@@ -21,7 +21,7 @@ export const LogBookInner: React.FC = () => {
       if (!entry.dateTime || entry.id === scrapToRender.id) {
         continue;
       }
-      days.add(format(utcToDateOnly(new Date(entry.dateTime)), "yyyy-MM-dd"));
+      days.add(getDayKey(utcToDateOnly(new Date(entry.dateTime))));
     }
     return days;
   }, [entries, scrapToRender.id]);
@@ -40,7 +40,7 @@ export const LogBookInner: React.FC = () => {
         <SimpleDateSelector
           setDate={setDate}
           date={date}
-          shouldDisableDate={(d) => usedDays.has(format(d, "yyyy-MM-dd"))}
+          shouldDisableDate={(d) => usedDays.has(getDayKey(d))}
         />
       ) : (
         <ReadonlyTitle

--- a/app/src/components/details/scraps/LogBookInner.tsx
+++ b/app/src/components/details/scraps/LogBookInner.tsx
@@ -5,10 +5,26 @@ import { ReadonlyTitle } from "../../overview/ReadonlyTitle";
 import { Markdown } from "./markdown/Markdown";
 import { SimpleDateSelector } from "../../common/DateSelector";
 import { format } from "date-fns";
+import { useJournalContext } from "../JournalContext";
+import { utcToDateOnly } from "../../../util/utils";
 
 export const LogBookInner: React.FC = () => {
   const { isEditMode, setIsEditMode, date, setDate, scrapToRender, hasFocus } =
     useScrapContext();
+  const { entries } = useJournalContext();
+
+  // Days that already have an entry (other than the one currently being edited) must not be
+  // selectable, so we can keep at most one entry per day.
+  const usedDays = React.useMemo(() => {
+    const days = new Set<string>();
+    for (const entry of entries) {
+      if (!entry.dateTime || entry.id === scrapToRender.id) {
+        continue;
+      }
+      days.add(format(utcToDateOnly(new Date(entry.dateTime)), "yyyy-MM-dd"));
+    }
+    return days;
+  }, [entries, scrapToRender.id]);
 
   return (
     <div
@@ -21,7 +37,11 @@ export const LogBookInner: React.FC = () => {
       data-scrap-type={scrapToRender.scrapType}
     >
       {isEditMode ? (
-        <SimpleDateSelector setDate={setDate} date={date} />
+        <SimpleDateSelector
+          setDate={setDate}
+          date={date}
+          shouldDisableDate={(d) => usedDays.has(format(d, "yyyy-MM-dd"))}
+        />
       ) : (
         <ReadonlyTitle
           entity={scrapToRender}

--- a/app/src/components/details/scraps/LogBookInner.tsx
+++ b/app/src/components/details/scraps/LogBookInner.tsx
@@ -5,13 +5,30 @@ import { ReadonlyTitle } from "../../overview/ReadonlyTitle";
 import { Markdown } from "./markdown/Markdown";
 import { SimpleDateSelector } from "../../common/DateSelector";
 import { format } from "date-fns";
-import { useJournalContext } from "../JournalContext";
 import { getDayKey, utcToDateOnly } from "../../../util/utils";
+import { useJournalEntriesQuery } from "../../../serverApi/reactQuery/queries/useJournalEntriesQuery";
 
 export const LogBookInner: React.FC = () => {
-  const { isEditMode, setIsEditMode, date, setDate, scrapToRender, hasFocus } =
-    useScrapContext();
-  const { entries } = useJournalContext();
+  const {
+    journal,
+    isEditMode,
+    setIsEditMode,
+    date,
+    setDate,
+    scrapToRender,
+    hasFocus,
+  } = useScrapContext();
+
+  // Fetch the journal's entries directly (rather than via JournalContext) so day-deduplication
+  // works wherever this component is rendered - the "add entry" action lives in the app header,
+  // outside the JournalContextProvider. Empty conditions reuse the cache the view page populates
+  // and ensure we always check all entries, not a filtered subset.
+  const entries = useJournalEntriesQuery(
+    journal?.id ?? scrapToRender.parentId ?? "",
+    {},
+    {},
+    "",
+  );
 
   // Days that already have an entry (other than the one currently being edited) must not be
   // selectable, so we can keep at most one entry per day.

--- a/app/src/components/details/scraps/ScrapContextProvider.tsx
+++ b/app/src/components/details/scraps/ScrapContextProvider.tsx
@@ -26,6 +26,7 @@ import {
   useItemAction,
 } from "../../common/actions/searchParamHooks";
 import { JournalType } from "../../../serverApi/JournalType";
+import { dateOnlyToUtc, utcToDateOnly } from "../../../util/utils";
 
 const quickAddStorageKey = "quick-add";
 
@@ -56,6 +57,8 @@ export const ScrapContextProvider: React.FC<{
 }) => {
   const { setAppAlert, user } = useAppContext();
   const { renderDialog } = useDialogContext();
+
+  const isLogBook = journal?.type === JournalType.LogBook;
 
   const [scrapToRender, setScrapToRender] = useState(initialScrap);
   const [isEditMode, setIsEditMode] = useState(!scrapToRender.id);
@@ -265,11 +268,18 @@ export const ScrapContextProvider: React.FC<{
         setTitle: (t) => setScrapToRender({ ...scrapToRender, title: t }),
         notes: scrapToRender.notes,
         setNotes: (n) => setScrapToRender({ ...scrapToRender, notes: n }),
-        date: new Date(scrapToRender.dateTime),
+        // LogBook entries are date-only and stored as UTC midnight. Convert at this boundary so
+        // the rest of the (local-time) UI keeps working and the shown calendar day is stable
+        // regardless of the viewer's timezone.
+        date: isLogBook
+          ? utcToDateOnly(new Date(scrapToRender.dateTime))
+          : new Date(scrapToRender.dateTime),
         setDate: (d) =>
           setScrapToRender({
             ...scrapToRender,
-            dateTime: d ? d.toJSON() : new Date().toJSON(),
+            dateTime: d
+              ? (isLogBook ? dateOnlyToUtc(d) : d).toJSON()
+              : new Date().toJSON(),
           }),
         parsedDate,
         setParsedDate,

--- a/app/src/journalTypes/LogBookJournalType.tsx
+++ b/app/src/journalTypes/LogBookJournalType.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import { Scrap } from "../components/details/scraps/Scrap";
 import { IScrapEntry, ScrapType } from "../serverApi/IScrapEntry";
 import { ILogBookJournal } from "../serverApi/ILogBookJournal";
+import { dateOnlyToUtc } from "../util/utils";
 
 export class LogBookJournalType implements IJournalType {
   type = JournalType.LogBook;
@@ -52,7 +53,7 @@ export class LogBookJournalType implements IJournalType {
   static createBlank(journal: ILogBookJournal): IScrapEntry {
     return {
       id: undefined,
-      dateTime: new Date().toJSON(),
+      dateTime: dateOnlyToUtc(new Date()).toJSON(),
       parentId: journal.id,
       notes: (journal.customProps?.template ?? "") as string,
       title: "",

--- a/app/src/util/utils.ts
+++ b/app/src/util/utils.ts
@@ -46,6 +46,11 @@ export function formatDateOnly(date: Date): string {
   return format(date, "dd.MM.yyyy");
 }
 
+// Stable key identifying a single calendar day, used to compare/deduplicate dates.
+export function getDayKey(date: Date): string {
+  return format(date, "yyyy-MM-dd");
+}
+
 export function isValidEmail(address: string): boolean {
   // https://stackoverflow.com/a/8829363/4092115
   return !!address.match(

--- a/app/src/util/utils.ts
+++ b/app/src/util/utils.ts
@@ -28,6 +28,20 @@ export function stripTime(date?: Date | null): Date | null {
     : null;
 }
 
+// Maps a user's local calendar day to its canonical UTC-midnight instant, so a date-only value
+// (e.g. a LogBook entry's day) is stored timezone-independently.
+export function dateOnlyToUtc(local: Date): Date {
+  return new Date(
+    Date.UTC(local.getFullYear(), local.getMonth(), local.getDate()),
+  );
+}
+
+// Inverse of dateOnlyToUtc: turns a stored UTC-midnight instant back into the local midnight of
+// the same calendar day, so existing local-time display/picker code shows the correct day.
+export function utcToDateOnly(utc: Date): Date {
+  return new Date(utc.getUTCFullYear(), utc.getUTCMonth(), utc.getUTCDate());
+}
+
 export function formatDateOnly(date: Date): string {
   return format(date, "dd.MM.yyyy");
 }


### PR DESCRIPTION
Prevent multiple LogBook entries on the same day (#2829)

LogBook entries stored a full UTC timestamp and the duplicate-day check compared the UTC .Date. The frontend represented "a day" inconsistently (new entries used the full current instant, the picker used local midnight), so two entries on the same day could land on different UTC dates and slip past the check.

Adopt a date-only model stored as UTC midnight:
- backend strips the time component on save, so at most one entry can exist per day regardless of the time the client sends
- frontend converts local calendar day <-> UTC midnight at the LogBook boundary, keeping local-time display correct in any timezone
- the date picker greys out days that already have an entry


@