### PR TITLE
Pass secrets to build-app reusable workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,7 @@ jobs:
   build-app:
     name: Build App
     uses: ./.github/workflows/build-app.yml
+    secrets: inherit
 
   e2e-tests:
     name: E2E Tests


### PR DESCRIPTION
The build-app reusable workflow reads secrets.APP_INSIGHTS_CONNECTING_STRING, but the calling job did not pass secrets down, so it resolved to an empty string. Add `secrets: inherit` to the build-app job.