### PR TITLE
Allow Application Insights endpoints in CSP connect-src

### DIFF
--- a/app/public/staticwebapp.config.json
+++ b/app/public/staticwebapp.config.json
@@ -4,7 +4,7 @@
     "exclude": ["*.{css,scss,js,png,gif,ico,jpg,svg}"]
   },
   "globalHeaders": {
-    "Content-Security-Policy": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.onesignal.com; connect-src 'self' https://engraved.azurewebsites.net https://engraved-lnx.azurewebsites.net https://accounts.google.com https://*.onesignal.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://accounts.google.com; worker-src 'self'; manifest-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.onesignal.com; connect-src 'self' https://engraved.azurewebsites.net https://engraved-lnx.azurewebsites.net https://accounts.google.com https://*.onesignal.com https://js.monitor.azure.com https://*.in.applicationinsights.azure.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://accounts.google.com; worker-src 'self'; manifest-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'",
     "X-Content-Type-Options": "nosniff",
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload"


### PR DESCRIPTION
## Problem

After the CSP from #2852, the browser console showed Application Insights being blocked:

> Connecting to 'https://js.monitor.azure.com/scripts/b/ai.config.1.cfg.json' violates the following Content Security Policy directive: "connect-src ...".
> Connecting to 'https://switzerlandnorth-0.in.applicationinsights.azure.com/v2/track' violates ... "connect-src ...".

The App Insights SDK fetches its config from `js.monitor.azure.com` and posts telemetry to a region-specific `*.in.applicationinsights.azure.com` endpoint, neither of which was in `connect-src`.

## Fix

Add `https://js.monitor.azure.com` and `https://*.in.applicationinsights.azure.com` to the `connect-src` directive in `staticwebapp.config.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)