### PR TITLE
Sanitize rendered markdown to prevent stored XSS

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -32,6 +32,7 @@
         "chartjs-plugin-annotation": "3.1.0",
         "chrono-node": "2.9.1",
         "date-fns": "4.4.0",
+        "dompurify": "3.4.10",
         "emoji-picker-react": "4.19.1",
         "emoji-regex": "10.6.0",
         "google-one-tap": "1.0.6",
@@ -2273,6 +2274,13 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -2808,6 +2816,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/emoji-picker-react": {

--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
     "chartjs-plugin-annotation": "3.1.0",
     "chrono-node": "2.9.1",
     "date-fns": "4.4.0",
+    "dompurify": "3.4.10",
     "emoji-picker-react": "4.19.1",
     "emoji-regex": "10.6.0",
     "google-one-tap": "1.0.6",

--- a/app/src/components/details/scraps/markdown/LazyMarkdown.spec.tsx
+++ b/app/src/components/details/scraps/markdown/LazyMarkdown.spec.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import LazyMarkdown from "./LazyMarkdown";
+
+describe("LazyMarkdown", () => {
+  it("strips script tags from rendered markdown", () => {
+    const { container } = render(
+      <LazyMarkdown value={"<script>window.xss = true;</script>hello"} />,
+    );
+
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.innerHTML).not.toContain("<script");
+  });
+
+  it("strips inline event handler attributes", () => {
+    const { container } = render(
+      <LazyMarkdown value={'<img src="x" onerror="window.xss = true;">'} />,
+    );
+
+    expect(container.querySelector("img")?.getAttribute("onerror")).toBeNull();
+  });
+
+  it("removes javascript: urls from links", () => {
+    const { container } = render(
+      <LazyMarkdown value={"[click me](javascript:alert(1))"} />,
+    );
+
+    const href = container.querySelector("a")?.getAttribute("href") ?? "";
+    expect(href.toLowerCase()).not.toContain("javascript:");
+  });
+
+  it("keeps safe links opening in a new tab", () => {
+    const { container } = render(
+      <LazyMarkdown value={"[example](https://example.com)"} />,
+    );
+
+    const anchor = container.querySelector("a");
+    expect(anchor?.getAttribute("href")).toBe("https://example.com");
+    expect(anchor?.getAttribute("target")).toBe("_blank");
+  });
+
+  it("renders regular markdown content", () => {
+    const { container } = render(<LazyMarkdown value={"**bold**"} />);
+
+    expect(container.querySelector("strong")?.textContent).toBe("bold");
+  });
+});

--- a/app/src/components/details/scraps/markdown/LazyMarkdown.tsx
+++ b/app/src/components/details/scraps/markdown/LazyMarkdown.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { IMarkdownProps } from "./Markdown";
 import { BasicMarkdownContainer, MarkdownContainer } from "./MarkdownContainer";
 import { marked, Tokens } from "marked";
+import DOMPurify from "dompurify";
 import emojiRegex from "emoji-regex";
 
 const regex = emojiRegex();
@@ -45,11 +46,14 @@ function getHtml(value: string, useBasic?: boolean) {
     return "";
   }
 
-  if (useBasic) {
-    return md.parseInline(value).toString();
-  }
+  const html = useBasic
+    ? md.parseInline(value).toString()
+    : md.parse(value).toString();
 
-  return md.parse(value).toString();
+  // The rendered markdown is injected via dangerouslySetInnerHTML, so it must
+  // be sanitized to prevent stored XSS from user-provided content. ADD_ATTR
+  // keeps the target="_blank" added by the link renderer.
+  return DOMPurify.sanitize(html, { ADD_ATTR: ["target"] });
 }
 
 export default LazyMarkdown;


### PR DESCRIPTION
## Problem

`LazyMarkdown` rendered user-provided markdown via `marked()` and injected the result with `dangerouslySetInnerHTML` **without sanitization**. `marked` does not sanitize, so user content such as:

- `<img src=x onerror=...>`
- `<script>...</script>`
- `[link](javascript:...)`

executed in the viewer's browser. Because scraps/journals can be **shared with other users**, this was a *stored* XSS — and since the auth token lives in `localStorage`, it could be exfiltrated.

## Fix

Run the `marked()` output through **DOMPurify** before injecting it. `ADD_ATTR: ["target"]` preserves the `target="_blank"` added by the custom link renderer (`rel="noopener noreferrer"` is kept by default).

Adds one dependency, `dompurify@3.4.10` (approved given it's the industry-standard sanitizer; rolling our own would be more error-prone).

## Tests

New `LazyMarkdown.spec.tsx` covers:
- script tags stripped
- inline event-handler attributes stripped
- `javascript:` urls removed from links
- safe links preserved with `target="_blank"`
- normal markdown still renders

All pass; `types:check`, `eslint`, and `knip` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)