### PR TITLE
Allow Google sign-in stylesheet in CSP style-src

### DIFF
--- a/app/public/staticwebapp.config.json
+++ b/app/public/staticwebapp.config.json
@@ -4,7 +4,7 @@
     "exclude": ["*.{css,scss,js,png,gif,ico,jpg,svg}"]
   },
   "globalHeaders": {
-    "Content-Security-Policy": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.onesignal.com; connect-src 'self' https://engraved.azurewebsites.net https://engraved-lnx.azurewebsites.net https://accounts.google.com https://*.onesignal.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://accounts.google.com; worker-src 'self'; manifest-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.onesignal.com; connect-src 'self' https://engraved.azurewebsites.net https://engraved-lnx.azurewebsites.net https://accounts.google.com https://*.onesignal.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://accounts.google.com; worker-src 'self'; manifest-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'",
     "X-Content-Type-Options": "nosniff",
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload"

--- a/app/src/serverApi/authentication/registerGooglePrompt.ts
+++ b/app/src/serverApi/authentication/registerGooglePrompt.ts
@@ -28,6 +28,10 @@ export function registerGooglePrompt(
         return;
       }
 
+      // With FedCM the prompt no longer reports display-moment status
+      // (isNotDisplayed()/isSkippedMoment() are deprecated and emit
+      // [GSI_LOGGER] warnings), so we render the button unconditionally as a
+      // fallback and let the browser decide whether to show One Tap.
       google.accounts.id.renderButton(domElement, {
         theme: "outline",
         size: "large",


### PR DESCRIPTION
## Problem

After #2852 added a `Content-Security-Policy`, the browser console showed:

> Loading the stylesheet 'https://accounts.google.com/gsi/style' violates the following Content Security Policy directive: "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com".

Google Identity Services (the `gsi/client` script) injects its own stylesheet from `https://accounts.google.com/gsi/style`. `accounts.google.com` was whitelisted for `script-src`, `connect-src`, and `frame-src`, but not `style-src`, so the stylesheet got blocked. (`'unsafe-inline'` doesn't cover external `<link>` stylesheets.)

## Fix

Add `https://accounts.google.com` to the `style-src` directive in `staticwebapp.config.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)