### PR TITLE
Add Content-Security-Policy and security headers

### DIFF
--- a/app/public/staticwebapp.config.json
+++ b/app/public/staticwebapp.config.json
@@ -2,5 +2,11 @@
   "navigationFallback": {
     "rewrite": "/index.html",
     "exclude": ["*.{css,scss,js,png,gif,ico,jpg,svg}"]
+  },
+  "globalHeaders": {
+    "Content-Security-Policy-Report-Only": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.onesignal.com; connect-src 'self' https://engraved.azurewebsites.net https://engraved-lnx.azurewebsites.net https://accounts.google.com https://*.onesignal.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://accounts.google.com; worker-src 'self'; manifest-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'",
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload"
   }
 }

--- a/app/public/staticwebapp.config.json
+++ b/app/public/staticwebapp.config.json
@@ -4,7 +4,7 @@
     "exclude": ["*.{css,scss,js,png,gif,ico,jpg,svg}"]
   },
   "globalHeaders": {
-    "Content-Security-Policy-Report-Only": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.onesignal.com; connect-src 'self' https://engraved.azurewebsites.net https://engraved-lnx.azurewebsites.net https://accounts.google.com https://*.onesignal.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://accounts.google.com; worker-src 'self'; manifest-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.onesignal.com; connect-src 'self' https://engraved.azurewebsites.net https://engraved-lnx.azurewebsites.net https://accounts.google.com https://*.onesignal.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://accounts.google.com; worker-src 'self'; manifest-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'",
     "X-Content-Type-Options": "nosniff",
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload"


### PR DESCRIPTION
## Why

Defense-in-depth follow-up to the auth/token work (#2846). Every token-storage choice shares one residual: if malicious JS runs in the page (e.g. a stored-XSS via user markdown, or a compromised dependency), it can still ride the session or read the in-memory token. CSP attacks that — it stops injected script from executing and limits where any script can send data — which no token-storage approach does.

## What

Adds a **`Content-Security-Policy`** header (plus `X-Content-Type-Options`, `Referrer-Policy`, `Strict-Transport-Security`) via `globalHeaders` in the Azure Static Web Apps config (`app/public/staticwebapp.config.json`).

It was first deployed in **report-only** mode from this branch; that surfaced no legitimate violations, so it's now switched to **enforcing**.

## The policy

```
default-src 'self';
script-src  'self' https://accounts.google.com https://cdn.onesignal.com;
connect-src 'self' https://engraved.azurewebsites.net https://engraved-lnx.azurewebsites.net
            https://accounts.google.com https://*.onesignal.com;
style-src   'self' 'unsafe-inline' https://fonts.googleapis.com;
font-src    'self' https://fonts.gstatic.com;
img-src     'self' data: https:;
frame-src   https://accounts.google.com;
worker-src  'self'; manifest-src 'self';
base-uri 'self'; frame-ancestors 'none'; object-src 'none';
```

- **`script-src` is strict** — no `'unsafe-inline'`, no `'unsafe-eval'`. The production bundle has a single external script and the app uses no `eval`, so the only allowed external script origins are **Google Identity Services** (One Tap) and **OneSignal**. Injected inline scripts won't execute.
- **`style-src` keeps `'unsafe-inline'`** because MUI/emotion inject runtime styles (low risk — styles can't run code).
- `connect-src` whitelists both API hosts + Google + OneSignal, so a script can't exfiltrate to an arbitrary origin.
- `img-src https:` is intentionally permissive (Google avatars + user-embedded markdown images).

## Notes
- Independent of #2846 — touches only hosting config, no app/auth code.
- Verified report-only against the live deploy before enforcing; JSON validated and confirmed it copies into the deployed `dist` artifact.
- If a new third-party origin is added later (e.g. a different OneSignal sub-domain), it'll be blocked until added here — watch the console after such changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)