### PR TITLE
Add TanStack Router ESLint plugin

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import typescriptEslint from "@typescript-eslint/eslint-plugin";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import pluginQuery from "@tanstack/eslint-plugin-query";
+import pluginRouter from "@tanstack/eslint-plugin-router";
 import playwright from "eslint-plugin-playwright";
 
 const appFiles = ["app/**/*.{js,jsx,ts,tsx}"];
@@ -35,6 +36,10 @@ export default [
     files: appFiles,
   },
   ...pluginQuery.configs["flat/recommended"].map((config) => ({
+    ...config,
+    files: appFiles,
+  })),
+  ...pluginRouter.configs["flat/recommended"].map((config) => ({
     ...config,
     files: appFiles,
   })),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@eslint/js": "10.0.1",
         "@tanstack/eslint-plugin-query": "5.101.0",
+        "@tanstack/eslint-plugin-router": "^1.162.0",
         "@types/node": "24.13.2",
         "@typescript-eslint/eslint-plugin": "8.62.0",
         "@typescript-eslint/parser": "8.62.0",
@@ -1214,6 +1215,23 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-router": {
+      "version": "1.162.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-router/-/eslint-plugin-router-1.162.0.tgz",
+      "integrity": "sha512-0mv+5fOnWXeorh6zd3VyHVfpejIzc7+z68Ts0CQMDzMiwjM5rvea46fyl2m50zx5JFennsu7RO/QJAfnqkKJXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.23.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -3935,6 +3953,15 @@
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^8.58.1"
+      }
+    },
+    "@tanstack/eslint-plugin-router": {
+      "version": "1.162.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-router/-/eslint-plugin-router-1.162.0.tgz",
+      "integrity": "sha512-0mv+5fOnWXeorh6zd3VyHVfpejIzc7+z68Ts0CQMDzMiwjM5rvea46fyl2m50zx5JFennsu7RO/QJAfnqkKJXw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "^8.23.0"
       }
     },
     "@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@tanstack/eslint-plugin-query": "5.101.0",
+    "@tanstack/eslint-plugin-router": "1.162.0",
     "@types/node": "24.13.2",
     "@typescript-eslint/eslint-plugin": "8.62.0",
     "@typescript-eslint/parser": "8.62.0",


### PR DESCRIPTION
## What

Adds `@tanstack/eslint-plugin-router` — the remaining dependency-specific gap noted in the ESLint review (#2872). Follow-up to the flat-config modernization in #2873.

## Changes

- Add `@tanstack/eslint-plugin-router` (1.162.0) as a devDependency.
- Wire `pluginRouter.configs["flat/recommended"]` into the flat config, scoped to `app/**` alongside the existing TanStack Query plugin.

This enables two rules for `@tanstack/react-router` usage:
- `@tanstack/router/create-route-property-order` (warn, auto-fixable)
- `@tanstack/router/route-param-names` (error)

## Behavior

Verified with `eslint --print-config`: the router rules resolve for `app/**` files and are absent for `tests/**`. `eslint .` passes clean — no existing violations.

Refs #2872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
