### PR TITLE
Escape user input in free-text search to prevent ReDoS

### DIFF
--- a/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepository_SearchEntries_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepository_SearchEntries_Should.cs
@@ -86,6 +86,37 @@ public class MongoRepository_SearchEntries_Should
   }
 
   [Test]
+  public async Task TreatRegexMetacharactersLiterally()
+  {
+    await _repository.UpsertEntry(
+      new GaugeEntry
+      {
+        ParentId = _journalId,
+        Value = 4,
+        Notes = "price (USD)",
+        EditedOn = DateTime.Now.AddDays(-5)
+      }
+    );
+
+    // "(USD)" is a valid regex (a group); when matched literally it must only
+    // find the entry that actually contains the parentheses.
+    IEntry[] results = await _repository.SearchEntries("(USD)", null, null, [_journalId], 10);
+
+    results.Length.Should().Be(1);
+    results[0].GetValue().Should().Be(4);
+  }
+
+  [Test]
+  public void DoesNotThrowOnMalformedRegexInput()
+  {
+    // An unbalanced bracket is an invalid regex. Before escaping, this threw
+    // while building the filter (and surfaced as a 500).
+    Assert.DoesNotThrowAsync(
+      async () => await _repository.SearchEntries("(unclosed", null, null, [_journalId], 10)
+    );
+  }
+
+  [Test]
   public async Task Consider_ScrapsTitle()
   {
     var journal = new ScrapsJournal { Name = "My Scrap" };

--- a/api/Engraved.Persistence.Mongo/Source/MongoRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/MongoRepository.cs
@@ -546,10 +546,15 @@ public class MongoRepository(MongoDatabaseClient mongoDatabaseClient) : IBaseRep
     return searchText.Split(" ")
       .Select(segment =>
         {
+          // Escape the user input so it is matched literally. Passing it to the
+          // regex engine unescaped allowed malformed patterns (exceptions) and
+          // catastrophic-backtracking patterns (ReDoS) to be injected via search.
           return Builders<T>.Filter.Or(
             fieldNameExpressions.Select(exp => Builders<T>.Filter.Regex(
                 exp,
-                new BsonRegularExpression(new Regex(segment, RegexOptions.IgnoreCase | RegexOptions.Multiline))
+                new BsonRegularExpression(
+                  new Regex(Regex.Escape(segment), RegexOptions.IgnoreCase | RegexOptions.Multiline)
+                )
               )
             )
           );


### PR DESCRIPTION
## Problem

`GetFreeTextFilters` (used by journal/entry search) passed the raw user search text straight into the regex engine — `new Regex(segment, ...)` — before building a Mongo `$regex` filter. This allowed regex injection via the search box:

- **ReDoS:** a catastrophic-backtracking pattern (e.g. `(a+)+$`) could pin CPU on the database.
- **Unhandled exception:** a malformed pattern (e.g. `(unclosed`) threw while building the filter, surfacing as a 500.

## Fix

Wrap the segment in `Regex.Escape(...)` so the search text is matched literally. Behaviour is unchanged for normal input (case-insensitive substring match).

## Tests

Added to `MongoRepository_SearchEntries_Should`:
- `TreatRegexMetacharactersLiterally` — searching `(USD)` matches only the entry containing those literal characters.
- `DoesNotThrowOnMalformedRegexInput` — searching `(unclosed` no longer throws.

## Notes

As with the delete-permission PR, the required .NET SDK (10.0.300) isn't available in my environment, so I couldn't build/run these Mongo integration tests locally — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)