### PR TITLE
Centralize relative time label updates into a shared ticker

### DIFF
--- a/app/src/components/common/FormatDate.tsx
+++ b/app/src/components/common/FormatDate.tsx
@@ -1,9 +1,8 @@
 import { DateFormat, formatDate, getAsDate } from "./dateTypes";
 import { differenceInHours } from "date-fns";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Tooltip } from "@mui/material";
-
-const autoUpdateIntervalSeconds = 30;
+import { useNow } from "./useNow";
 
 export const FormatDate: React.FC<{
   value: Date | string | number | null | undefined;
@@ -32,37 +31,23 @@ const FormatDateInternal: React.FC<{
   dateFormat?: DateFormat;
   onClick?: () => void;
 }> = ({ value, dateFormat, onClick }) => {
-  const calculateValues = useCallback(() => {
-    return {
-      title: formatDate(
-        value,
-        dateFormat === DateFormat.relativeToNow || !dateFormat
-          ? DateFormat.full
-          : DateFormat.relativeToNow,
-      ),
-      label: formatDate(value, dateFormat),
-    };
-  }, [dateFormat, value]);
+  // Relative labels only need to keep updating while the value is recent. Older
+  // values don't visibly change, so they don't subscribe to the shared ticker.
+  const isRecent = differenceInHours(new Date(), getAsDate(value)) <= 2;
 
-  const [values, setValues] = useState<{ title: string; label: string }>(
-    calculateValues(),
+  // Re-render on every shared tick (while recent) to refresh the relative label.
+  useNow(isRecent);
+
+  const title = formatDate(
+    value,
+    dateFormat === DateFormat.relativeToNow || !dateFormat
+      ? DateFormat.full
+      : DateFormat.relativeToNow,
   );
-
-  useEffect(() => {
-    if (differenceInHours(new Date(), getAsDate(value)) > 2) {
-      return;
-    }
-
-    const interval = window.setInterval(
-      () => setValues(calculateValues()),
-      autoUpdateIntervalSeconds * 1000,
-    );
-
-    return () => window.clearInterval(interval);
-  }, [dateFormat, value, calculateValues]);
+  const label = formatDate(value, dateFormat);
 
   return (
-    <Tooltip title={values.title}>
+    <Tooltip title={title}>
       <span
         style={{ cursor: "pointer" }}
         onClick={(e) => {
@@ -74,7 +59,7 @@ const FormatDateInternal: React.FC<{
           onClick();
         }}
       >
-        {values.label}
+        {label}
       </span>
     </Tooltip>
   );

--- a/app/src/components/common/useNow.ts
+++ b/app/src/components/common/useNow.ts
@@ -1,0 +1,52 @@
+import { useSyncExternalStore } from "react";
+
+const autoUpdateIntervalSeconds = 30;
+
+// A single, shared ticker for all relative time labels (see FormatDate.tsx).
+// Instead of every component instance registering its own setInterval, they all
+// subscribe to this one loop. The interval is started lazily when the first
+// subscriber appears and stopped again once the last one unsubscribes, so it
+// only runs while there is actually something on screen that needs updating.
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+let intervalId: number | undefined;
+let now = Date.now();
+
+const tick = () => {
+  now = Date.now();
+  listeners.forEach((listener) => listener());
+};
+
+const subscribe = (listener: Listener) => {
+  listeners.add(listener);
+
+  if (intervalId === undefined) {
+    intervalId = window.setInterval(tick, autoUpdateIntervalSeconds * 1000);
+  }
+
+  return () => {
+    listeners.delete(listener);
+
+    if (listeners.size === 0 && intervalId !== undefined) {
+      window.clearInterval(intervalId);
+      intervalId = undefined;
+    }
+  };
+};
+
+const getSnapshot = () => now;
+
+const noopSubscribe = () => () => {};
+const getDisabledSnapshot = () => 0;
+
+// Returns a value that changes on every shared tick, causing the consuming
+// component to re-render. When `enabled` is false the component does not
+// subscribe at all (and never re-renders because of the ticker).
+export const useNow = (enabled = true): number => {
+  return useSyncExternalStore(
+    enabled ? subscribe : noopSubscribe,
+    enabled ? getSnapshot : getDisabledSnapshot,
+  );
+};


### PR DESCRIPTION
Closes #2838

## Problem
Every `FormatDate` instance registered its own `setInterval` to refresh relative time labels. With N recent timestamps on screen this means N independent timers, each started at its own mount time — so labels tick over **out of sync** and trigger N separate re-renders per cycle.

## Change
- Add **`useNow.ts`**: a single module-level ticker exposed via `useSyncExternalStore`. One `setInterval` (still 30s) drives all subscribers; it starts lazily when the first label subscribes and stops when the last unsubscribes, so nothing runs when no recent labels are mounted.
- Simplify **`FormatDate.tsx`**: drop the per-instance `useState`/`useEffect`/`useCallback`/`setInterval`. Values are derived during render, and `useNow(isRecent)` re-renders on the shared tick only while the value is within 2 hours (same threshold as before).

Behavior is preserved (30s cadence, 2h recency cutoff, toggle, tooltip), but now there is one synchronized loop instead of one timer per label.

`tsc --noEmit` and ESLint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)