### PR TITLE
Enforce write permission when deleting entries

### DIFF
--- a/api/Engraved.Persistence.Mongo.Tests/Source/UserScopedMongoRepository_Permissions_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/UserScopedMongoRepository_Permissions_Should.cs
@@ -282,6 +282,58 @@ public class UserScopedMongoRepository_Permissions_Should
     await AddEntryAsMe(journalId);
   }
 
+  [Test]
+  public async Task DeleteEntry_NotPossible_WithNoPermissionsAtAll()
+  {
+    string journalId = await CreateJournalForOtherUser();
+    string entryId = await AddEntryForOtherUser(journalId);
+
+    Assert.ThrowsAsync<NotAllowedOperationException>(
+      async () => { await _userScopedRepository.DeleteEntry(entryId); }
+    );
+
+    (await _repository.GetEntry(entryId)).Should().NotBeNull();
+  }
+
+  [Test]
+  public async Task DeleteEntry_NotPossible_WithOnlyReadPermissions()
+  {
+    string journalId = await CreateJournalForOtherUser();
+    await GiveMePermissions(journalId, PermissionKind.Read);
+    string entryId = await AddEntryForOtherUser(journalId);
+
+    Assert.ThrowsAsync<NotAllowedOperationException>(
+      async () => { await _userScopedRepository.DeleteEntry(entryId); }
+    );
+
+    (await _repository.GetEntry(entryId)).Should().NotBeNull();
+  }
+
+  [Test]
+  public async Task DeleteEntry_Possible_WithWritePermissions()
+  {
+    string journalId = await CreateJournalForOtherUser();
+    await GiveMePermissions(journalId, PermissionKind.Write);
+    string entryId = await AddEntryForOtherUser(journalId);
+
+    await _userScopedRepository.DeleteEntry(entryId);
+
+    (await _repository.GetEntry(entryId)).Should().BeNull();
+  }
+
+  private async Task<string> AddEntryForOtherUser(string journalId)
+  {
+    UpsertResult result = await _repository.UpsertEntry(
+      new CounterEntry
+      {
+        ParentId = journalId,
+        UserId = _otherUserId
+      }
+    );
+
+    return result.EntityId;
+  }
+
   private async Task UpsertJournalAsMe(string journalId)
   {
     await _userScopedRepository.UpsertJournal(

--- a/api/Engraved.Persistence.Mongo/Source/MongoRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/MongoRepository.cs
@@ -376,7 +376,7 @@ public class MongoRepository(MongoDatabaseClient mongoDatabaseClient) : IBaseRep
     return CreateUpsertResult(entry.Id, replaceOneResult);
   }
 
-  public async Task DeleteEntry(string entryId)
+  public virtual async Task DeleteEntry(string entryId)
   {
     await EntriesCollection.DeleteOneAsync(MongoUtil.GetDocumentByIdFilter<EntryDocument>(entryId));
   }

--- a/api/Engraved.Persistence.Mongo/Source/UserScopedMongoRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/UserScopedMongoRepository.cs
@@ -1,6 +1,7 @@
 ﻿using Engraved.Core.Application;
 using Engraved.Core.Application.Persistence;
 using Engraved.Core.Domain;
+using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Permissions;
 using Engraved.Core.Domain.Users;
@@ -49,6 +50,18 @@ public class UserScopedMongoRepository : MongoRepository, IUserScopedRepository
   {
     await EnsureUserHasPermission(journalId, PermissionKind.Write);
     await base.DeleteJournal(journalId);
+  }
+
+  public override async Task DeleteEntry(string entryId)
+  {
+    IEntry? entry = await GetEntry(entryId);
+    if (entry == null)
+    {
+      return;
+    }
+
+    await EnsureUserHasPermission(entry.ParentId, PermissionKind.Write);
+    await base.DeleteEntry(entryId);
   }
 
   protected override FilterDefinition<TDocument> GetAllJournalDocumentsFilter<TDocument>(PermissionKind kind)


### PR DESCRIPTION
## Problem

Any authenticated user could delete **another** user's entry by id (IDOR / broken access control).

Two issues combined:
- `DeleteEntryCommandExecutor` deleted the entry **before** checking the caller's permission on its parent journal.
- `UserScopedMongoRepository` did not override `DeleteEntry` at all, so `MongoRepository.DeleteEntry` ran unscoped — deleting by id regardless of ownership/permissions.

(The in-memory repository already scoped `DeleteEntry`, so only the Mongo path was affected. The read path `GetEntryQueryExecutor` was already safe — it checks journal permission before returning.)

## Fix

Override `DeleteEntry` in `UserScopedMongoRepository` to require `Write` permission on the entry's parent journal before deleting, mirroring the existing `UpsertEntry` / `DeleteJournal` checks. `MongoRepository.DeleteEntry` is made `virtual` to allow the override.

## Tests

Added permission tests to `UserScopedMongoRepository_Permissions_Should`:
- delete denied with no permission (entry remains)
- delete denied with read-only permission (entry remains)
- delete allowed with write permission (entry removed)

## Notes

The required .NET SDK (10.0.300) isn't available in my environment, so I couldn't build/test locally — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)