### PR TITLE
Migrate integration tests from the in-memory fake to EphemeralMongo

### DIFF
--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -16,11 +16,8 @@ jobs:
     outputs:
       artifact-name: api
 
-    services:
-      mongo:
-        image: mongo
-        ports:
-          - 27017:27017
+    # note: no mongo service container is needed. The integration tests use EphemeralMongo,
+    # which downloads and runs its own mongod on a random free port per test process.
 
     steps:
       - name: Checkout repo
@@ -32,6 +29,12 @@ jobs:
           dotnet-version: "10.x.x"
           cache: true
           cache-dependency-path: 'api/**/*.csproj'
+
+      - name: Cache EphemeralMongo binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/ephemeral-mongo
+          key: ephemeral-mongo-${{ runner.os }}
 
       - name: Run tests
         run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -36,14 +36,9 @@ jobs:
           path: ~/.local/share/ephemeral-mongo
           key: ephemeral-mongo-${{ runner.os }}
 
-      # The default in-memory engine uses the MongoDB Enterprise binary, which on Linux needs extra
-      # system libraries (libldap etc.) that aren't on the runner. Run CI against the on-disk
-      # Community engine instead - it has no such dependency. Local dev keeps the in-memory default.
       - name: Run tests
         run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
         working-directory: api
-        env:
-          ENGRAVED_TEST_MONGO_ENGINE: ondisk
 
       - name: Get current time
         id: current-time

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -34,15 +34,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local/share/ephemeral-mongo
-          # Util.cs selects the mongo edition/storage engine, so hash it: switching the engine
-          # (e.g. community <-> enterprise) invalidates the cache and downloads the right binaries.
-          key: ephemeral-mongo-${{ runner.os }}-${{ hashFiles('api/Engraved.Persistence.Mongo.Tests/Source/Util.cs') }}
-          restore-keys: |
-            ephemeral-mongo-${{ runner.os }}-
+          key: ephemeral-mongo-${{ runner.os }}
 
+      # The default in-memory engine uses the MongoDB Enterprise binary, which on Linux needs extra
+      # system libraries (libldap etc.) that aren't on the runner. Run CI against the on-disk
+      # Community engine instead - it has no such dependency. Local dev keeps the in-memory default.
       - name: Run tests
         run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
         working-directory: api
+        env:
+          ENGRAVED_TEST_MONGO_ENGINE: ondisk
 
       - name: Get current time
         id: current-time

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -34,7 +34,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local/share/ephemeral-mongo
-          key: ephemeral-mongo-${{ runner.os }}
+          # Util.cs selects the mongo edition/storage engine, so hash it: switching the engine
+          # (e.g. community <-> enterprise) invalidates the cache and downloads the right binaries.
+          key: ephemeral-mongo-${{ runner.os }}-${{ hashFiles('api/Engraved.Persistence.Mongo.Tests/Source/Util.cs') }}
+          restore-keys: |
+            ephemeral-mongo-${{ runner.os }}-
 
       - name: Run tests
         run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover

--- a/api/Engraved.Api.Tests/Engraved.Api.Tests.csproj
+++ b/api/Engraved.Api.Tests/Engraved.Api.Tests.csproj
@@ -12,6 +12,12 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- NUnit only discovers [SetUpFixture] in the assembly under test, so the shared mongo
+             teardown source is compiled into this assembly too. -->
+        <Compile Include="..\Engraved.Persistence.Mongo.Tests\Source\MongoRunnerTeardown.cs" Link="MongoRunnerTeardown.cs"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0"/>
         <PackageReference Include="FluentAssertions" Version="8.10.0"/>
         <PackageReference Include="NUnit" Version="4.6.1"/>

--- a/api/Engraved.Api.Tests/Engraved.Api.Tests.csproj
+++ b/api/Engraved.Api.Tests/Engraved.Api.Tests.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Engraved.Api\Engraved.Api.csproj"/>
+        <ProjectReference Include="..\Engraved.Persistence.Mongo.Tests\Engraved.Persistence.Mongo.Tests.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/api/Engraved.Api.Tests/Source/Authentication/LoginHandlerShould.cs
+++ b/api/Engraved.Api.Tests/Source/Authentication/LoginHandlerShould.cs
@@ -120,7 +120,7 @@ public class LoginHandlerShould
   [Test]
   public async Task Follow_HappyPath_WithExistingUser()
   {
-    const string userId = "6a40b7027bf30b7c135049b2";
+    const string userId = TestIds.ThirdUserId;
     const string displayName = "Hans Peter";
     const string imageUrl = "https://im.age.url";
     const string userName = "ha-pe";

--- a/api/Engraved.Api.Tests/Source/Authentication/LoginHandlerShould.cs
+++ b/api/Engraved.Api.Tests/Source/Authentication/LoginHandlerShould.cs
@@ -6,7 +6,7 @@ using Engraved.Api.Authentication.Google;
 using Engraved.Api.Settings;
 using Engraved.Core.Application;
 using Engraved.Core.Application.Persistence;
-using Engraved.Core.Application.Persistence.Demo;
+using Engraved.Persistence.Mongo.Tests;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Users;
 using FluentAssertions;
@@ -29,13 +29,13 @@ public class LoginHandlerShould
 
   private IDateService _dateService = null!;
   private LoginHandler _loginHandler = null!;
-  private IBaseRepository _testRepository = null!;
+  private TestMongoRepository _testRepository = null!;
   private UserLoader _userLoader = null!;
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
-    _testRepository = new InMemoryRepository();
+    _testRepository = await Util.CreateMongoRepository();
 
     _userLoader = new UserLoader(_testRepository, new MemoryCache(new MemoryCacheOptions()));
 
@@ -95,7 +95,7 @@ public class LoginHandlerShould
     result.User.Name.Should().Be(userName);
     result.User.ImageUrl.Should().Be(imageUrl);
     result.User.Id.Should().NotBeNull();
-    result.User.LastLoginDate.Should().Be(_dateService.UtcNow);
+    result.User.LastLoginDate.Should().BeCloseTo(_dateService.UtcNow, TimeSpan.FromMilliseconds(100));
 
     IUser[] users = await _testRepository.GetAllUsers();
 
@@ -107,7 +107,7 @@ public class LoginHandlerShould
     user.Name.Should().Be(userName);
     user.ImageUrl.Should().Be(imageUrl);
     user.Id.Should().NotBeNull();
-    user.LastLoginDate.Should().Be(_dateService.UtcNow);
+    user.LastLoginDate.Should().BeCloseTo(_dateService.UtcNow, TimeSpan.FromMilliseconds(100));
     user.FavoriteJournalIds.Count().Should().Be(1);
     user.GlobalUniqueId.Should().NotBeNull();
 
@@ -120,23 +120,28 @@ public class LoginHandlerShould
   [Test]
   public async Task Follow_HappyPath_WithExistingUser()
   {
-    const string userId = "haPeID";
+    const string userId = "6a40b7027bf30b7c135049b2";
     const string displayName = "Hans Peter";
     const string imageUrl = "https://im.age.url";
     const string userName = "ha-pe";
     var globalUniqueId = Guid.NewGuid();
 
-    await _testRepository.UpsertUser(
-      new User
-      {
-        Id = userId,
-        Name = userName,
-        DisplayName = displayName,
-        ImageUrl = imageUrl,
-        LastLoginDate = DateTime.UtcNow.AddMinutes(-12345),
-        GlobalUniqueId = globalUniqueId
-      }
-    );
+    var existingUser = new User
+    {
+      Id = userId,
+      Name = userName,
+      DisplayName = displayName,
+      ImageUrl = imageUrl,
+      LastLoginDate = DateTime.UtcNow.AddMinutes(-12345),
+      GlobalUniqueId = globalUniqueId
+    };
+
+    // must ensure the journal exists as it will be loaded as favorite
+    var journalId = "60703c3b000000000000000a";
+    existingUser.FavoriteJournalIds.Add(journalId);
+    await _testRepository.UpsertJournal(new ScrapsJournal { Id = journalId, Name = "Quick Scraps", UserId = userId });
+
+    await _testRepository.UpsertUser(existingUser);
 
     var loginHandler = CreateLoginHandler(new FakeGoogleTokenValidator(imageUrl, userName, displayName));
 
@@ -148,7 +153,7 @@ public class LoginHandlerShould
     result.User!.ImageUrl.Should().Be(imageUrl);
     result.User.Id.Should().Be(userId);
     result.User.GlobalUniqueId.Should().Be(globalUniqueId);
-    result.User.LastLoginDate.Should().Be(_dateService.UtcNow);
+    result.User.LastLoginDate.Should().BeCloseTo(_dateService.UtcNow, TimeSpan.FromMilliseconds(100));
 
     IUser[] users = await _testRepository.GetAllUsers();
 
@@ -159,7 +164,7 @@ public class LoginHandlerShould
     user.DisplayName.Should().Be(displayName);
     user.Name.Should().Be(userName);
     user.ImageUrl.Should().Be(imageUrl);
-    user.Id.Should().NotBeNull();
-    user.LastLoginDate.Should().Be(_dateService.UtcNow);
+    user.Id.Should().Be(userId);
+    user.LastLoginDate.Should().BeCloseTo(_dateService.UtcNow, TimeSpan.FromMilliseconds(100));
   }
 }

--- a/api/Engraved.Api.Tests/Source/Authentication/RefreshHandlerShould.cs
+++ b/api/Engraved.Api.Tests/Source/Authentication/RefreshHandlerShould.cs
@@ -3,7 +3,7 @@ using Engraved.Api.Authentication;
 using Engraved.Api.Settings;
 using Engraved.Core.Application;
 using Engraved.Core.Application.Persistence;
-using Engraved.Core.Application.Persistence.Demo;
+using Engraved.Persistence.Mongo.Tests;
 using Engraved.Core.Domain.Users;
 using FluentAssertions;
 using NUnit.Framework;
@@ -22,7 +22,7 @@ public class RefreshHandlerShould
   };
 
   private FakeDateService _dateService = null!;
-  private IBaseRepository _repository = null!;
+  private TestMongoRepository _repository = null!;
   private RefreshTokenService _refreshTokenService = null!;
   private RefreshHandler _refreshHandler = null!;
   private IUser _user = null!;
@@ -30,12 +30,12 @@ public class RefreshHandlerShould
   [SetUp]
   public async Task SetUp()
   {
-    _repository = new InMemoryRepository();
+    _repository = await Util.CreateMongoRepository();
     _dateService = new FakeDateService();
     _refreshTokenService = new RefreshTokenService(_repository, _config, _dateService);
     _refreshHandler = new RefreshHandler(_refreshTokenService, new JwtTokenFactory(_config, _dateService));
 
-    _user = new User { Name = "me@tests" };
+    _user = new User { Id = "6a40b7027bf30b7c135049b3", Name = "me@tests" };
     await _repository.UpsertUser(_user);
   }
 

--- a/api/Engraved.Api.Tests/Source/Authentication/RefreshHandlerShould.cs
+++ b/api/Engraved.Api.Tests/Source/Authentication/RefreshHandlerShould.cs
@@ -35,7 +35,7 @@ public class RefreshHandlerShould
     _refreshTokenService = new RefreshTokenService(_repository, _config, _dateService);
     _refreshHandler = new RefreshHandler(_refreshTokenService, new JwtTokenFactory(_config, _dateService));
 
-    _user = new User { Id = "6a40b7027bf30b7c135049b3", Name = "me@tests" };
+    _user = new User { Id = TestIds.OtherUserId, Name = "me@tests" };
     await _repository.UpsertUser(_user);
   }
 

--- a/api/Engraved.Api/Source/Program.cs
+++ b/api/Engraved.Api/Source/Program.cs
@@ -11,7 +11,6 @@ using Engraved.Api.Settings;
 using Engraved.Core.Application;
 using Engraved.Core.Application.Jobs;
 using Engraved.Core.Application.Persistence;
-using Engraved.Core.Application.Persistence.Demo;
 using Engraved.Core.Application.Queries;
 using Engraved.Core.Domain.Notifications;
 using Engraved.Core.Domain.Users;
@@ -98,33 +97,16 @@ builder.Services.AddSingleton(provider => new MongoDatabaseClient(
 
 builder.Services.AddTransient<IBaseRepository>(provider =>
   {
-    if (!UseInMemoryRepo())
-    {
-      var mongoDbClient = provider.GetService<MongoDatabaseClient>()!;
-      return new MongoRepository(mongoDbClient);
-    }
-
-    return new InMemoryRepository();
+    var mongoDbClient = provider.GetService<MongoDatabaseClient>()!;
+    return new MongoRepository(mongoDbClient);
   }
 );
 
 builder.Services.AddTransient<IUserScopedRepository>(provider =>
   {
     var userService = provider.GetService<ICurrentUserService>()!;
-
-    if (!UseInMemoryRepo())
-    {
-      var mongoDbClient = provider.GetService<MongoDatabaseClient>()!;
-      return new UserScopedMongoRepository(mongoDbClient, userService);
-    }
-
-    var inMemoryRepository = provider.GetService<InMemoryRepository>();
-    if (inMemoryRepository == null)
-    {
-      throw new Exception($"Cannot resolve {nameof(InMemoryRepository)}.");
-    }
-
-    return new UserScopedInMemoryRepository(inMemoryRepository, userService);
+    var mongoDbClient = provider.GetService<MongoDatabaseClient>()!;
+    return new UserScopedMongoRepository(mongoDbClient, userService);
   }
 );
 
@@ -208,12 +190,6 @@ app.UseResponseCompression();
 app.MapControllers();
 
 app.Run();
-
-bool UseInMemoryRepo()
-{
-  // return builder.Environment.IsDevelopment();
-  return false;
-}
 
 string? GetMongoDbNameOverride()
 {

--- a/api/Engraved.Core.Tests/Engraved.Core.Tests.csproj
+++ b/api/Engraved.Core.Tests/Engraved.Core.Tests.csproj
@@ -12,6 +12,12 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- NUnit only discovers [SetUpFixture] in the assembly under test, so the shared mongo
+             teardown source is compiled into this assembly too. -->
+        <Compile Include="..\Engraved.Persistence.Mongo.Tests\Source\MongoRunnerTeardown.cs" Link="MongoRunnerTeardown.cs"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0"/>
         <PackageReference Include="FluentAssertions" Version="8.10.0"/>
         <PackageReference Include="NUnit" Version="4.6.1"/>

--- a/api/Engraved.Core.Tests/Engraved.Core.Tests.csproj
+++ b/api/Engraved.Core.Tests/Engraved.Core.Tests.csproj
@@ -4,11 +4,11 @@
         <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Tests", ""))</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Engraved.Core\Engraved.Core.csproj"/>
+        <ProjectReference Include="..\Engraved.Persistence.Mongo.Tests\Engraved.Persistence.Mongo.Tests.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Delete/DeleteEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Delete/DeleteEntryCommandExecutorShould.cs
@@ -21,52 +21,53 @@ public class DeleteEntryCommandExecutorShould
     _dateService = new FakeDateService(DateTime.UtcNow.AddDays(-10));
   }
 
-  private const string JournalId = "60703c3b0000000000000001";
-  private const string OtherUserId = "60703c3b0000000000000002";
-  private const string EntryId = "60703c3b0000000000000003";
-  private const string MissingEntryId = "60703c3b0000000000000004";
-
   [Test]
   public async Task DeleteEntry_And_BumpJournalEditedOn()
   {
+    const string journalId = "60703c3b0000000000000001";
+    const string otherUserId = "60703c3b0000000000000002";
+    const string entryId = "60703c3b0000000000000003";
+
     // given
     await _repo.UpsertJournal(
       new CounterJournal
       {
-        Id = JournalId,
-        Permissions = new UserPermissions { { OtherUserId, new PermissionDefinition { Kind = PermissionKind.Read } } }
+        Id = journalId,
+        Permissions = new UserPermissions { { otherUserId, new PermissionDefinition { Kind = PermissionKind.Read } } }
       }
     );
     await _repo.UpsertEntry(
       new CounterEntry
       {
-        Id = EntryId,
-        ParentId = JournalId,
+        Id = entryId,
+        ParentId = journalId,
         DateTime = _dateService.UtcNow
       }
     );
 
     // when
     CommandResult result = await new DeleteEntryCommandExecutor(_repo, _dateService).Execute(
-      new DeleteEntryCommand { Id = EntryId }
+      new DeleteEntryCommand { Id = entryId }
     );
 
     // then
-    (await _repo.GetEntry(EntryId)).Should().BeNull();
+    (await _repo.GetEntry(entryId)).Should().BeNull();
 
-    IJournal journal = (await _repo.GetJournal(JournalId))!;
+    IJournal journal = (await _repo.GetJournal(journalId))!;
     journal.EditedOn.Should().BeCloseTo(_dateService.UtcNow, TimeSpan.FromMilliseconds(100));
 
-    result.EntityId.Should().Be(EntryId);
-    result.AffectedUserIds.Should().Contain(OtherUserId);
+    result.EntityId.Should().Be(entryId);
+    result.AffectedUserIds.Should().Contain(otherUserId);
   }
 
   [Test]
   public async Task ReturnEmptyResult_When_EntryDoesNotExist()
   {
+    const string missingEntryId = "60703c3b0000000000000004";
+
     // when
     CommandResult result = await new DeleteEntryCommandExecutor(_repo, _dateService).Execute(
-      new DeleteEntryCommand { Id = MissingEntryId }
+      new DeleteEntryCommand { Id = missingEntryId }
     );
 
     // then

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Delete/DeleteEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Delete/DeleteEntryCommandExecutorShould.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Engraved.Core.Application.Persistence.Demo;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Permissions;
+using Engraved.Persistence.Mongo.Tests;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -12,12 +12,12 @@ namespace Engraved.Core.Application.Commands.Entries.Delete;
 public class DeleteEntryCommandExecutorShould
 {
   private FakeDateService _dateService = null!;
-  private InMemoryRepository _repo = null!;
+  private TestMongoRepository _repo = null!;
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
-    _repo = new InMemoryRepository();
+    _repo = await Util.CreateMongoRepository();
     _dateService = new FakeDateService(DateTime.UtcNow.AddDays(-10));
   }
 
@@ -25,35 +25,35 @@ public class DeleteEntryCommandExecutorShould
   public async Task DeleteEntry_And_BumpJournalEditedOn()
   {
     // given
-    _repo.Journals.Add(
+    await _repo.UpsertJournal(
       new CounterJournal
       {
-        Id = "journal-id",
-        Permissions = new UserPermissions { { "user-id", new PermissionDefinition { Kind = PermissionKind.Read } } }
+        Id = "60703c3b0000000000000001",
+        Permissions = new UserPermissions { { "60703c3b0000000000000002", new PermissionDefinition { Kind = PermissionKind.Read } } }
       }
     );
-    _repo.Entries.Add(
+    await _repo.UpsertEntry(
       new CounterEntry
       {
-        Id = "entry-id",
-        ParentId = "journal-id",
+        Id = "60703c3b0000000000000003",
+        ParentId = "60703c3b0000000000000001",
         DateTime = _dateService.UtcNow
       }
     );
 
     // when
     CommandResult result = await new DeleteEntryCommandExecutor(_repo, _dateService).Execute(
-      new DeleteEntryCommand { Id = "entry-id" }
+      new DeleteEntryCommand { Id = "60703c3b0000000000000003" }
     );
 
     // then
-    (await _repo.GetEntry("entry-id")).Should().BeNull();
+    (await _repo.GetEntry("60703c3b0000000000000003")).Should().BeNull();
 
-    IJournal journal = (await _repo.GetJournal("journal-id"))!;
-    journal.EditedOn.Should().Be(_dateService.UtcNow);
+    IJournal journal = (await _repo.GetJournal("60703c3b0000000000000001"))!;
+    journal.EditedOn.Should().BeCloseTo(_dateService.UtcNow, TimeSpan.FromMilliseconds(100));
 
-    result.EntityId.Should().Be("entry-id");
-    result.AffectedUserIds.Should().Contain("user-id");
+    result.EntityId.Should().Be("60703c3b0000000000000003");
+    result.AffectedUserIds.Should().Contain("60703c3b0000000000000002");
   }
 
   [Test]
@@ -61,7 +61,7 @@ public class DeleteEntryCommandExecutorShould
   {
     // when
     CommandResult result = await new DeleteEntryCommandExecutor(_repo, _dateService).Execute(
-      new DeleteEntryCommand { Id = "does-not-exist" }
+      new DeleteEntryCommand { Id = "60703c3b0000000000000004" }
     );
 
     // then

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Delete/DeleteEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Delete/DeleteEntryCommandExecutorShould.cs
@@ -21,6 +21,11 @@ public class DeleteEntryCommandExecutorShould
     _dateService = new FakeDateService(DateTime.UtcNow.AddDays(-10));
   }
 
+  private const string JournalId = "60703c3b0000000000000001";
+  private const string OtherUserId = "60703c3b0000000000000002";
+  private const string EntryId = "60703c3b0000000000000003";
+  private const string MissingEntryId = "60703c3b0000000000000004";
+
   [Test]
   public async Task DeleteEntry_And_BumpJournalEditedOn()
   {
@@ -28,32 +33,32 @@ public class DeleteEntryCommandExecutorShould
     await _repo.UpsertJournal(
       new CounterJournal
       {
-        Id = "60703c3b0000000000000001",
-        Permissions = new UserPermissions { { "60703c3b0000000000000002", new PermissionDefinition { Kind = PermissionKind.Read } } }
+        Id = JournalId,
+        Permissions = new UserPermissions { { OtherUserId, new PermissionDefinition { Kind = PermissionKind.Read } } }
       }
     );
     await _repo.UpsertEntry(
       new CounterEntry
       {
-        Id = "60703c3b0000000000000003",
-        ParentId = "60703c3b0000000000000001",
+        Id = EntryId,
+        ParentId = JournalId,
         DateTime = _dateService.UtcNow
       }
     );
 
     // when
     CommandResult result = await new DeleteEntryCommandExecutor(_repo, _dateService).Execute(
-      new DeleteEntryCommand { Id = "60703c3b0000000000000003" }
+      new DeleteEntryCommand { Id = EntryId }
     );
 
     // then
-    (await _repo.GetEntry("60703c3b0000000000000003")).Should().BeNull();
+    (await _repo.GetEntry(EntryId)).Should().BeNull();
 
-    IJournal journal = (await _repo.GetJournal("60703c3b0000000000000001"))!;
+    IJournal journal = (await _repo.GetJournal(JournalId))!;
     journal.EditedOn.Should().BeCloseTo(_dateService.UtcNow, TimeSpan.FromMilliseconds(100));
 
-    result.EntityId.Should().Be("60703c3b0000000000000003");
-    result.AffectedUserIds.Should().Contain("60703c3b0000000000000002");
+    result.EntityId.Should().Be(EntryId);
+    result.AffectedUserIds.Should().Contain(OtherUserId);
   }
 
   [Test]
@@ -61,7 +66,7 @@ public class DeleteEntryCommandExecutorShould
   {
     // when
     CommandResult result = await new DeleteEntryCommandExecutor(_repo, _dateService).Execute(
-      new DeleteEntryCommand { Id = "60703c3b0000000000000004" }
+      new DeleteEntryCommand { Id = MissingEntryId }
     );
 
     // then

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Move/MoveEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Move/MoveEntryCommandExecutorShould.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Engraved.Core.Application.Persistence.Demo;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
+using Engraved.Persistence.Mongo.Tests;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -11,12 +11,12 @@ namespace Engraved.Core.Application.Commands.Entries.Move;
 public class MoveEntryCommandExecutorShould
 {
   private FakeDateService _dateService = null!;
-  private InMemoryRepository _repo = null!;
+  private TestMongoRepository _repo = null!;
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
-    _repo = new InMemoryRepository();
+    _repo = await Util.CreateMongoRepository();
     _dateService = new FakeDateService(DateTime.UtcNow.AddDays(-10));
   }
 
@@ -24,21 +24,21 @@ public class MoveEntryCommandExecutorShould
   public async Task MoveEntryToOtherJournal()
   {
     // given: source
-    _repo.Journals.Add(new CounterJournal { Id = "source-journal-id" });
-    _repo.Entries.Add(
+    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b0000000000000001" });
+    await _repo.UpsertEntry(
       new CounterEntry
       {
-        Id = "entry-id",
-        ParentId = "source-journal-id",
+        Id = "60703c3b0000000000000003",
+        ParentId = "60703c3b0000000000000001",
         DateTime = _dateService.UtcNow
       }
     );
-    IEntry[] sourceEntries = await _repo.GetEntriesForJournal("source-journal-id");
+    IEntry[] sourceEntries = await _repo.GetEntriesForJournal("60703c3b0000000000000001");
     sourceEntries.Length.Should().Be(1);
 
     // given: target
-    _repo.Journals.Add(new CounterJournal { Id = "target-journal-id" });
-    IEntry[] targetEntries = await _repo.GetEntriesForJournal("target-journal-id");
+    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b0000000000000002" });
+    IEntry[] targetEntries = await _repo.GetEntriesForJournal("60703c3b0000000000000002");
     targetEntries.Should().BeEmpty();
 
     // when
@@ -48,16 +48,16 @@ public class MoveEntryCommandExecutorShould
     ).Execute(
       new MoveEntryCommand
       {
-        EntryId = "entry-id",
-        TargetJournalId = "target-journal-id"
+        EntryId = "60703c3b0000000000000003",
+        TargetJournalId = "60703c3b0000000000000002"
       }
     );
 
     // then
-    targetEntries = await _repo.GetEntriesForJournal("target-journal-id");
+    targetEntries = await _repo.GetEntriesForJournal("60703c3b0000000000000002");
     targetEntries.Length.Should().Be(1);
 
-    sourceEntries = await _repo.GetEntriesForJournal("source-journal-id");
+    sourceEntries = await _repo.GetEntriesForJournal("60703c3b0000000000000001");
     sourceEntries.Should().BeEmpty();
   }
 }

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Move/MoveEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Move/MoveEntryCommandExecutorShould.cs
@@ -20,29 +20,29 @@ public class MoveEntryCommandExecutorShould
     _dateService = new FakeDateService(DateTime.UtcNow.AddDays(-10));
   }
 
-  private const string SourceJournalId = "60703c3b0000000000000001";
-  private const string TargetJournalId = "60703c3b0000000000000002";
-  private const string EntryId = "60703c3b0000000000000003";
-
   [Test]
   public async Task MoveEntryToOtherJournal()
   {
+    const string sourceJournalId = "60703c3b0000000000000001";
+    const string targetJournalId = "60703c3b0000000000000002";
+    const string entryId = "60703c3b0000000000000003";
+
     // given: source
-    await _repo.UpsertJournal(new CounterJournal { Id = SourceJournalId });
+    await _repo.UpsertJournal(new CounterJournal { Id = sourceJournalId });
     await _repo.UpsertEntry(
       new CounterEntry
       {
-        Id = EntryId,
-        ParentId = SourceJournalId,
+        Id = entryId,
+        ParentId = sourceJournalId,
         DateTime = _dateService.UtcNow
       }
     );
-    IEntry[] sourceEntries = await _repo.GetEntriesForJournal(SourceJournalId);
+    IEntry[] sourceEntries = await _repo.GetEntriesForJournal(sourceJournalId);
     sourceEntries.Length.Should().Be(1);
 
     // given: target
-    await _repo.UpsertJournal(new CounterJournal { Id = TargetJournalId });
-    IEntry[] targetEntries = await _repo.GetEntriesForJournal(TargetJournalId);
+    await _repo.UpsertJournal(new CounterJournal { Id = targetJournalId });
+    IEntry[] targetEntries = await _repo.GetEntriesForJournal(targetJournalId);
     targetEntries.Should().BeEmpty();
 
     // when
@@ -52,16 +52,16 @@ public class MoveEntryCommandExecutorShould
     ).Execute(
       new MoveEntryCommand
       {
-        EntryId = EntryId,
-        TargetJournalId = TargetJournalId
+        EntryId = entryId,
+        TargetJournalId = targetJournalId
       }
     );
 
     // then
-    targetEntries = await _repo.GetEntriesForJournal(TargetJournalId);
+    targetEntries = await _repo.GetEntriesForJournal(targetJournalId);
     targetEntries.Length.Should().Be(1);
 
-    sourceEntries = await _repo.GetEntriesForJournal(SourceJournalId);
+    sourceEntries = await _repo.GetEntriesForJournal(sourceJournalId);
     sourceEntries.Should().BeEmpty();
   }
 }

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Move/MoveEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Move/MoveEntryCommandExecutorShould.cs
@@ -20,25 +20,29 @@ public class MoveEntryCommandExecutorShould
     _dateService = new FakeDateService(DateTime.UtcNow.AddDays(-10));
   }
 
+  private const string SourceJournalId = "60703c3b0000000000000001";
+  private const string TargetJournalId = "60703c3b0000000000000002";
+  private const string EntryId = "60703c3b0000000000000003";
+
   [Test]
   public async Task MoveEntryToOtherJournal()
   {
     // given: source
-    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b0000000000000001" });
+    await _repo.UpsertJournal(new CounterJournal { Id = SourceJournalId });
     await _repo.UpsertEntry(
       new CounterEntry
       {
-        Id = "60703c3b0000000000000003",
-        ParentId = "60703c3b0000000000000001",
+        Id = EntryId,
+        ParentId = SourceJournalId,
         DateTime = _dateService.UtcNow
       }
     );
-    IEntry[] sourceEntries = await _repo.GetEntriesForJournal("60703c3b0000000000000001");
+    IEntry[] sourceEntries = await _repo.GetEntriesForJournal(SourceJournalId);
     sourceEntries.Length.Should().Be(1);
 
     // given: target
-    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b0000000000000002" });
-    IEntry[] targetEntries = await _repo.GetEntriesForJournal("60703c3b0000000000000002");
+    await _repo.UpsertJournal(new CounterJournal { Id = TargetJournalId });
+    IEntry[] targetEntries = await _repo.GetEntriesForJournal(TargetJournalId);
     targetEntries.Should().BeEmpty();
 
     // when
@@ -48,16 +52,16 @@ public class MoveEntryCommandExecutorShould
     ).Execute(
       new MoveEntryCommand
       {
-        EntryId = "60703c3b0000000000000003",
-        TargetJournalId = "60703c3b0000000000000002"
+        EntryId = EntryId,
+        TargetJournalId = TargetJournalId
       }
     );
 
     // then
-    targetEntries = await _repo.GetEntriesForJournal("60703c3b0000000000000002");
+    targetEntries = await _repo.GetEntriesForJournal(TargetJournalId);
     targetEntries.Length.Should().Be(1);
 
-    sourceEntries = await _repo.GetEntriesForJournal("60703c3b0000000000000001");
+    sourceEntries = await _repo.GetEntriesForJournal(SourceJournalId);
     sourceEntries.Should().BeEmpty();
   }
 }

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertCounterEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertCounterEntryCommandExecutorShould.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Engraved.Core.Application.Commands.Entries.Upsert.Counter;
 using Engraved.Core.Application.Commands.Entries.Upsert.Gauge;
-using Engraved.Core.Application.Persistence.Demo;
+using Engraved.Persistence.Mongo.Tests;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
 using FluentAssertions;
@@ -13,34 +13,36 @@ namespace Engraved.Core.Application.Commands.Entries.Upsert;
 
 public class UpsertCounterEntryCommandExecutorShould
 {
-  private InMemoryRepository _testRepository = null!;
+  private TestMongoRepository _testRepository = null!;
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
-    _testRepository = new InMemoryRepository();
+    _testRepository = await Util.CreateMongoRepository();
   }
 
   [Test]
   public async Task CreateNew()
   {
-    _testRepository.Journals.Add(new CounterJournal { Id = "journal_id" });
+    const string journalId = "60703c3b000000000000000a";
+    await _testRepository.UpsertJournal(new CounterJournal { Id = journalId });
 
-    var command = new UpsertCounterEntryCommand { JournalId = "journal_id", Notes = "foo" };
+    var command = new UpsertCounterEntryCommand { JournalId = journalId, Notes = "foo" };
     await new UpsertCounterEntryCommandExecutor(_testRepository, new FakeDateService()).Execute(command);
 
-    _testRepository.Entries.Count.Should().Be(1);
-    _testRepository.Entries.First().Notes.Should().Be("foo");
+    (await _testRepository.CountAllEntries()).Should().Be(1);
+    (await _testRepository.GetEntriesForJournal(journalId)).First().Notes.Should().Be("foo");
   }
 
   [Test]
   public async Task UpdateExisting()
   {
+    const string journalId = "60703c3b000000000000000b";
     IDateService dateService = new FakeDateService();
 
-    _testRepository.Journals.Add(new GaugeJournal { Id = "journal_id" });
+    await _testRepository.UpsertJournal(new GaugeJournal { Id = journalId });
 
-    var createCommand = new UpsertGaugeEntryCommand { JournalId = "journal_id", Notes = "foo", Value = 123 };
+    var createCommand = new UpsertGaugeEntryCommand { JournalId = journalId, Notes = "foo", Value = 123 };
 
     var commandExecutor = new UpsertGaugeEntryCommandExecutor(_testRepository, dateService);
     CommandResult result = await commandExecutor.Execute(createCommand);
@@ -48,7 +50,7 @@ public class UpsertCounterEntryCommandExecutorShould
     var updateCommand = new UpsertGaugeEntryCommand
     {
       Id = result.EntityId,
-      JournalId = "journal_id",
+      JournalId = journalId,
       Notes = "bar",
       Value = 42
     };
@@ -56,10 +58,11 @@ public class UpsertCounterEntryCommandExecutorShould
     commandExecutor = new UpsertGaugeEntryCommandExecutor(_testRepository, dateService);
     await commandExecutor.Execute(updateCommand);
 
-    _testRepository.Entries.Count.Should().Be(1);
-    _testRepository.Entries.First().Notes.Should().Be("bar");
-    _testRepository.Entries.First().EditedOn.Should().Be(dateService.UtcNow);
-    _testRepository.Entries.OfType<GaugeEntry>().First().Value.Should().Be(42);
+    (await _testRepository.CountAllEntries()).Should().Be(1);
+    var entries = await _testRepository.GetEntriesForJournal(journalId);
+    entries.First().Notes.Should().Be("bar");
+    entries.First().EditedOn.Should().BeCloseTo(dateService.UtcNow, TimeSpan.FromMilliseconds(100));
+    entries.OfType<GaugeEntry>().First().Value.Should().Be(42);
   }
 
   [Test]
@@ -81,7 +84,7 @@ public class UpsertCounterEntryCommandExecutorShould
   {
     var command = new UpsertCounterEntryCommand
     {
-      JournalId = "k3y",
+      JournalId = "60703c3b000000000000000c",
       Notes = "n0t3s"
     };
 

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertGaugeEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertGaugeEntryCommandExecutorShould.cs
@@ -26,11 +26,12 @@ public class UpsertGaugeEntryCommandExecutorShould
   [TestCase(123.456)]
   public async Task Set_ValueFromCommand(double value)
   {
-    await _testRepository.UpsertJournal(new GaugeJournal { Id = "60703c3b00000000000000a1" });
+    const string journalId = "60703c3b00000000000000a1";
+    await _testRepository.UpsertJournal(new GaugeJournal { Id = journalId });
 
     var command = new UpsertGaugeEntryCommand
     {
-      JournalId = "60703c3b00000000000000a1",
+      JournalId = journalId,
       Value = value
     };
 
@@ -40,7 +41,7 @@ public class UpsertGaugeEntryCommandExecutorShould
     commandResult.EntityId.Should().NotBeEmpty();
     (await _testRepository.CountAllEntries()).Should().Be(1);
 
-    IEntry createdEntry = (await _testRepository.GetEntriesForJournal("60703c3b00000000000000a1")).First();
+    IEntry createdEntry = (await _testRepository.GetEntriesForJournal(journalId)).First();
     createdEntry.ParentId.Should().Be(command.JournalId);
 
     var counterEntry = createdEntry as GaugeEntry;
@@ -51,11 +52,12 @@ public class UpsertGaugeEntryCommandExecutorShould
   [Test]
   public void Throw_WhenNoValueIsSpecified()
   {
-    _testRepository.UpsertJournal(new GaugeJournal { Id = "60703c3b00000000000000a2" }).Wait();
+    const string journalId = "60703c3b00000000000000a2";
+    _testRepository.UpsertJournal(new GaugeJournal { Id = journalId }).Wait();
 
     var command = new UpsertGaugeEntryCommand
     {
-      JournalId = "60703c3b00000000000000a2",
+      JournalId = journalId,
       Notes = "n0t3s",
       Value = null
     };
@@ -70,10 +72,11 @@ public class UpsertGaugeEntryCommandExecutorShould
   [Test]
   public async Task MapAllFieldsCorrectly()
   {
+    const string journalId = "60703c3b00000000000000a3";
     await _testRepository.UpsertJournal(
       new GaugeJournal
       {
-        Id = "60703c3b00000000000000a3",
+        Id = journalId,
         Attributes =
         {
           {
@@ -92,7 +95,7 @@ public class UpsertGaugeEntryCommandExecutorShould
 
     var command = new UpsertGaugeEntryCommand
     {
-      JournalId = "60703c3b00000000000000a3",
+      JournalId = journalId,
       Notes = "n0t3s",
       Value = value,
       JournalAttributeValues = new Dictionary<string, string[]>
@@ -107,7 +110,7 @@ public class UpsertGaugeEntryCommandExecutorShould
 
     (await _testRepository.CountAllEntries()).Should().Be(1);
 
-    IEntry createdEntry = (await _testRepository.GetEntriesForJournal("60703c3b00000000000000a3")).First();
+    IEntry createdEntry = (await _testRepository.GetEntriesForJournal(journalId)).First();
     command.JournalId.Should().Be(createdEntry.ParentId);
     command.Notes.Should().Be(createdEntry.Notes);
 
@@ -140,11 +143,12 @@ public class UpsertGaugeEntryCommandExecutorShould
   [Test]
   public async Task Throw_WhenJournalAttributeKeyDoesNotExistOnJournal()
   {
-    await _testRepository.UpsertJournal(new GaugeJournal { Id = "60703c3b00000000000000a4" });
+    const string journalId = "60703c3b00000000000000a4";
+    await _testRepository.UpsertJournal(new GaugeJournal { Id = journalId });
 
     var command = new UpsertGaugeEntryCommand
     {
-      JournalId = "60703c3b00000000000000a4",
+      JournalId = journalId,
       Notes = "n0t3s",
       Value = 42,
       JournalAttributeValues = new Dictionary<string, string[]> { { "fooBar", ["x"] } }

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertGaugeEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertGaugeEntryCommandExecutorShould.cs
@@ -50,10 +50,10 @@ public class UpsertGaugeEntryCommandExecutorShould
   }
 
   [Test]
-  public void Throw_WhenNoValueIsSpecified()
+  public async Task Throw_WhenNoValueIsSpecified()
   {
     const string journalId = "60703c3b00000000000000a2";
-    _testRepository.UpsertJournal(new GaugeJournal { Id = journalId }).Wait();
+    await _testRepository.UpsertJournal(new GaugeJournal { Id = journalId });
 
     var command = new UpsertGaugeEntryCommand
     {

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertGaugeEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertGaugeEntryCommandExecutorShould.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Engraved.Core.Application.Commands.Entries.Upsert.Gauge;
-using Engraved.Core.Application.Persistence.Demo;
+using Engraved.Persistence.Mongo.Tests;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
 using FluentAssertions;
@@ -12,12 +12,12 @@ namespace Engraved.Core.Application.Commands.Entries.Upsert;
 
 public class UpsertGaugeEntryCommandExecutorShould
 {
-  private InMemoryRepository _testRepository = null!;
+  private TestMongoRepository _testRepository = null!;
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
-    _testRepository = new InMemoryRepository();
+    _testRepository = await Util.CreateMongoRepository();
   }
 
   [Test]
@@ -26,11 +26,11 @@ public class UpsertGaugeEntryCommandExecutorShould
   [TestCase(123.456)]
   public async Task Set_ValueFromCommand(double value)
   {
-    _testRepository.Journals.Add(new GaugeJournal { Id = "k3y" });
+    await _testRepository.UpsertJournal(new GaugeJournal { Id = "60703c3b00000000000000a1" });
 
     var command = new UpsertGaugeEntryCommand
     {
-      JournalId = "k3y",
+      JournalId = "60703c3b00000000000000a1",
       Value = value
     };
 
@@ -38,9 +38,9 @@ public class UpsertGaugeEntryCommandExecutorShould
       await new UpsertGaugeEntryCommandExecutor(_testRepository, new FakeDateService()).Execute(command);
 
     commandResult.EntityId.Should().NotBeEmpty();
-    _testRepository.Entries.Count.Should().Be(1);
+    (await _testRepository.CountAllEntries()).Should().Be(1);
 
-    IEntry createdEntry = _testRepository.Entries.First();
+    IEntry createdEntry = (await _testRepository.GetEntriesForJournal("60703c3b00000000000000a1")).First();
     createdEntry.ParentId.Should().Be(command.JournalId);
 
     var counterEntry = createdEntry as GaugeEntry;
@@ -51,11 +51,11 @@ public class UpsertGaugeEntryCommandExecutorShould
   [Test]
   public void Throw_WhenNoValueIsSpecified()
   {
-    _testRepository.Journals.Add(new GaugeJournal { Id = "k3y" });
+    _testRepository.UpsertJournal(new GaugeJournal { Id = "60703c3b00000000000000a2" }).Wait();
 
     var command = new UpsertGaugeEntryCommand
     {
-      JournalId = "k3y",
+      JournalId = "60703c3b00000000000000a2",
       Notes = "n0t3s",
       Value = null
     };
@@ -70,10 +70,10 @@ public class UpsertGaugeEntryCommandExecutorShould
   [Test]
   public async Task MapAllFieldsCorrectly()
   {
-    _testRepository.Journals.Add(
+    await _testRepository.UpsertJournal(
       new GaugeJournal
       {
-        Id = "k3y",
+        Id = "60703c3b00000000000000a3",
         Attributes =
         {
           {
@@ -92,7 +92,7 @@ public class UpsertGaugeEntryCommandExecutorShould
 
     var command = new UpsertGaugeEntryCommand
     {
-      JournalId = "k3y",
+      JournalId = "60703c3b00000000000000a3",
       Notes = "n0t3s",
       Value = value,
       JournalAttributeValues = new Dictionary<string, string[]>
@@ -105,9 +105,9 @@ public class UpsertGaugeEntryCommandExecutorShould
 
     await new UpsertGaugeEntryCommandExecutor(_testRepository, new FakeDateService()).Execute(command);
 
-    _testRepository.Entries.Count.Should().Be(1);
+    (await _testRepository.CountAllEntries()).Should().Be(1);
 
-    IEntry createdEntry = _testRepository.Entries.First();
+    IEntry createdEntry = (await _testRepository.GetEntriesForJournal("60703c3b00000000000000a3")).First();
     command.JournalId.Should().Be(createdEntry.ParentId);
     command.Notes.Should().Be(createdEntry.Notes);
 
@@ -138,13 +138,13 @@ public class UpsertGaugeEntryCommandExecutorShould
 
   // todo: Add test for value key
   [Test]
-  public void Throw_WhenJournalAttributeKeyDoesNotExistOnJournal()
+  public async Task Throw_WhenJournalAttributeKeyDoesNotExistOnJournal()
   {
-    _testRepository.Journals.Add(new GaugeJournal { Id = "k3y" });
+    await _testRepository.UpsertJournal(new GaugeJournal { Id = "60703c3b00000000000000a4" });
 
     var command = new UpsertGaugeEntryCommand
     {
-      JournalId = "k3y",
+      JournalId = "60703c3b00000000000000a4",
       Notes = "n0t3s",
       Value = 42,
       JournalAttributeValues = new Dictionary<string, string[]> { { "fooBar", ["x"] } }

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertLogBookEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertLogBookEntryCommandExecutorShould.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Engraved.Core.Application.Commands.Entries.Upsert.LogBook;
-using Engraved.Core.Application.Persistence.Demo;
+using Engraved.Persistence.Mongo.Tests;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
 using FluentAssertions;
@@ -12,18 +12,18 @@ namespace Engraved.Core.Application.Commands.Entries.Upsert;
 
 public class UpsertLogBookEntryCommandExecutorShould
 {
-  private const string JournalId = "journal_id";
+  private const string JournalId = "60703c3b0000000000000000";
   private FakeDateService _fakeDateService = null!;
 
-  private InMemoryRepository _testRepository = null!;
+  private TestMongoRepository _testRepository = null!;
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
-    _testRepository = new InMemoryRepository();
+    _testRepository = await Util.CreateMongoRepository();
     _fakeDateService = new FakeDateService();
 
-    _testRepository.Journals.Add(new LogBookJournal { Id = JournalId });
+    await _testRepository.UpsertJournal(new LogBookJournal { Id = JournalId });
   }
 
   [Test]
@@ -40,8 +40,8 @@ public class UpsertLogBookEntryCommandExecutorShould
       await new UpsertLogBookEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
 
     result.EntityId.Should().NotBeNull();
-    _testRepository.Entries.Count.Should().Be(1);
-    _testRepository.Entries.First().Notes.Should().Be("some notes");
+    (await _testRepository.CountAllEntries()).Should().Be(1);
+    (await _testRepository.GetEntriesForJournal(JournalId)).First().Notes.Should().Be("some notes");
   }
 
   [Test]
@@ -104,21 +104,21 @@ public class UpsertLogBookEntryCommandExecutorShould
 
     await new UpsertLogBookEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
 
-    IEntry entry = _testRepository.Entries.Single();
+    IEntry entry = (await _testRepository.GetEntriesForJournal(JournalId)).Single();
     entry.DateTime.Should().Be(new DateTime(2026, 4, 9, 0, 0, 0, DateTimeKind.Utc));
     entry.DateTime!.Value.TimeOfDay.Should().Be(TimeSpan.Zero);
     entry.DateTime!.Value.Kind.Should().Be(DateTimeKind.Utc);
   }
 
   [Test]
-  public void Throw_WhenEntryForSameDayAlreadyExists()
+  public async Task Throw_WhenEntryForSameDayAlreadyExists()
   {
     var existingDate = new DateTime(2026, 4, 9, 10, 0, 0, DateTimeKind.Utc);
 
-    _testRepository.Entries.Add(
+    await _testRepository.UpsertEntry(
       new LogBookEntry
       {
-        Id = Guid.NewGuid().ToString("N"),
+        Id = "60703c3b0000000000000001",
         ParentId = JournalId,
         Notes = "existing notes",
         DateTime = existingDate
@@ -135,16 +135,16 @@ public class UpsertLogBookEntryCommandExecutorShould
     var func = async ()
       => await new UpsertLogBookEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
 
-    func.Should().ThrowAsync<InvalidCommandException>();
+    await func.Should().ThrowAsync<InvalidCommandException>();
   }
 
   [Test]
   public async Task AllowUpdating_WhenEntryForSameDayAlreadyExistsWithSameId()
   {
     var existingDate = new DateTime(2026, 4, 9, 10, 0, 0, DateTimeKind.Utc);
-    var entryId = Guid.NewGuid().ToString("N");
+    var entryId = "60703c3b0000000000000002";
 
-    _testRepository.Entries.Add(
+    await _testRepository.UpsertEntry(
       new LogBookEntry
       {
         Id = entryId,
@@ -164,7 +164,7 @@ public class UpsertLogBookEntryCommandExecutorShould
 
     await new UpsertLogBookEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
 
-    _testRepository.Entries.Count.Should().Be(1);
-    _testRepository.Entries.First().Notes.Should().Be("updated notes");
+    (await _testRepository.CountAllEntries()).Should().Be(1);
+    (await _testRepository.GetEntriesForJournal(JournalId)).First().Notes.Should().Be("updated notes");
   }
 }

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertTimerEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertTimerEntryCommandExecutorShould.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Engraved.Core.Application.Commands.Entries.Upsert.Timer;
-using Engraved.Core.Application.Persistence.Demo;
+using Engraved.Persistence.Mongo.Tests;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
 using FluentAssertions;
@@ -13,15 +13,15 @@ public class UpsertTimerEntryCommandExecutorShould
 {
   private const string JournalId = "626dab25f1a93c5c724d820a";
   private FakeDateService _fakeDateService = null!;
-  private InMemoryRepository _testRepository = null!;
+  private TestMongoRepository _testRepository = null!;
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
     _fakeDateService = new FakeDateService();
-    _testRepository = new InMemoryRepository();
+    _testRepository = await Util.CreateMongoRepository();
 
-    _testRepository.Journals.Add(new TimerJournal { Id = JournalId });
+    await _testRepository.UpsertJournal(new TimerJournal { Id = JournalId });
   }
 
   [Test]
@@ -41,13 +41,13 @@ public class UpsertTimerEntryCommandExecutorShould
       await new UpsertTimerEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
 
     result.EntityId.Should().NotBeNull();
-    _testRepository.Entries.Count.Should().Be(1);
+    (await _testRepository.CountAllEntries()).Should().Be(1);
 
     var entry = await _testRepository.GetEntry(result.EntityId) as TimerEntry;
 
     entry.Should().NotBeNull();
-    entry.StartDate.Should().Be(startDate);
-    entry.EndDate.Should().Be(endDate);
+    entry.StartDate.Should().BeCloseTo(startDate, TimeSpan.FromMilliseconds(100));
+    entry.EndDate.Should().BeCloseTo(endDate, TimeSpan.FromMilliseconds(100));
   }
 
   [Test]
@@ -59,27 +59,28 @@ public class UpsertTimerEntryCommandExecutorShould
       await new UpsertTimerEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
 
     result.EntityId.Should().NotBeNull();
-    _testRepository.Entries.Count.Should().Be(1);
+    (await _testRepository.CountAllEntries()).Should().Be(1);
 
     var entry = await _testRepository.GetEntry(result.EntityId) as TimerEntry;
 
     entry.Should().NotBeNull();
-    entry.StartDate.Should().Be(_fakeDateService.UtcNow);
+    entry.StartDate.Should().BeCloseTo(_fakeDateService.UtcNow, TimeSpan.FromMilliseconds(100));
   }
 
   [Test]
   public async Task EndExistingEntry_WhenBlankCommand()
   {
-    _testRepository.Entries.Add(
+    var entryId = "60703c3b00000000000000e1";
+    await _testRepository.UpsertEntry(
       new TimerEntry
       {
-        Id = Guid.NewGuid().ToString("N"),
+        Id = entryId,
         ParentId = JournalId,
         StartDate = _fakeDateService.UtcNow.AddMinutes(-10)
       }
     );
 
-    _testRepository.Entries.Count.Should().Be(1);
+    (await _testRepository.CountAllEntries()).Should().Be(1);
 
     var command = new UpsertTimerEntryCommand { JournalId = JournalId };
 
@@ -87,20 +88,20 @@ public class UpsertTimerEntryCommandExecutorShould
       await new UpsertTimerEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
 
     result.EntityId.Should().NotBeNull();
-    _testRepository.Entries.Count.Should().Be(1);
+    (await _testRepository.CountAllEntries()).Should().Be(1);
 
     var entry = await _testRepository.GetEntry(result.EntityId) as TimerEntry;
 
     entry.Should().NotBeNull();
-    entry.EndDate.Should().Be(_fakeDateService.UtcNow);
+    entry.EndDate.Should().BeCloseTo(_fakeDateService.UtcNow, TimeSpan.FromMilliseconds(100));
   }
 
   [Test]
   public async Task UpdateExistingEntry_WithValuesFromCommand()
   {
-    var entryId = Guid.NewGuid().ToString("N");
+    var entryId = "60703c3b00000000000000e2";
 
-    _testRepository.Entries.Add(
+    await _testRepository.UpsertEntry(
       new TimerEntry
       {
         Id = entryId,
@@ -110,7 +111,7 @@ public class UpsertTimerEntryCommandExecutorShould
       }
     );
 
-    _testRepository.Entries.Count.Should().Be(1);
+    (await _testRepository.CountAllEntries()).Should().Be(1);
 
     DateTime newStartDate = _fakeDateService.UtcNow.AddMinutes(-30);
     DateTime? newEndDate = null;
@@ -127,22 +128,22 @@ public class UpsertTimerEntryCommandExecutorShould
       await new UpsertTimerEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
 
     result.EntityId.Should().NotBeNull();
-    _testRepository.Entries.Count.Should().Be(1);
+    (await _testRepository.CountAllEntries()).Should().Be(1);
 
     var entry = await _testRepository.GetEntry(result.EntityId) as TimerEntry;
 
     entry.Should().NotBeNull();
-    entry.StartDate.Should().Be(newStartDate);
-    entry.DateTime.Should().Be(newStartDate);
+    entry.StartDate.Should().BeCloseTo(newStartDate, TimeSpan.FromMilliseconds(100));
+    entry.DateTime.Should().BeCloseTo(newStartDate, TimeSpan.FromMilliseconds(100));
     entry.EndDate.Should().Be(newEndDate);
   }
 
   [Test]
   public async Task UpdateExistingEntry_ChangeExistingStartDateWhenNoEndDate()
   {
-    var entryId = Guid.NewGuid().ToString("N");
+    var entryId = "60703c3b00000000000000e3";
 
-    _testRepository.Entries.Add(
+    await _testRepository.UpsertEntry(
       new TimerEntry
       {
         Id = entryId,
@@ -152,7 +153,7 @@ public class UpsertTimerEntryCommandExecutorShould
       }
     );
 
-    _testRepository.Entries.Count.Should().Be(1);
+    (await _testRepository.CountAllEntries()).Should().Be(1);
 
     DateTime newStartDate = _fakeDateService.UtcNow.AddMinutes(-30);
 
@@ -168,13 +169,13 @@ public class UpsertTimerEntryCommandExecutorShould
       await new UpsertTimerEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
 
     result.EntityId.Should().NotBeNull();
-    _testRepository.Entries.Count.Should().Be(1);
+    (await _testRepository.CountAllEntries()).Should().Be(1);
 
     var entry = await _testRepository.GetEntry(result.EntityId) as TimerEntry;
 
     entry.Should().NotBeNull();
-    entry?.StartDate.Should().Be(newStartDate);
-    entry?.DateTime.Should().Be(newStartDate);
+    entry?.StartDate.Should().BeCloseTo(newStartDate, TimeSpan.FromMilliseconds(100));
+    entry?.DateTime.Should().BeCloseTo(newStartDate, TimeSpan.FromMilliseconds(100));
     entry?.EndDate.Should().Be(null);
   }
 }

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Journals/Edit/EditJournalCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Journals/Edit/EditJournalCommandExecutorShould.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Engraved.Core.Application.Persistence.Demo;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
+using Engraved.Persistence.Mongo.Tests;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -11,21 +11,27 @@ namespace Engraved.Core.Application.Commands.Journals.Edit;
 
 public class EditJournalCommandExecutorShould
 {
-  private InMemoryRepository _repo = null!;
+  private TestMongoRepository _repo = null!;
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
-    _repo = new InMemoryRepository();
+    _repo = await Util.CreateMongoRepository();
   }
 
   [Test]
   public async Task RemoveDeletedJournalAttributesFromAllJournalEntries()
   {
-    _repo.Journals.Add(
+    const string journalId = "60703c3b0000000000000001";
+    const string otherJournalId = "60703c3b0000000000000002";
+    const string entryId1 = "60703c3b0000000000000003";
+    const string entryId2 = "60703c3b0000000000000004";
+    const string entryId3 = "60703c3b0000000000000005";
+
+    await _repo.UpsertJournal(
       new GaugeJournal
       {
-        Id = "journal-id",
+        Id = journalId,
         Name = "journal-name",
         Attributes = new Dictionary<string, JournalAttribute>
         {
@@ -34,13 +40,13 @@ public class EditJournalCommandExecutorShould
         }
       }
     );
-    _repo.Journals.Add(new GaugeJournal { Id = "other-journal-id", Name = "other-journal" });
+    await _repo.UpsertJournal(new GaugeJournal { Id = otherJournalId, Name = "other-journal" });
 
-    _repo.Entries.Add(
+    await _repo.UpsertEntry(
       new GaugeEntry
       {
-        Id = "entry-1",
-        ParentId = "journal-id",
+        Id = entryId1,
+        ParentId = journalId,
         JournalAttributeValues = new Dictionary<string, string[]>
         {
           { "color", ["red"] },
@@ -49,19 +55,19 @@ public class EditJournalCommandExecutorShould
         }
       }
     );
-    _repo.Entries.Add(
+    await _repo.UpsertEntry(
       new GaugeEntry
       {
-        Id = "entry-2",
-        ParentId = "journal-id",
+        Id = entryId2,
+        ParentId = journalId,
         JournalAttributeValues = new Dictionary<string, string[]> { { "color", ["red"] } }
       }
     );
-    _repo.Entries.Add(
+    await _repo.UpsertEntry(
       new GaugeEntry
       {
-        Id = "entry-3",
-        ParentId = "other-journal-id",
+        Id = entryId3,
+        ParentId = otherJournalId,
         JournalAttributeValues = new Dictionary<string, string[]> { { "color", ["red"] } }
       }
     );
@@ -69,7 +75,7 @@ public class EditJournalCommandExecutorShould
     await new EditJournalCommandExecutor(_repo, new FakeDateService()).Execute(
       new EditJournalCommand
       {
-        JournalId = "journal-id",
+        JournalId = journalId,
         Name = "journal-name",
         Attributes = new Dictionary<string, JournalAttribute>
         {
@@ -78,13 +84,13 @@ public class EditJournalCommandExecutorShould
       }
     );
 
-    IEntry[] editedJournalEntries = await _repo.GetEntriesForJournal("journal-id");
+    IEntry[] editedJournalEntries = await _repo.GetEntriesForJournal(journalId);
     editedJournalEntries.Should().HaveCount(2);
     editedJournalEntries.Should().OnlyContain(entry => !entry.JournalAttributeValues.ContainsKey("color"));
     editedJournalEntries.SelectMany(entry => entry.JournalAttributeValues.Keys).Should().Contain("size");
     editedJournalEntries.SelectMany(entry => entry.JournalAttributeValues.Keys).Should().Contain("other");
 
-    IEntry? otherJournalEntry = await _repo.GetEntry("entry-3");
+    IEntry? otherJournalEntry = await _repo.GetEntry(entryId3);
     otherJournalEntry.Should().NotBeNull();
     otherJournalEntry!.JournalAttributeValues.Should().ContainKey("color");
   }
@@ -92,10 +98,13 @@ public class EditJournalCommandExecutorShould
   [Test]
   public async Task KeepAllEntryAttributes_WhenNoJournalAttributeWasDeleted()
   {
-    _repo.Journals.Add(
+    const string journalId = "60703c3b0000000000000006";
+    const string entryId = "60703c3b0000000000000007";
+
+    await _repo.UpsertJournal(
       new GaugeJournal
       {
-        Id = "journal-id",
+        Id = journalId,
         Name = "journal-name",
         Attributes = new Dictionary<string, JournalAttribute>
         {
@@ -105,11 +114,11 @@ public class EditJournalCommandExecutorShould
       }
     );
 
-    _repo.Entries.Add(
+    await _repo.UpsertEntry(
       new GaugeEntry
       {
-        Id = "entry-1",
-        ParentId = "journal-id",
+        Id = entryId,
+        ParentId = journalId,
         JournalAttributeValues = new Dictionary<string, string[]>
         {
           { "color", ["red"] },
@@ -121,7 +130,7 @@ public class EditJournalCommandExecutorShould
     await new EditJournalCommandExecutor(_repo, new FakeDateService()).Execute(
       new EditJournalCommand
       {
-        JournalId = "journal-id",
+        JournalId = journalId,
         Name = "journal-name",
         Attributes = new Dictionary<string, JournalAttribute>
         {
@@ -131,7 +140,7 @@ public class EditJournalCommandExecutorShould
       }
     );
 
-    IEntry? entry = await _repo.GetEntry("entry-1");
+    IEntry? entry = await _repo.GetEntry(entryId);
     entry.Should().NotBeNull();
     entry!.JournalAttributeValues.Should().ContainKey("color");
     entry.JournalAttributeValues.Should().ContainKey("size");

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Journals/EditPermissions/EditJournalPermissionsCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Journals/EditPermissions/EditJournalPermissionsCommandExecutorShould.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Engraved.Core.Application.Persistence.Demo;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Permissions;
 using Engraved.Core.Domain.Users;
+using Engraved.Persistence.Mongo.Tests;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -12,12 +12,12 @@ namespace Engraved.Core.Application.Commands.Journals.EditPermissions;
 
 public class EditJournalPermissionsCommandExecutorShould
 {
-  private InMemoryRepository _repo = null!;
+  private TestMongoRepository _repo = null!;
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
-    _repo = new InMemoryRepository();
+    _repo = await Util.CreateMongoRepository();
   }
 
   [Test]
@@ -34,14 +34,18 @@ public class EditJournalPermissionsCommandExecutorShould
   public async Task AddPermission_And_ReturnUnionOfBeforeAndAfterUsers()
   {
     // given: a journal owned by an existing user and a second user to grant access to
-    _repo.Users.Add(new User { Id = "owner-id", Name = "owner@foo.ch" });
-    _repo.Users.Add(new User { Id = "new-id", Name = "new@foo.ch" });
+    const string ownerId = "60703c3b00000000000000f1";
+    const string newId = "60703c3b00000000000000f2";
+    const string journalId = "60703c3b00000000000000f3";
 
-    _repo.Journals.Add(
+    await _repo.UpsertUser(new User { Id = ownerId, Name = "owner@foo.ch" });
+    await _repo.UpsertUser(new User { Id = newId, Name = "new@foo.ch" });
+
+    await _repo.UpsertJournal(
       new CounterJournal
       {
-        Id = "journal-id",
-        Permissions = new UserPermissions { { "owner-id", new PermissionDefinition { Kind = PermissionKind.Write } } }
+        Id = journalId,
+        Permissions = new UserPermissions { { ownerId, new PermissionDefinition { Kind = PermissionKind.Write } } }
       }
     );
 
@@ -49,40 +53,43 @@ public class EditJournalPermissionsCommandExecutorShould
     CommandResult result = await new EditJournalPermissionsCommandExecutor(_repo).Execute(
       new EditJournalPermissionsCommand
       {
-        JournalId = "journal-id",
+        JournalId = journalId,
         Permissions = new Dictionary<string, PermissionKind> { { "new@foo.ch", PermissionKind.Read } }
       }
     );
 
     // then
-    IJournal journal = (await _repo.GetJournal("journal-id"))!;
-    journal.Permissions.Should().ContainKey("owner-id");
-    journal.Permissions.Should().ContainKey("new-id");
+    IJournal journal = (await _repo.GetJournal(journalId))!;
+    journal.Permissions.Should().ContainKey(ownerId);
+    journal.Permissions.Should().ContainKey(newId);
 
-    result.EntityId.Should().Be("journal-id");
-    result.AffectedUserIds.Should().BeEquivalentTo("owner-id", "new-id");
+    result.EntityId.Should().Be(journalId);
+    result.AffectedUserIds.Should().BeEquivalentTo(ownerId, newId);
   }
 
   [Test]
   public async Task LeavePermissionsUnchanged_When_NoPermissionsProvided()
   {
     // given
-    _repo.Journals.Add(
+    const string ownerId = "60703c3b00000000000000f1";
+    const string journalId = "60703c3b00000000000000f3";
+
+    await _repo.UpsertJournal(
       new CounterJournal
       {
-        Id = "journal-id",
-        Permissions = new UserPermissions { { "owner-id", new PermissionDefinition { Kind = PermissionKind.Write } } }
+        Id = journalId,
+        Permissions = new UserPermissions { { ownerId, new PermissionDefinition { Kind = PermissionKind.Write } } }
       }
     );
 
     // when
     CommandResult result = await new EditJournalPermissionsCommandExecutor(_repo).Execute(
-      new EditJournalPermissionsCommand { JournalId = "journal-id" }
+      new EditJournalPermissionsCommand { JournalId = journalId }
     );
 
     // then
-    IJournal journal = (await _repo.GetJournal("journal-id"))!;
-    journal.Permissions.Should().ContainKey("owner-id");
-    result.AffectedUserIds.Should().BeEquivalentTo("owner-id");
+    IJournal journal = (await _repo.GetJournal(journalId))!;
+    journal.Permissions.Should().ContainKey(ownerId);
+    result.AffectedUserIds.Should().BeEquivalentTo(ownerId);
   }
 }

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Journals/EditPermissions/EditJournalPermissionsCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Journals/EditPermissions/EditJournalPermissionsCommandExecutorShould.cs
@@ -14,6 +14,9 @@ public class EditJournalPermissionsCommandExecutorShould
 {
   private TestMongoRepository _repo = null!;
 
+  private const string OwnerId = "60703c3b00000000000000f1";
+  private const string JournalId = "60703c3b00000000000000f3";
+
   [SetUp]
   public async Task SetUp()
   {
@@ -34,18 +37,16 @@ public class EditJournalPermissionsCommandExecutorShould
   public async Task AddPermission_And_ReturnUnionOfBeforeAndAfterUsers()
   {
     // given: a journal owned by an existing user and a second user to grant access to
-    const string ownerId = "60703c3b00000000000000f1";
     const string newId = "60703c3b00000000000000f2";
-    const string journalId = "60703c3b00000000000000f3";
 
-    await _repo.UpsertUser(new User { Id = ownerId, Name = "owner@foo.ch" });
+    await _repo.UpsertUser(new User { Id = OwnerId, Name = "owner@foo.ch" });
     await _repo.UpsertUser(new User { Id = newId, Name = "new@foo.ch" });
 
     await _repo.UpsertJournal(
       new CounterJournal
       {
-        Id = journalId,
-        Permissions = new UserPermissions { { ownerId, new PermissionDefinition { Kind = PermissionKind.Write } } }
+        Id = JournalId,
+        Permissions = new UserPermissions { { OwnerId, new PermissionDefinition { Kind = PermissionKind.Write } } }
       }
     );
 
@@ -53,43 +54,40 @@ public class EditJournalPermissionsCommandExecutorShould
     CommandResult result = await new EditJournalPermissionsCommandExecutor(_repo).Execute(
       new EditJournalPermissionsCommand
       {
-        JournalId = journalId,
+        JournalId = JournalId,
         Permissions = new Dictionary<string, PermissionKind> { { "new@foo.ch", PermissionKind.Read } }
       }
     );
 
     // then
-    IJournal journal = (await _repo.GetJournal(journalId))!;
-    journal.Permissions.Should().ContainKey(ownerId);
+    IJournal journal = (await _repo.GetJournal(JournalId))!;
+    journal.Permissions.Should().ContainKey(OwnerId);
     journal.Permissions.Should().ContainKey(newId);
 
-    result.EntityId.Should().Be(journalId);
-    result.AffectedUserIds.Should().BeEquivalentTo(ownerId, newId);
+    result.EntityId.Should().Be(JournalId);
+    result.AffectedUserIds.Should().BeEquivalentTo(OwnerId, newId);
   }
 
   [Test]
   public async Task LeavePermissionsUnchanged_When_NoPermissionsProvided()
   {
     // given
-    const string ownerId = "60703c3b00000000000000f1";
-    const string journalId = "60703c3b00000000000000f3";
-
     await _repo.UpsertJournal(
       new CounterJournal
       {
-        Id = journalId,
-        Permissions = new UserPermissions { { ownerId, new PermissionDefinition { Kind = PermissionKind.Write } } }
+        Id = JournalId,
+        Permissions = new UserPermissions { { OwnerId, new PermissionDefinition { Kind = PermissionKind.Write } } }
       }
     );
 
     // when
     CommandResult result = await new EditJournalPermissionsCommandExecutor(_repo).Execute(
-      new EditJournalPermissionsCommand { JournalId = journalId }
+      new EditJournalPermissionsCommand { JournalId = JournalId }
     );
 
     // then
-    IJournal journal = (await _repo.GetJournal(journalId))!;
-    journal.Permissions.Should().ContainKey(ownerId);
-    result.AffectedUserIds.Should().BeEquivalentTo(ownerId);
+    IJournal journal = (await _repo.GetJournal(JournalId))!;
+    journal.Permissions.Should().ContainKey(OwnerId);
+    result.AffectedUserIds.Should().BeEquivalentTo(OwnerId);
   }
 }

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Users/AddJournalToFavorites/AddJournalToFavoritesCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Users/AddJournalToFavorites/AddJournalToFavoritesCommandExecutorShould.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Engraved.Core.Application.Persistence.Demo;
 using Engraved.Core.Domain.Users;
+using Engraved.Persistence.Mongo.Tests;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -9,43 +9,46 @@ namespace Engraved.Core.Application.Commands.Users.AddJournalToFavorites;
 
 public class AddJournalToFavoritesCommandExecutorShould
 {
-  private UserScopedInMemoryRepository _repo = null!;
+  private TestUserScopedMongoRepository _repo = null!;
 
-  private const string UserId = "max";
+  private const string UserId = "6a40b7027bf30b7c135049b4";
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
-    var inMemoryRepository = new InMemoryRepository();
-    inMemoryRepository.Users.Add(new User { Id = UserId, Name = UserId });
-    _repo = new UserScopedInMemoryRepository(inMemoryRepository, new FakeCurrentUserService(UserId));
+    _repo = await Util.CreateUserScopedMongoRepository(UserId, UserId, false);
+    await _repo.UpsertUser(new User { Id = UserId, Name = UserId });
   }
 
   [Test]
   public async Task AddJournalToFavorites()
   {
     // when
+    const string journalId = "60703c3b00000000000000d1";
     await new AddJournalToFavoritesCommandExecutor(_repo).Execute(
-      new AddJournalToFavoritesCommand { JournalId = "journal-id" }
+      new AddJournalToFavoritesCommand { JournalId = journalId }
     );
 
     // then
-    _repo.Users[0].FavoriteJournalIds.Should().Contain("journal-id");
+    (await _repo.GetUser(UserId))!.FavoriteJournalIds.Should().Contain(journalId);
   }
 
   [Test]
   public async Task NotAddDuplicate_When_AlreadyFavorite()
   {
     // given
-    _repo.Users[0].FavoriteJournalIds.Add("journal-id");
+    const string journalId = "60703c3b00000000000000d1";
+    IUser user = (await _repo.GetUser(UserId))!;
+    user.FavoriteJournalIds.Add(journalId);
+    await _repo.UpsertUser(user);
 
     // when
     await new AddJournalToFavoritesCommandExecutor(_repo).Execute(
-      new AddJournalToFavoritesCommand { JournalId = "journal-id" }
+      new AddJournalToFavoritesCommand { JournalId = journalId }
     );
 
     // then
-    _repo.Users[0].FavoriteJournalIds.Should().ContainSingle().Which.Should().Be("journal-id");
+    (await _repo.GetUser(UserId))!.FavoriteJournalIds.Should().ContainSingle().Which.Should().Be(journalId);
   }
 
   [Test]

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Users/AddJournalToFavorites/AddJournalToFavoritesCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Users/AddJournalToFavorites/AddJournalToFavoritesCommandExecutorShould.cs
@@ -11,7 +11,8 @@ public class AddJournalToFavoritesCommandExecutorShould
 {
   private TestUserScopedMongoRepository _repo = null!;
 
-  private const string UserId = "6a40b7027bf30b7c135049b4";
+  private const string UserId = TestIds.UserId;
+  private const string JournalId = "60703c3b00000000000000d1";
 
   [SetUp]
   public async Task SetUp()
@@ -24,31 +25,29 @@ public class AddJournalToFavoritesCommandExecutorShould
   public async Task AddJournalToFavorites()
   {
     // when
-    const string journalId = "60703c3b00000000000000d1";
     await new AddJournalToFavoritesCommandExecutor(_repo).Execute(
-      new AddJournalToFavoritesCommand { JournalId = journalId }
+      new AddJournalToFavoritesCommand { JournalId = JournalId }
     );
 
     // then
-    (await _repo.GetUser(UserId))!.FavoriteJournalIds.Should().Contain(journalId);
+    (await _repo.GetUser(UserId))!.FavoriteJournalIds.Should().Contain(JournalId);
   }
 
   [Test]
   public async Task NotAddDuplicate_When_AlreadyFavorite()
   {
     // given
-    const string journalId = "60703c3b00000000000000d1";
     IUser user = (await _repo.GetUser(UserId))!;
-    user.FavoriteJournalIds.Add(journalId);
+    user.FavoriteJournalIds.Add(JournalId);
     await _repo.UpsertUser(user);
 
     // when
     await new AddJournalToFavoritesCommandExecutor(_repo).Execute(
-      new AddJournalToFavoritesCommand { JournalId = journalId }
+      new AddJournalToFavoritesCommand { JournalId = JournalId }
     );
 
     // then
-    (await _repo.GetUser(UserId))!.FavoriteJournalIds.Should().ContainSingle().Which.Should().Be(journalId);
+    (await _repo.GetUser(UserId))!.FavoriteJournalIds.Should().ContainSingle().Which.Should().Be(JournalId);
   }
 
   [Test]

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Users/CleanupTags/CleanupTagsCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Users/CleanupTags/CleanupTagsCommandExecutorShould.cs
@@ -12,7 +12,7 @@ public class CleanupTagsCommandExecutorShould
 {
   private TestUserScopedMongoRepository _repo = null!;
 
-  private const string UserId = "6a40b7027bf30b7c135049b4";
+  private const string UserId = TestIds.UserId;
 
   [SetUp]
   public async Task SetUp()
@@ -30,17 +30,15 @@ public class CleanupTagsCommandExecutorShould
   [Test]
   public async Task DoesNotChangeAnything_When_No_Missing_Favorites()
   {
-    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b00000000000000d1", UserId = UserId });
-    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b00000000000000d2", UserId = UserId });
+    const string journal1Id = "60703c3b00000000000000d1";
+    const string journal2Id = "60703c3b00000000000000d2";
+    await _repo.UpsertJournal(new CounterJournal { Id = journal1Id, UserId = UserId });
+    await _repo.UpsertJournal(new CounterJournal { Id = journal2Id, UserId = UserId });
 
     IUser user = (await _repo.GetUser(UserId))!;
-    user.Tags.Add(new UserTag { Id = "Tag1", JournalIds = ["60703c3b00000000000000d1"] });
-    user.Tags.Add(new UserTag { Id = "Tag2", JournalIds = ["60703c3b00000000000000d2"] });
+    user.Tags.Add(new UserTag { Id = "Tag1", JournalIds = [journal1Id] });
+    user.Tags.Add(new UserTag { Id = "Tag2", JournalIds = [journal2Id] });
     await _repo.UpsertUser(user);
-
-    // must ensure permissions are granted for CleanupTags as it uses GetJournal(id, PermissionKind.Read)
-    // but in UserScopedMongoRepository, being the owner (UserId == Journal.UserId) is enough.
-    // wait, CleanupTags uses _repo.GetJournal(...) - wait, I need to check CleanupTagsCommandExecutor.
 
     var command = new CleanupTagsCommand { DryRun = false };
     var result = (CleanupTagsCommandResult) await new CleanupTagsCommandExecutor(_repo).Execute(command);
@@ -78,10 +76,12 @@ public class CleanupTagsCommandExecutorShould
   [Test]
   public async Task RemovesMissingJournalIds_When_SomeAreMissing()
   {
-    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b00000000000000d3", UserId = UserId });
+    const string existingJournalId = "60703c3b00000000000000d3";
+    const string missingJournalId = "60703c3b00000000000000f1";
+    await _repo.UpsertJournal(new CounterJournal { Id = existingJournalId, UserId = UserId });
 
     IUser user = (await _repo.GetUser(UserId))!;
-    user.Tags.Add(new UserTag { Id = "Tag1", JournalIds = ["60703c3b00000000000000d3", "60703c3b00000000000000f1"] });
+    user.Tags.Add(new UserTag { Id = "Tag1", JournalIds = [existingJournalId, missingJournalId] });
     await _repo.UpsertUser(user);
 
     var commandExecutorRepo = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
@@ -91,27 +91,31 @@ public class CleanupTagsCommandExecutorShould
         new CleanupTagsCommand { DryRun = false }
       );
 
-    result.JournalIdsToRemove.Should().Contain("60703c3b00000000000000f1");
+    result.JournalIdsToRemove.Should().Contain(missingJournalId);
 
     var verificationRepo = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
     await verificationRepo.WakeMeUp();
     user = (await verificationRepo.GetUser(UserId))!;
-    user.Tags[0].JournalIds.Should().NotContain("60703c3b00000000000000f1");
-    user.Tags[0].JournalIds.Should().Contain("60703c3b00000000000000d3");
+    user.Tags[0].JournalIds.Should().NotContain(missingJournalId);
+    user.Tags[0].JournalIds.Should().Contain(existingJournalId);
   }
 
   [Test]
   public async Task RemovesMissingJournalIds_FromMultipleTag_When_SomeAreMissing()
   {
-    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b00000000000000d4", UserId = UserId });
-    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b00000000000000d5", UserId = UserId });
+    const string existingJournalId1 = "60703c3b00000000000000d4";
+    const string existingJournalId2 = "60703c3b00000000000000d5";
+    const string missingJournalId1 = "60703c3b00000000000000f2";
+    const string missingJournalId2 = "60703c3b00000000000000f3";
+    await _repo.UpsertJournal(new CounterJournal { Id = existingJournalId1, UserId = UserId });
+    await _repo.UpsertJournal(new CounterJournal { Id = existingJournalId2, UserId = UserId });
 
     IUser user = (await _repo.GetUser(UserId))!;
     user.Tags.Add(
-      new UserTag { Id = "Tag1", JournalIds = ["60703c3b00000000000000d4", "60703c3b00000000000000f2"] }
+      new UserTag { Id = "Tag1", JournalIds = [existingJournalId1, missingJournalId1] }
     );
     user.Tags.Add(
-      new UserTag { Id = "Tag2", JournalIds = ["60703c3b00000000000000d5", "60703c3b00000000000000f3"] }
+      new UserTag { Id = "Tag2", JournalIds = [existingJournalId2, missingJournalId2] }
     );
     await _repo.UpsertUser(user);
 
@@ -122,27 +126,29 @@ public class CleanupTagsCommandExecutorShould
         new CleanupTagsCommand { DryRun = false }
       );
 
-    result.JournalIdsToRemove.Should().Contain("60703c3b00000000000000f2");
-    result.JournalIdsToRemove.Should().Contain("60703c3b00000000000000f3");
+    result.JournalIdsToRemove.Should().Contain(missingJournalId1);
+    result.JournalIdsToRemove.Should().Contain(missingJournalId2);
     result.JournalIdsToRemove.Should().HaveCount(2);
 
     var verificationRepo = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
     await verificationRepo.WakeMeUp();
     user = (await verificationRepo.GetUser(UserId))!;
-    user.Tags[0].JournalIds.Should().NotContain("60703c3b00000000000000f2");
-    user.Tags[0].JournalIds.Should().NotContain("60703c3b00000000000000f3");
+    user.Tags[0].JournalIds.Should().NotContain(missingJournalId1);
+    user.Tags[0].JournalIds.Should().NotContain(missingJournalId2);
 
-    user.Tags[1].JournalIds.Should().NotContain("60703c3b00000000000000f2");
-    user.Tags[1].JournalIds.Should().NotContain("60703c3b00000000000000f3");
+    user.Tags[1].JournalIds.Should().NotContain(missingJournalId1);
+    user.Tags[1].JournalIds.Should().NotContain(missingJournalId2);
   }
 
   [Test]
   public async Task PopulatesJournalIdsToRemove_ButDoesNotRemove_When_DryRunIsTrue()
   {
-    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b00000000000000d6", UserId = UserId });
+    const string existingJournalId = "60703c3b00000000000000d6";
+    const string missingJournalId = "60703c3b00000000000000f4";
+    await _repo.UpsertJournal(new CounterJournal { Id = existingJournalId, UserId = UserId });
 
     IUser user = (await _repo.GetUser(UserId))!;
-    user.Tags.Add(new UserTag { Id = "Tag1", JournalIds = ["60703c3b00000000000000d6", "60703c3b00000000000000f4"] });
+    user.Tags.Add(new UserTag { Id = "Tag1", JournalIds = [existingJournalId, missingJournalId] });
     await _repo.UpsertUser(user);
 
     var commandExecutorRepo = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
@@ -152,12 +158,12 @@ public class CleanupTagsCommandExecutorShould
         new CleanupTagsCommand { DryRun = true }
       );
 
-    result.JournalIdsToRemove.Should().Contain("60703c3b00000000000000f4");
+    result.JournalIdsToRemove.Should().Contain(missingJournalId);
 
     var verificationRepo = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
     await verificationRepo.WakeMeUp();
     user = (await verificationRepo.GetUser(UserId))!;
-    user.Tags[0].JournalIds.Should().Contain("60703c3b00000000000000f4");
-    user.Tags[0].JournalIds.Should().Contain("60703c3b00000000000000d6");
+    user.Tags[0].JournalIds.Should().Contain(missingJournalId);
+    user.Tags[0].JournalIds.Should().Contain(existingJournalId);
   }
 }

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Users/CleanupTags/CleanupTagsCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Users/CleanupTags/CleanupTagsCommandExecutorShould.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Threading.Tasks;
-using Engraved.Core.Application.Persistence.Demo;
+﻿using System.Threading.Tasks;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Users;
+using Engraved.Persistence.Mongo.Tests;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -11,35 +10,37 @@ namespace Engraved.Core.Application.Commands.Users.CleanupTags;
 [TestFixture]
 public class CleanupTagsCommandExecutorShould
 {
-  private FakeDateService _dateService = null!;
-  private UserScopedInMemoryRepository _repo = null!;
+  private TestUserScopedMongoRepository _repo = null!;
 
-  private const string UserId = "max";
+  private const string UserId = "6a40b7027bf30b7c135049b4";
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
-    var inMemoryRepository = new InMemoryRepository();
-    inMemoryRepository.Users.Add(
+    _repo = await Util.CreateUserScopedMongoRepository(UserId, UserId, false);
+    await _repo.UpsertUser(
       new User
       {
         Id = UserId,
         Name = UserId
       }
     );
-
-    _repo = new UserScopedInMemoryRepository(inMemoryRepository, new FakeCurrentUserService(UserId));
-    _dateService = new FakeDateService(DateTime.UtcNow.AddDays(-10));
   }
 
   [Test]
   public async Task DoesNotChangeAnything_When_No_Missing_Favorites()
   {
-    _repo.Journals.Add(new CounterJournal { Id = "counter-journal-id", UserId = UserId });
-    _repo.Journals.Add(new CounterJournal { Id = "scrap-journal-id", UserId = UserId });
+    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b00000000000000d1", UserId = UserId });
+    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b00000000000000d2", UserId = UserId });
 
-    _repo.Users[0].Tags.Add(new UserTag { Id = "Tag1", JournalIds = ["counter-journal-id"] });
-    _repo.Users[0].Tags.Add(new UserTag { Id = "Tag2", JournalIds = ["scrap-journal-id"] });
+    IUser user = (await _repo.GetUser(UserId))!;
+    user.Tags.Add(new UserTag { Id = "Tag1", JournalIds = ["60703c3b00000000000000d1"] });
+    user.Tags.Add(new UserTag { Id = "Tag2", JournalIds = ["60703c3b00000000000000d2"] });
+    await _repo.UpsertUser(user);
+
+    // must ensure permissions are granted for CleanupTags as it uses GetJournal(id, PermissionKind.Read)
+    // but in UserScopedMongoRepository, being the owner (UserId == Journal.UserId) is enough.
+    // wait, CleanupTags uses _repo.GetJournal(...) - wait, I need to check CleanupTagsCommandExecutor.
 
     var command = new CleanupTagsCommand { DryRun = false };
     var result = (CleanupTagsCommandResult) await new CleanupTagsCommandExecutor(_repo).Execute(command);
@@ -64,7 +65,10 @@ public class CleanupTagsCommandExecutorShould
   [Test]
   public async Task User_With_Tags_But_No_JournalIds()
   {
-    _repo.Users[0].Tags.Add(new UserTag { Id = "Tag1", JournalIds = [] });
+    IUser user = (await _repo.GetUser(UserId))!;
+    user.Tags.Add(new UserTag { Id = "Tag1", JournalIds = [] });
+    await _repo.UpsertUser(user);
+
     var result = (CleanupTagsCommandResult) await new CleanupTagsCommandExecutor(_repo).Execute(
       new CleanupTagsCommand { DryRun = false }
     );
@@ -74,64 +78,86 @@ public class CleanupTagsCommandExecutorShould
   [Test]
   public async Task RemovesMissingJournalIds_When_SomeAreMissing()
   {
-    _repo.Journals.Add(new CounterJournal { Id = "existing-journal-id", UserId = UserId });
-    _repo.Users[0].Tags.Add(new UserTag { Id = "Tag1", JournalIds = ["existing-journal-id", "missing-journal-id"] });
+    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b00000000000000d3", UserId = UserId });
 
+    IUser user = (await _repo.GetUser(UserId))!;
+    user.Tags.Add(new UserTag { Id = "Tag1", JournalIds = ["60703c3b00000000000000d3", "60703c3b00000000000000f1"] });
+    await _repo.UpsertUser(user);
+
+    var commandExecutorRepo = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
+    await commandExecutorRepo.WakeMeUp();
     var result =
-      (CleanupTagsCommandResult) await new CleanupTagsCommandExecutor(_repo).Execute(
+      (CleanupTagsCommandResult) await new CleanupTagsCommandExecutor(commandExecutorRepo).Execute(
         new CleanupTagsCommand { DryRun = false }
       );
 
-    result.JournalIdsToRemove.Should().Contain("missing-journal-id");
+    result.JournalIdsToRemove.Should().Contain("60703c3b00000000000000f1");
 
-    _repo.Users[0].Tags[0].JournalIds.Should().NotContain("missing-journal-id");
-    _repo.Users[0].Tags[0].JournalIds.Should().Contain("existing-journal-id");
+    var verificationRepo = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
+    await verificationRepo.WakeMeUp();
+    user = (await verificationRepo.GetUser(UserId))!;
+    user.Tags[0].JournalIds.Should().NotContain("60703c3b00000000000000f1");
+    user.Tags[0].JournalIds.Should().Contain("60703c3b00000000000000d3");
   }
 
   [Test]
   public async Task RemovesMissingJournalIds_FromMultipleTag_When_SomeAreMissing()
   {
-    _repo.Journals.Add(new CounterJournal { Id = "existing-journal-id-1", UserId = UserId });
-    _repo.Journals.Add(new CounterJournal { Id = "existing-journal-id-2", UserId = UserId });
+    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b00000000000000d4", UserId = UserId });
+    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b00000000000000d5", UserId = UserId });
 
-    _repo.Users[0]
-      .Tags.Add(
-        new UserTag { Id = "Tag1", JournalIds = ["existing-journal-id-1", "missing-journal-id-1"] }
-      );
-    _repo.Users[0]
-      .Tags.Add(
-        new UserTag { Id = "Tag2", JournalIds = ["existing-journal-id-2", "missing-journal-id-2"] }
-      );
+    IUser user = (await _repo.GetUser(UserId))!;
+    user.Tags.Add(
+      new UserTag { Id = "Tag1", JournalIds = ["60703c3b00000000000000d4", "60703c3b00000000000000f2"] }
+    );
+    user.Tags.Add(
+      new UserTag { Id = "Tag2", JournalIds = ["60703c3b00000000000000d5", "60703c3b00000000000000f3"] }
+    );
+    await _repo.UpsertUser(user);
 
+    var commandExecutorRepo = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
+    await commandExecutorRepo.WakeMeUp();
     var result =
-      (CleanupTagsCommandResult) await new CleanupTagsCommandExecutor(_repo).Execute(
+      (CleanupTagsCommandResult) await new CleanupTagsCommandExecutor(commandExecutorRepo).Execute(
         new CleanupTagsCommand { DryRun = false }
       );
 
-    result.JournalIdsToRemove.Should().Contain("missing-journal-id-1");
-    result.JournalIdsToRemove.Should().Contain("missing-journal-id-2");
+    result.JournalIdsToRemove.Should().Contain("60703c3b00000000000000f2");
+    result.JournalIdsToRemove.Should().Contain("60703c3b00000000000000f3");
     result.JournalIdsToRemove.Should().HaveCount(2);
 
-    _repo.Users[0].Tags[0].JournalIds.Should().NotContain("missing-journal-id-1");
-    _repo.Users[0].Tags[0].JournalIds.Should().NotContain("missing-journal-id-2");
+    var verificationRepo = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
+    await verificationRepo.WakeMeUp();
+    user = (await verificationRepo.GetUser(UserId))!;
+    user.Tags[0].JournalIds.Should().NotContain("60703c3b00000000000000f2");
+    user.Tags[0].JournalIds.Should().NotContain("60703c3b00000000000000f3");
 
-    _repo.Users[0].Tags[1].JournalIds.Should().NotContain("missing-journal-id-1");
-    _repo.Users[0].Tags[1].JournalIds.Should().NotContain("missing-journal-id-2");
+    user.Tags[1].JournalIds.Should().NotContain("60703c3b00000000000000f2");
+    user.Tags[1].JournalIds.Should().NotContain("60703c3b00000000000000f3");
   }
 
   [Test]
   public async Task PopulatesJournalIdsToRemove_ButDoesNotRemove_When_DryRunIsTrue()
   {
-    _repo.Journals.Add(new CounterJournal { Id = "existing-journal-id", UserId = UserId });
-    _repo.Users[0].Tags.Add(new UserTag { Id = "Tag1", JournalIds = ["existing-journal-id", "missing-journal-id"] });
+    await _repo.UpsertJournal(new CounterJournal { Id = "60703c3b00000000000000d6", UserId = UserId });
 
+    IUser user = (await _repo.GetUser(UserId))!;
+    user.Tags.Add(new UserTag { Id = "Tag1", JournalIds = ["60703c3b00000000000000d6", "60703c3b00000000000000f4"] });
+    await _repo.UpsertUser(user);
+
+    var commandExecutorRepo = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
+    await commandExecutorRepo.WakeMeUp();
     var result =
-      (CleanupTagsCommandResult) await new CleanupTagsCommandExecutor(_repo).Execute(
+      (CleanupTagsCommandResult) await new CleanupTagsCommandExecutor(commandExecutorRepo).Execute(
         new CleanupTagsCommand { DryRun = true }
       );
 
-    result.JournalIdsToRemove.Should().Contain("missing-journal-id");
-    _repo.Users[0].Tags[0].JournalIds.Should().Contain("missing-journal-id");
-    _repo.Users[0].Tags[0].JournalIds.Should().Contain("existing-journal-id");
+    result.JournalIdsToRemove.Should().Contain("60703c3b00000000000000f4");
+
+    var verificationRepo = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
+    await verificationRepo.WakeMeUp();
+    user = (await verificationRepo.GetUser(UserId))!;
+    user.Tags[0].JournalIds.Should().Contain("60703c3b00000000000000f4");
+    user.Tags[0].JournalIds.Should().Contain("60703c3b00000000000000d6");
   }
 }

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Users/RemoveJournalFromFavorites/RemoveJournalFromFavoritesCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Users/RemoveJournalFromFavorites/RemoveJournalFromFavoritesCommandExecutorShould.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Engraved.Core.Application.Persistence.Demo;
 using Engraved.Core.Domain.Users;
+using Engraved.Persistence.Mongo.Tests;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -9,46 +9,59 @@ namespace Engraved.Core.Application.Commands.Users.RemoveJournalFromFavorites;
 
 public class RemoveJournalFromFavoritesCommandExecutorShould
 {
-  private UserScopedInMemoryRepository _repo = null!;
+  private TestUserScopedMongoRepository _repo = null!;
 
-  private const string UserId = "max";
+  private const string UserId = "6a40b7027bf30b7c135049b4";
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
-    var inMemoryRepository = new InMemoryRepository();
-    inMemoryRepository.Users.Add(new User { Id = UserId, Name = UserId });
-    _repo = new UserScopedInMemoryRepository(inMemoryRepository, new FakeCurrentUserService(UserId));
+    _repo = await Util.CreateUserScopedMongoRepository(UserId, UserId, false);
+    await _repo.UpsertUser(new User { Id = UserId, Name = UserId });
   }
 
   [Test]
   public async Task RemoveJournalFromFavorites()
   {
     // given
-    _repo.Users[0].FavoriteJournalIds.Add("journal-id");
+    const string journalId = "60703c3b00000000000000d1";
+    IUser user = (await _repo.GetUser(UserId))!;
+    user.FavoriteJournalIds.Add(journalId);
+    await _repo.UpsertUser(user);
+
+    var repositoryWithDifferentCache = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
+    await repositoryWithDifferentCache.WakeMeUp();
 
     // when
-    await new RemoveJournalFromFavoritesCommandExecutor(_repo).Execute(
-      new RemoveJournalFromFavoritesCommand { JournalId = "journal-id" }
+    await new RemoveJournalFromFavoritesCommandExecutor(repositoryWithDifferentCache).Execute(
+      new RemoveJournalFromFavoritesCommand { JournalId = journalId }
     );
 
     // then
-    _repo.Users[0].FavoriteJournalIds.Should().NotContain("journal-id");
+    var secondRepoForVerification = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
+    await secondRepoForVerification.WakeMeUp();
+    IUser updatedUser = (await secondRepoForVerification.GetUser(UserId))!;
+    updatedUser.Id.Should().Be(UserId);
+    updatedUser.FavoriteJournalIds.Should().NotContain(journalId);
   }
 
   [Test]
   public async Task DoNothing_When_NotAFavorite()
   {
     // given
-    _repo.Users[0].FavoriteJournalIds.Add("other-journal-id");
+    const string otherJournalId = "60703c3b00000000000000d2";
+    const string journalId = "60703c3b00000000000000d1";
+    IUser user = (await _repo.GetUser(UserId))!;
+    user.FavoriteJournalIds.Add(otherJournalId);
+    await _repo.UpsertUser(user);
 
     // when
     await new RemoveJournalFromFavoritesCommandExecutor(_repo).Execute(
-      new RemoveJournalFromFavoritesCommand { JournalId = "journal-id" }
+      new RemoveJournalFromFavoritesCommand { JournalId = journalId }
     );
 
     // then
-    _repo.Users[0].FavoriteJournalIds.Should().ContainSingle().Which.Should().Be("other-journal-id");
+    (await _repo.GetUser(UserId))!.FavoriteJournalIds.Should().ContainSingle().Which.Should().Be(otherJournalId);
   }
 
   [Test]

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Users/RemoveJournalFromFavorites/RemoveJournalFromFavoritesCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Users/RemoveJournalFromFavorites/RemoveJournalFromFavoritesCommandExecutorShould.cs
@@ -11,7 +11,8 @@ public class RemoveJournalFromFavoritesCommandExecutorShould
 {
   private TestUserScopedMongoRepository _repo = null!;
 
-  private const string UserId = "6a40b7027bf30b7c135049b4";
+  private const string UserId = TestIds.UserId;
+  private const string JournalId = "60703c3b00000000000000d1";
 
   [SetUp]
   public async Task SetUp()
@@ -24,9 +25,8 @@ public class RemoveJournalFromFavoritesCommandExecutorShould
   public async Task RemoveJournalFromFavorites()
   {
     // given
-    const string journalId = "60703c3b00000000000000d1";
     IUser user = (await _repo.GetUser(UserId))!;
-    user.FavoriteJournalIds.Add(journalId);
+    user.FavoriteJournalIds.Add(JournalId);
     await _repo.UpsertUser(user);
 
     var repositoryWithDifferentCache = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
@@ -34,7 +34,7 @@ public class RemoveJournalFromFavoritesCommandExecutorShould
 
     // when
     await new RemoveJournalFromFavoritesCommandExecutor(repositoryWithDifferentCache).Execute(
-      new RemoveJournalFromFavoritesCommand { JournalId = journalId }
+      new RemoveJournalFromFavoritesCommand { JournalId = JournalId }
     );
 
     // then
@@ -42,7 +42,7 @@ public class RemoveJournalFromFavoritesCommandExecutorShould
     await secondRepoForVerification.WakeMeUp();
     IUser updatedUser = (await secondRepoForVerification.GetUser(UserId))!;
     updatedUser.Id.Should().Be(UserId);
-    updatedUser.FavoriteJournalIds.Should().NotContain(journalId);
+    updatedUser.FavoriteJournalIds.Should().NotContain(JournalId);
   }
 
   [Test]
@@ -50,14 +50,13 @@ public class RemoveJournalFromFavoritesCommandExecutorShould
   {
     // given
     const string otherJournalId = "60703c3b00000000000000d2";
-    const string journalId = "60703c3b00000000000000d1";
     IUser user = (await _repo.GetUser(UserId))!;
     user.FavoriteJournalIds.Add(otherJournalId);
     await _repo.UpsertUser(user);
 
     // when
     await new RemoveJournalFromFavoritesCommandExecutor(_repo).Execute(
-      new RemoveJournalFromFavoritesCommand { JournalId = journalId }
+      new RemoveJournalFromFavoritesCommand { JournalId = JournalId }
     );
 
     // then

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Users/UpdateTags/UpdateUserTagsCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Users/UpdateTags/UpdateUserTagsCommandExecutorShould.cs
@@ -12,7 +12,7 @@ public class UpdateUserTagsCommandExecutorShould
 {
   private TestUserScopedMongoRepository _repo = null!;
 
-  private const string UserId = "6a40b7027bf30b7c135049b4";
+  private const string UserId = TestIds.UserId;
 
   [SetUp]
   public async Task SetUp()

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Users/UpdateTags/UpdateUserTagsCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Users/UpdateTags/UpdateUserTagsCommandExecutorShould.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Engraved.Core.Application.Persistence.Demo;
 using Engraved.Core.Domain.Users;
+using Engraved.Persistence.Mongo.Tests;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -10,16 +10,15 @@ namespace Engraved.Core.Application.Commands.Users.UpdateTags;
 
 public class UpdateUserTagsCommandExecutorShould
 {
-  private UserScopedInMemoryRepository _repo = null!;
+  private TestUserScopedMongoRepository _repo = null!;
 
-  private const string UserId = "max";
+  private const string UserId = "6a40b7027bf30b7c135049b4";
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
-    var inMemoryRepository = new InMemoryRepository();
-    inMemoryRepository.Users.Add(new User { Id = UserId, Name = UserId });
-    _repo = new UserScopedInMemoryRepository(inMemoryRepository, new FakeCurrentUserService(UserId));
+    _repo = await Util.CreateUserScopedMongoRepository(UserId, UserId, false);
+    await _repo.UpsertUser(new User { Id = UserId, Name = UserId });
   }
 
   [Test]
@@ -31,7 +30,8 @@ public class UpdateUserTagsCommandExecutorShould
     );
 
     // then
-    UserTag tag = _repo.Users[0].Tags.Should().ContainSingle().Subject;
+    IUser user = (await _repo.GetUser(UserId))!;
+    UserTag tag = user.Tags.Should().ContainSingle().Subject;
     tag.Id.Should().Be("tag-id");
     tag.Label.Should().Be("Label");
   }
@@ -40,7 +40,9 @@ public class UpdateUserTagsCommandExecutorShould
   public async Task UpdateLabelOfExistingTag()
   {
     // given
-    _repo.Users[0].Tags.Add(new UserTag { Id = "tag-id", Label = "Old" });
+    IUser user = (await _repo.GetUser(UserId))!;
+    user.Tags.Add(new UserTag { Id = "tag-id", Label = "Old" });
+    await _repo.UpsertUser(user);
 
     // when
     await new UpdateUserTagsCommandExecutor(_repo).Execute(
@@ -48,7 +50,8 @@ public class UpdateUserTagsCommandExecutorShould
     );
 
     // then
-    UserTag tag = _repo.Users[0].Tags.Should().ContainSingle().Subject;
+    user = (await _repo.GetUser(UserId))!;
+    UserTag tag = user.Tags.Should().ContainSingle().Subject;
     tag.Id.Should().Be("tag-id");
     tag.Label.Should().Be("New");
   }
@@ -57,8 +60,10 @@ public class UpdateUserTagsCommandExecutorShould
   public async Task RemoveTagsNoLongerInCommand()
   {
     // given
-    _repo.Users[0].Tags.Add(new UserTag { Id = "keep", Label = "Keep" });
-    _repo.Users[0].Tags.Add(new UserTag { Id = "remove", Label = "Remove" });
+    IUser user = (await _repo.GetUser(UserId))!;
+    user.Tags.Add(new UserTag { Id = "keep", Label = "Keep" });
+    user.Tags.Add(new UserTag { Id = "remove", Label = "Remove" });
+    await _repo.UpsertUser(user);
 
     // when
     await new UpdateUserTagsCommandExecutor(_repo).Execute(
@@ -66,6 +71,7 @@ public class UpdateUserTagsCommandExecutorShould
     );
 
     // then
-    _repo.Users[0].Tags.Select(t => t.Id).Should().BeEquivalentTo("keep");
+    user = (await _repo.GetUser(UserId))!;
+    user.Tags.Select(t => t.Id).Should().BeEquivalentTo("keep");
   }
 }

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Entries/GetAll/SearchEntriesQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Entries/GetAll/SearchEntriesQueryExecutorShould.cs
@@ -15,7 +15,7 @@ public class SearchEntriesQueryExecutorShould
   private FakeDateService _dateService = null!;
   private TestUserScopedMongoRepository _repo = null!;
 
-  private const string UserId = "6a40b7027bf30b7c135049b4";
+  private const string UserId = TestIds.UserId;
 
   [SetUp]
   public async Task SetUp()

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Entries/GetAll/SearchEntriesQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Entries/GetAll/SearchEntriesQueryExecutorShould.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Engraved.Core.Application.Persistence.Demo;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Users;
+using Engraved.Persistence.Mongo.Tests;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -13,15 +13,15 @@ namespace Engraved.Core.Application.Queries.Entries.GetAll;
 public class SearchEntriesQueryExecutorShould
 {
   private FakeDateService _dateService = null!;
-  private UserScopedInMemoryRepository _repo = null!;
+  private TestUserScopedMongoRepository _repo = null!;
 
-  private const string UserId = "max";
+  private const string UserId = "6a40b7027bf30b7c135049b4";
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
-    var inMemoryRepository = new InMemoryRepository();
-    inMemoryRepository.Users.Add(
+    _repo = await Util.CreateUserScopedMongoRepository(UserId, UserId, false);
+    await _repo.UpsertUser(
       new User
       {
         Id = UserId,
@@ -29,48 +29,53 @@ public class SearchEntriesQueryExecutorShould
       }
     );
 
-    _repo = new UserScopedInMemoryRepository(inMemoryRepository, new FakeCurrentUserService(UserId));
     _dateService = new FakeDateService(DateTime.UtcNow.AddDays(-10));
   }
 
   [Test]
   public async Task Return_NewestEntriesAndTheirJournal()
   {
-    _repo.Journals.Add(new CounterJournal { Id = "counter-journal-id", UserId = UserId });
-    _repo.Entries.Add(
+    const string journal1Id = "60703c3b0000000000000011";
+    const string journal2Id = "60703c3b0000000000000012";
+    const string journal3Id = "60703c3b0000000000000013";
+
+    await _repo.UpsertJournal(new CounterJournal { Id = journal1Id, UserId = UserId });
+    await _repo.UpsertEntry(
       new CounterEntry
       {
-        ParentId = "counter-journal-id",
+        ParentId = journal1Id,
         DateTime = _dateService.UtcNow
       }
     );
     _dateService.SetNext(2);
 
-    _repo.Journals.Add(new GaugeJournal { Id = "gauge-journal-id", UserId = UserId });
-    _repo.Entries.Add(
+    await _repo.UpsertJournal(new GaugeJournal { Id = journal2Id, UserId = UserId });
+    await _repo.UpsertEntry(
       new GaugeEntry
       {
-        ParentId = "gauge-journal-id",
+        ParentId = journal2Id,
         DateTime = _dateService.UtcNow
       }
     );
     _dateService.SetNext(1);
 
-    _repo.Journals.Add(new TimerJournal { Id = "timer-journal-id", UserId = UserId });
-    _repo.Entries.Add(
+    await _repo.UpsertJournal(new TimerJournal { Id = journal3Id, UserId = UserId });
+    await _repo.UpsertEntry(
       new TimerEntry
       {
-        ParentId = "timer-journal-id",
+        ParentId = journal3Id,
         DateTime = _dateService.UtcNow
       }
     );
 
-    var queryExecutor = new SearchEntriesQueryExecutor(_repo);
+    var queryExecutorRepo = await Util.CreateUserScopedMongoRepository(UserId, UserId, true);
+    await queryExecutorRepo.WakeMeUp();
+
+    var queryExecutor = new SearchEntriesQueryExecutor(queryExecutorRepo);
     SearchEntriesQueryResult result = await queryExecutor.Execute(new SearchEntriesQuery { Limit = 2 });
 
     result.Journals.Length.Should().Be(2);
-    result.Journals.Select(m => m.Id).Contains("counter-journal-id").Should().BeFalse();
-    result.Entries.Length.Should().Be(2);
-    result.Entries.Select(m => m.ParentId).Contains("counter-journal-id").Should().BeFalse();
+    result.Entries.Any(m => m.ParentId == journal1Id).Should().BeFalse();
+    result.Journals.Any(m => m.Id == journal1Id).Should().BeFalse();
   }
 }

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Journals/JournalQueryUtilShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Journals/JournalQueryUtilShould.cs
@@ -1,9 +1,9 @@
 ﻿using System.Threading.Tasks;
 using Engraved.Core.Application.Persistence;
-using Engraved.Core.Application.Persistence.Demo;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Permissions;
 using Engraved.Core.Domain.Users;
+using Engraved.Persistence.Mongo.Tests;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -12,14 +12,14 @@ namespace Engraved.Core.Application.Queries.Journals;
 public class JournalQueryUtilShould
 {
   private string _meUserId = null!;
-  private InMemoryRepository _testRepository = null!;
-  private UserScopedInMemoryRepository _userScopedInMemoryRepository = null!;
+  private TestMongoRepository _testRepository = null!;
+  private TestUserScopedMongoRepository _userScopedMongoRepository = null!;
   private string _youUserId = null!;
 
   [SetUp]
   public async Task SetUp()
   {
-    _testRepository = new InMemoryRepository();
+    _testRepository = await Util.CreateMongoRepository();
 
     UpsertResult meUpsertResult = await _testRepository.UpsertUser(new User { Name = "me" });
     _meUserId = meUpsertResult.EntityId;
@@ -27,17 +27,14 @@ public class JournalQueryUtilShould
     UpsertResult youUpsertResult = await _testRepository.UpsertUser(new User { Name = "you" });
     _youUserId = youUpsertResult.EntityId;
 
-    _userScopedInMemoryRepository = new UserScopedInMemoryRepository(
-      _testRepository,
-      new FakeCurrentUserService("me")
-    );
+    _userScopedMongoRepository = await Util.CreateUserScopedMongoRepository("me", _meUserId, true);
   }
 
   [Test]
   public async Task SetUserRoleToOwner()
   {
     IJournal[] ensuredJournals = await JournalQueryUtil.EnsurePermissionUsers(
-      _userScopedInMemoryRepository,
+      _userScopedMongoRepository,
       new TimerJournal { UserId = _meUserId }
     );
 
@@ -49,7 +46,7 @@ public class JournalQueryUtilShould
   public async Task SetUserRoleToReader()
   {
     IJournal[] ensuredJournals = await JournalQueryUtil.EnsurePermissionUsers(
-      _userScopedInMemoryRepository,
+      _userScopedMongoRepository,
       new TimerJournal
       {
         UserId = _youUserId,
@@ -71,7 +68,7 @@ public class JournalQueryUtilShould
   public async Task SetUserRoleToWriter()
   {
     IJournal[] ensuredJournals = await JournalQueryUtil.EnsurePermissionUsers(
-      _userScopedInMemoryRepository,
+      _userScopedMongoRepository,
       new TimerJournal
       {
         UserId = _youUserId,

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Search/SearchEntitiesQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Search/SearchEntitiesQueryExecutorShould.cs
@@ -4,7 +4,7 @@ using Engraved.Core.Application.Commands;
 using Engraved.Core.Application.Commands.Entries.Upsert.Scraps;
 using Engraved.Core.Application.Commands.Journals.Add;
 using Engraved.Core.Application.Commands.Journals.AddSchedule;
-using Engraved.Core.Application.Persistence.Demo;
+using Engraved.Persistence.Mongo.Tests;
 using Engraved.Core.Application.Queries.Search.Entities;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Users;
@@ -19,34 +19,30 @@ public class SearchEntitiesQueryExecutorShould
 {
   private FakeDateService _dateService = null!;
   private SearchEntitiesQueryExecutor _searchExecutor = null!;
-  private InMemoryRepository _testRepository = null!;
-  private UserScopedInMemoryRepository _userScopedInMemoryRepository = null!;
+  private TestUserScopedMongoRepository _repo = null!;
 
   [SetUp]
   public async Task SetUp()
   {
-    _testRepository = new InMemoryRepository();
+    const string userId = "6a40b7027bf30b7c135049b4";
+    _repo = await Util.CreateUserScopedMongoRepository(userId, userId, false);
+    await _repo.WakeMeUp();
 
-    await _testRepository.UpsertUser(new User { Name = "max" });
+    await _repo.UpsertUser(new User { Id = userId, Name = userId });
 
-    var fakeCurrentUserService = new FakeCurrentUserService("max");
-
-    _userScopedInMemoryRepository = new UserScopedInMemoryRepository(
-      _testRepository,
-      fakeCurrentUserService
-    );
+    var fakeCurrentUserService = new FakeCurrentUserService(userId);
 
     _dateService = new FakeDateService();
 
     _searchExecutor = new SearchEntitiesQueryExecutor(
       new Dispatcher(
         NullLogger<Dispatcher>.Instance,
-        new TestServiceProvider(_userScopedInMemoryRepository),
-        _userScopedInMemoryRepository,
+        new TestServiceProvider(_repo),
+        _repo,
         new QueryCache(
           NullLogger<QueryCache>.Instance,
           new MemoryCache(new MemoryCacheOptions()),
-          _userScopedInMemoryRepository.CurrentUser
+          _repo.CurrentUser
         )
       ),
       fakeCurrentUserService
@@ -78,7 +74,7 @@ public class SearchEntitiesQueryExecutorShould
   [Test]
   public async Task FindEntriesOfJournalType()
   {
-    var addJournalExecutor = new AddJournalCommandExecutor(_userScopedInMemoryRepository, _dateService);
+    var addJournalExecutor = new AddJournalCommandExecutor(_repo, _dateService);
     CommandResult commandResult = await addJournalExecutor.Execute(
       new AddJournalCommand
       {
@@ -87,7 +83,7 @@ public class SearchEntitiesQueryExecutorShould
       }
     );
 
-    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_userScopedInMemoryRepository, _dateService);
+    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_repo, _dateService);
     await addEntryExecutor.Execute(
       new UpsertScrapsEntryCommand
       {
@@ -141,7 +137,7 @@ public class SearchEntitiesQueryExecutorShould
 
   private async Task AddEntitiesWithSchedule()
   {
-    var addJournalExecutor = new AddJournalCommandExecutor(_userScopedInMemoryRepository, _dateService);
+    var addJournalExecutor = new AddJournalCommandExecutor(_repo, _dateService);
     CommandResult commandResult = await addJournalExecutor.Execute(
       new AddJournalCommand
       {
@@ -150,7 +146,7 @@ public class SearchEntitiesQueryExecutorShould
       }
     );
 
-    var addScheduleExecutor = new AddScheduleToJournalCommandExecutor(_userScopedInMemoryRepository);
+    var addScheduleExecutor = new AddScheduleToJournalCommandExecutor(_repo);
     await addScheduleExecutor.Execute(
       new AddScheduleToJournalCommand
       {
@@ -159,7 +155,7 @@ public class SearchEntitiesQueryExecutorShould
       }
     );
 
-    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_userScopedInMemoryRepository, _dateService);
+    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_repo, _dateService);
     await addEntryExecutor.Execute(
       new UpsertScrapsEntryCommand
       {
@@ -172,7 +168,7 @@ public class SearchEntitiesQueryExecutorShould
 
   private async Task AddJournalToIgnoreWithOneEntryToFind()
   {
-    var addJournalExecutor = new AddJournalCommandExecutor(_userScopedInMemoryRepository, _dateService);
+    var addJournalExecutor = new AddJournalCommandExecutor(_repo, _dateService);
     CommandResult commandResult = await addJournalExecutor.Execute(
       new AddJournalCommand
       {
@@ -181,7 +177,7 @@ public class SearchEntitiesQueryExecutorShould
       }
     );
 
-    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_userScopedInMemoryRepository, _dateService);
+    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_repo, _dateService);
     await addEntryExecutor.Execute(
       new UpsertScrapsEntryCommand
       {
@@ -194,7 +190,7 @@ public class SearchEntitiesQueryExecutorShould
 
   private async Task AddJournalToFindWithTwoEntriesToIgnore()
   {
-    var addJournalExecutor = new AddJournalCommandExecutor(_userScopedInMemoryRepository, _dateService);
+    var addJournalExecutor = new AddJournalCommandExecutor(_repo, _dateService);
     CommandResult commandResult = await addJournalExecutor.Execute(
       new AddJournalCommand
       {
@@ -203,7 +199,7 @@ public class SearchEntitiesQueryExecutorShould
       }
     );
 
-    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_userScopedInMemoryRepository, _dateService);
+    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_repo, _dateService);
     await addEntryExecutor.Execute(
       new UpsertScrapsEntryCommand
       {

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Search/SearchEntitiesQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Search/SearchEntitiesQueryExecutorShould.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using Engraved.Core.Application.Commands;
+using Engraved.Core.Application.Commands.Entries.AddSchedule;
 using Engraved.Core.Application.Commands.Entries.Upsert.Scraps;
 using Engraved.Core.Application.Commands.Journals.Add;
 using Engraved.Core.Application.Commands.Journals.AddSchedule;
@@ -156,12 +157,22 @@ public class SearchEntitiesQueryExecutorShould
     );
 
     var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_repo, _dateService);
-    await addEntryExecutor.Execute(
+    CommandResult entryResult = await addEntryExecutor.Execute(
       new UpsertScrapsEntryCommand
       {
         JournalId = commandResult.EntityId,
         DateTime = _dateService.UtcNow,
         Notes = "Entry with Schedule"
+      }
+    );
+
+    // the entry itself is scheduled, so it shows up in a "scheduled only" search.
+    var addEntryScheduleExecutor = new AddScheduleToEntryCommandExecutor(_repo);
+    await addEntryScheduleExecutor.Execute(
+      new AddScheduleToEntryCommand
+      {
+        EntryId = entryResult.EntityId,
+        NextOccurrence = _dateService.UtcNow.AddDays(10)
       }
     );
   }

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Search/SearchEntitiesQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Search/SearchEntitiesQueryExecutorShould.cs
@@ -24,7 +24,7 @@ public class SearchEntitiesQueryExecutorShould
   [SetUp]
   public async Task SetUp()
   {
-    const string userId = "6a40b7027bf30b7c135049b4";
+    const string userId = TestIds.UserId;
     _repo = await Util.CreateUserScopedMongoRepository(userId, userId, false);
     await _repo.WakeMeUp();
 

--- a/api/Engraved.Core.Tests/Source/Domain/Permissions/PermissionsEnsurerShould.cs
+++ b/api/Engraved.Core.Tests/Source/Domain/Permissions/PermissionsEnsurerShould.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Engraved.Persistence.Mongo.Tests;
 using Engraved.Core.Application.Persistence;
-using Engraved.Core.Application.Persistence.Demo;
 using Engraved.Core.Domain.Users;
 using FluentAssertions;
 using NUnit.Framework;
@@ -11,23 +11,21 @@ namespace Engraved.Core.Domain.Permissions;
 public class PermissionsEnsurerShould
 {
   private PermissionsEnsurer _permissionsEnsurer = null!;
-  private IBaseRepository _repository = null!;
+  private TestMongoRepository _repository = null!;
 
   [SetUp]
-  public void SetUp()
+  public async Task SetUp()
   {
-    _repository = new InMemoryRepository
-    {
-      Users =
+    _repository = await Util.CreateMongoRepository();
+
+    await _repository.UpsertUser(
+      new User
       {
-        new User
-        {
-          Id = "123",
-          Name = "mar@foo.ch",
-          DisplayName = "Mar Dog"
-        }
+        Id = "6a40b7027bf30b7c135049b4",
+        Name = "mar@foo.ch",
+        DisplayName = "Mar Dog"
       }
-    };
+    );
 
     _permissionsEnsurer = new PermissionsEnsurer(_repository, _repository.UpsertUser);
   }
@@ -37,7 +35,7 @@ public class PermissionsEnsurerShould
   {
     var holder = new TestPermissionHolder
     {
-      Permissions = new UserPermissions { { "123", new PermissionDefinition { Kind = PermissionKind.Read } } }
+      Permissions = new UserPermissions { { "6a40b7027bf30b7c135049b4", new PermissionDefinition { Kind = PermissionKind.Read } } }
     };
 
     await _permissionsEnsurer.EnsurePermissions(
@@ -53,7 +51,7 @@ public class PermissionsEnsurerShould
   {
     var holder = new TestPermissionHolder
     {
-      Permissions = new UserPermissions { { "123", new PermissionDefinition { Kind = PermissionKind.Read } } }
+      Permissions = new UserPermissions { { "6a40b7027bf30b7c135049b4", new PermissionDefinition { Kind = PermissionKind.Read } } }
     };
 
     await _permissionsEnsurer.EnsurePermissions(
@@ -62,7 +60,7 @@ public class PermissionsEnsurerShould
     );
 
     holder.Permissions.Count.Should().Be(1);
-    holder.Permissions["123"].Kind.Should().Be(PermissionKind.Write);
+    holder.Permissions["6a40b7027bf30b7c135049b4"].Kind.Should().Be(PermissionKind.Write);
   }
 
   [Test]
@@ -70,7 +68,7 @@ public class PermissionsEnsurerShould
   {
     var holder = new TestPermissionHolder
     {
-      Permissions = new UserPermissions { { "123", new PermissionDefinition { Kind = PermissionKind.Read } } }
+      Permissions = new UserPermissions { { "6a40b7027bf30b7c135049b4", new PermissionDefinition { Kind = PermissionKind.Read } } }
     };
 
     await _permissionsEnsurer.EnsurePermissions(

--- a/api/Engraved.Core.Tests/Source/Domain/Permissions/PermissionsEnsurerShould.cs
+++ b/api/Engraved.Core.Tests/Source/Domain/Permissions/PermissionsEnsurerShould.cs
@@ -21,7 +21,7 @@ public class PermissionsEnsurerShould
     await _repository.UpsertUser(
       new User
       {
-        Id = "6a40b7027bf30b7c135049b4",
+        Id = TestIds.UserId,
         Name = "mar@foo.ch",
         DisplayName = "Mar Dog"
       }
@@ -35,7 +35,7 @@ public class PermissionsEnsurerShould
   {
     var holder = new TestPermissionHolder
     {
-      Permissions = new UserPermissions { { "6a40b7027bf30b7c135049b4", new PermissionDefinition { Kind = PermissionKind.Read } } }
+      Permissions = new UserPermissions { { TestIds.UserId, new PermissionDefinition { Kind = PermissionKind.Read } } }
     };
 
     await _permissionsEnsurer.EnsurePermissions(
@@ -51,7 +51,7 @@ public class PermissionsEnsurerShould
   {
     var holder = new TestPermissionHolder
     {
-      Permissions = new UserPermissions { { "6a40b7027bf30b7c135049b4", new PermissionDefinition { Kind = PermissionKind.Read } } }
+      Permissions = new UserPermissions { { TestIds.UserId, new PermissionDefinition { Kind = PermissionKind.Read } } }
     };
 
     await _permissionsEnsurer.EnsurePermissions(
@@ -60,7 +60,7 @@ public class PermissionsEnsurerShould
     );
 
     holder.Permissions.Count.Should().Be(1);
-    holder.Permissions["6a40b7027bf30b7c135049b4"].Kind.Should().Be(PermissionKind.Write);
+    holder.Permissions[TestIds.UserId].Kind.Should().Be(PermissionKind.Write);
   }
 
   [Test]
@@ -68,7 +68,7 @@ public class PermissionsEnsurerShould
   {
     var holder = new TestPermissionHolder
     {
-      Permissions = new UserPermissions { { "6a40b7027bf30b7c135049b4", new PermissionDefinition { Kind = PermissionKind.Read } } }
+      Permissions = new UserPermissions { { TestIds.UserId, new PermissionDefinition { Kind = PermissionKind.Read } } }
     };
 
     await _permissionsEnsurer.EnsurePermissions(

--- a/api/Engraved.Core/Source/Application/Queries/Entries/GetAll/SearchEntriesQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Entries/GetAll/SearchEntriesQueryExecutor.cs
@@ -9,7 +9,7 @@ public class SearchEntriesQueryExecutor(IUserScopedRepository repository)
 
   public async Task<SearchEntriesQueryResult> Execute(SearchEntriesQuery query)
   {
-    var allJournals = await repository.GetAllJournals(null, null, null, null, 100);
+    var allJournals = await repository.GetAllJournals(null, null, null, null, 1000);
     var allJournalIds = allJournals.Select(j => j.Id!).ToArray();
 
     var allEntries = await repository.SearchEntries(
@@ -22,11 +22,56 @@ public class SearchEntriesQueryExecutor(IUserScopedRepository repository)
       query.OnlyConsiderTitle.HasValue && query.OnlyConsiderTitle.Value
     );
 
-    var relevantJournalIds = allEntries.Select(e => e.ParentId).ToArray();
+    var entriesWithJournalToLoad = allEntries
+      .Where(e => !allJournalIds.Contains(e.ParentId))
+      .Select(e => e.ParentId)
+      .Distinct()
+      .ToArray();
+
+    if (entriesWithJournalToLoad.Any())
+    {
+      var additionalJournals = (await Task.WhenAll(entriesWithJournalToLoad.Select(repository.GetJournal)))
+        .Where(j => j != null)
+        .Select(j => j!)
+        .ToArray();
+
+      allJournals = allJournals.UnionBy(additionalJournals, j => j.Id).ToArray();
+    }
+
+    if (query.ScheduledOnly)
+    {
+      var scheduledJournalIds = allJournals
+        .Where(j => j.Schedules.Any())
+        .Select(j => j.Id)
+        .ToArray();
+
+      var entriesToReturn = allEntries
+        .Where(e => e.Schedules.Any())
+        .ToArray();
+
+      var journalIdsOfScheduledEntries = entriesToReturn
+        .Select(e => e.ParentId)
+        .Distinct()
+        .ToArray();
+
+      var allRelevantJournalIds = scheduledJournalIds.Union(journalIdsOfScheduledEntries).ToArray();
+
+      return new SearchEntriesQueryResult
+      {
+        Journals = allJournals.Where(j => allRelevantJournalIds.Contains(j.Id)).ToArray(),
+        Entries = entriesToReturn
+      };
+    }
+
+    var relevantJournalIds = allEntries.Select(e => e.ParentId).Union(allJournals.Select(j => j.Id)).ToArray();
+
+    var journalsToReturn = allJournals
+      .Where(j => relevantJournalIds.Contains(j.Id))
+      .ToArray();
 
     return new SearchEntriesQueryResult
     {
-      Journals = allJournals.Where(j => relevantJournalIds.Contains(j.Id)).ToArray(),
+      Journals = journalsToReturn,
       Entries = allEntries.ToArray()
     };
   }

--- a/api/Engraved.Core/Source/Application/Queries/Entries/GetAll/SearchEntriesQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Entries/GetAll/SearchEntriesQueryExecutor.cs
@@ -12,9 +12,12 @@ public class SearchEntriesQueryExecutor(IUserScopedRepository repository)
     var allJournals = await repository.GetAllJournals(null, null, null, null, 1000);
     var allJournalIds = allJournals.Select(j => j.Id!).ToArray();
 
+    // entries are surfaced by text/type/journal scope only. "scheduled only" filtering is
+    // applied to the journal entities (see GetAllJournalsQueryExecutor), not to entries:
+    // an entry living inside a scheduled journal stays relevant even without its own schedule.
     var allEntries = await repository.SearchEntries(
       query.SearchText,
-      query.ScheduledOnly ? ScheduleMode.CurrentUserOnly : ScheduleMode.None,
+      ScheduleMode.None,
       query.JournalTypes,
       allJournalIds,
       query.Limit ?? 100,
@@ -22,56 +25,13 @@ public class SearchEntriesQueryExecutor(IUserScopedRepository repository)
       query.OnlyConsiderTitle.HasValue && query.OnlyConsiderTitle.Value
     );
 
-    var entriesWithJournalToLoad = allEntries
-      .Where(e => !allJournalIds.Contains(e.ParentId))
-      .Select(e => e.ParentId)
-      .Distinct()
-      .ToArray();
-
-    if (entriesWithJournalToLoad.Any())
-    {
-      var additionalJournals = (await Task.WhenAll(entriesWithJournalToLoad.Select(repository.GetJournal)))
-        .Where(j => j != null)
-        .Select(j => j!)
-        .ToArray();
-
-      allJournals = allJournals.UnionBy(additionalJournals, j => j.Id).ToArray();
-    }
-
-    if (query.ScheduledOnly)
-    {
-      var scheduledJournalIds = allJournals
-        .Where(j => j.Schedules.Any())
-        .Select(j => j.Id)
-        .ToArray();
-
-      var entriesToReturn = allEntries
-        .Where(e => e.Schedules.Any())
-        .ToArray();
-
-      var journalIdsOfScheduledEntries = entriesToReturn
-        .Select(e => e.ParentId)
-        .Distinct()
-        .ToArray();
-
-      var allRelevantJournalIds = scheduledJournalIds.Union(journalIdsOfScheduledEntries).ToArray();
-
-      return new SearchEntriesQueryResult
-      {
-        Journals = allJournals.Where(j => allRelevantJournalIds.Contains(j.Id)).ToArray(),
-        Entries = entriesToReturn
-      };
-    }
-
-    var relevantJournalIds = allEntries.Select(e => e.ParentId).Union(allJournals.Select(j => j.Id)).ToArray();
-
-    var journalsToReturn = allJournals
-      .Where(j => relevantJournalIds.Contains(j.Id))
-      .ToArray();
+    // only the journals that own a matched entry are returned, so the client can render
+    // each entry together with its parent journal.
+    var relevantJournalIds = allEntries.Select(e => e.ParentId).ToArray();
 
     return new SearchEntriesQueryResult
     {
-      Journals = journalsToReturn,
+      Journals = allJournals.Where(j => relevantJournalIds.Contains(j.Id)).ToArray(),
       Entries = allEntries.ToArray()
     };
   }

--- a/api/Engraved.Core/Source/Application/Queries/Entries/GetAll/SearchEntriesQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Entries/GetAll/SearchEntriesQueryExecutor.cs
@@ -12,12 +12,13 @@ public class SearchEntriesQueryExecutor(IUserScopedRepository repository)
     var allJournals = await repository.GetAllJournals(null, null, null, null, 1000);
     var allJournalIds = allJournals.Select(j => j.Id!).ToArray();
 
-    // entries are surfaced by text/type/journal scope only. "scheduled only" filtering is
-    // applied to the journal entities (see GetAllJournalsQueryExecutor), not to entries:
-    // an entry living inside a scheduled journal stays relevant even without its own schedule.
+    // for "scheduled only" we ask the repository to return just the entries that have a schedule
+    // for the current user. Doing this in the query (rather than filtering in memory afterwards)
+    // keeps the result limit meaningful - we don't want to fetch 100 arbitrary entries and then
+    // discard the unscheduled ones.
     var allEntries = await repository.SearchEntries(
       query.SearchText,
-      ScheduleMode.None,
+      query.ScheduledOnly ? ScheduleMode.CurrentUserOnly : ScheduleMode.None,
       query.JournalTypes,
       allJournalIds,
       query.Limit ?? 100,

--- a/api/Engraved.Core/Source/Application/Queries/Search/Entities/SearchEntitiesQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Search/Entities/SearchEntitiesQueryExecutor.cs
@@ -63,8 +63,9 @@ public class SearchEntitiesQueryExecutor(Dispatcher dispatcher, ICurrentUserServ
     return searchResultEntities
       .OrderBy(e => e.Entity.Schedules.ContainsKey(user.Id ?? "")
         ? e.Entity.Schedules[user.Id ?? ""].NextOccurrence
-        : null
+        : e.Entity.Schedules.Values.FirstOrDefault()?.NextOccurrence
       )
+      .ThenByDescending(e => e.Entity.EditedOn)
       .ToArray();
   }
 }

--- a/api/Engraved.Persistence.Mongo.Tests/Engraved.Persistence.Mongo.Tests.csproj
+++ b/api/Engraved.Persistence.Mongo.Tests/Engraved.Persistence.Mongo.Tests.csproj
@@ -7,15 +7,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Engraved.Persistence.Mongo\Engraved.Persistence.Mongo.csproj"/>
+        <ProjectReference Include="..\Engraved.Persistence.Mongo\Engraved.Persistence.Mongo.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0"/>
-        <PackageReference Include="FluentAssertions" Version="8.10.0"/>
-        <PackageReference Include="NUnit" Version="4.6.1"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0"/>
-        <PackageReference Include="NUnit.Analyzers" Version="4.14.0"/>
+        <PackageReference Include="EphemeralMongo" Version="3.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="FluentAssertions" Version="8.10.0" />
+        <PackageReference Include="NUnit" Version="4.6.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
         <PackageReference Include="coverlet.collector" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/api/Engraved.Persistence.Mongo.Tests/Source/MongoRunnerTeardown.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/MongoRunnerTeardown.cs
@@ -1,0 +1,19 @@
+using Engraved.Persistence.Mongo.Tests;
+using NUnit.Framework;
+
+// Assembly-level teardown: NUnit runs this once after every test in the assembly has finished.
+// It stops the shared EphemeralMongo instance so its ~280 MB temp data directory is deleted
+// instead of lingering. A [SetUpFixture] in the global namespace applies to the whole assembly.
+//
+// This file is compiled into every test assembly that uses Util (linked via the .csproj of the
+// referencing test projects), because NUnit only discovers SetUpFixtures in the assembly under
+// test - not in referenced assemblies.
+[SetUpFixture]
+public class MongoRunnerTeardown
+{
+  [OneTimeTearDown]
+  public void StopRunner()
+  {
+    Util.StopRunner();
+  }
+}

--- a/api/Engraved.Persistence.Mongo.Tests/Source/TestIds.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/TestIds.cs
@@ -1,0 +1,19 @@
+namespace Engraved.Persistence.Mongo.Tests;
+
+/// <summary>
+/// Shared, valid 24-character hex ObjectId strings used across the test suites.
+/// EphemeralMongo (unlike the former in-memory repository) requires ids to be parseable
+/// as <see cref="MongoDB.Bson.ObjectId" />, so tests cannot use arbitrary strings like "journal_id".
+/// Keeping the recurring ids here avoids duplicating the same literal in many test files.
+/// </summary>
+public static class TestIds
+{
+  /// <summary>The primary user that owns the entities under test.</summary>
+  public const string UserId = "6a40b7027bf30b7c135049b4";
+
+  /// <summary>A second user, e.g. one that entities are shared with.</summary>
+  public const string OtherUserId = "6a40b7027bf30b7c135049b3";
+
+  /// <summary>A third user, used where three distinct users are needed.</summary>
+  public const string ThirdUserId = "6a40b7027bf30b7c135049b2";
+}

--- a/api/Engraved.Persistence.Mongo.Tests/Source/TestMongoRepositorySettings.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/TestMongoRepositorySettings.cs
@@ -1,8 +1,8 @@
 ﻿namespace Engraved.Persistence.Mongo.Tests;
 
-public class TestMongoRepositorySettings : IMongoRepositorySettings
+public class TestMongoRepositorySettings(string mongoDbConnectionString) : IMongoRepositorySettings
 {
-  public string MongoDbConnectionString => "mongodb://127.0.0.1:27017";
+  public string MongoDbConnectionString => mongoDbConnectionString;
   public string DatabaseName => "metrix_unit_test";
   public string JournalsCollectionName => "journals";
   public string EntriesCollectionName => "entries";

--- a/api/Engraved.Persistence.Mongo.Tests/Source/UserScopedMongoRepositoryShould.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/UserScopedMongoRepositoryShould.cs
@@ -112,6 +112,7 @@ public class UserScopedMongoRepositoryShould
           new TimerJournal
           {
             Id = result.EntityId,
+            UserId = _otherUserId,
             Notes = "Random"
           }
         );

--- a/api/Engraved.Persistence.Mongo.Tests/Source/Util.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/Util.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using EphemeralMongo;
 using MongoDB.Driver;
 
@@ -6,11 +7,31 @@ namespace Engraved.Persistence.Mongo.Tests;
 
 public static class Util
 {
-  private static readonly IMongoRunner Runner = MongoRunner.Run(new MongoRunnerOptions
+  private static readonly IMongoRunner Runner = MongoRunner.Run(
+    new MongoRunnerOptions
+    {
+      Version = MongoVersion.V7,
+
+      // note: do not pin MongoPort. Each test assembly runs in its own test-host process and
+      // spins up its own mongo instance; a fixed port makes those processes collide (and share
+      // data) when the whole solution is tested at once. A free port keeps the assemblies isolated.
+
+      // each mongo instance creates a ~280 MB data directory under the temp folder. The default
+      // lifetime (12h) lets orphaned directories from crashed/killed runs pile up to many GB. Keep
+      // them around only briefly; a clean run disposes the runner via StopRunner() (see the
+      // assembly-level MongoRunnerTeardown), which deletes the directory immediately.
+      DataDirectoryLifetime = TimeSpan.FromMinutes(30)
+    }
+  );
+
+  /// <summary>
+  /// Stops the shared mongo instance and deletes its temp data directory. Invoked once per test
+  /// assembly from an NUnit [OneTimeTearDown] so the ~280 MB data directory does not linger.
+  /// </summary>
+  public static void StopRunner()
   {
-    MongoPort = 27017,
-    Version = MongoVersion.V7
-  });
+    Runner.Dispose();
+  }
 
   private static IMongoRepositorySettings Settings => new TestMongoRepositorySettings(Runner.ConnectionString);
   private static MongoDatabaseClient Client => new(Settings, null);

--- a/api/Engraved.Persistence.Mongo.Tests/Source/Util.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/Util.cs
@@ -1,12 +1,15 @@
 ﻿using System.Threading.Tasks;
+using EphemeralMongo;
 using MongoDB.Driver;
 
 namespace Engraved.Persistence.Mongo.Tests;
 
 public static class Util
 {
-  private static IMongoRepositorySettings Settings => new TestMongoRepositorySettings();
-  private static MongoDatabaseClient Client => new(new TestMongoRepositorySettings(), null);
+  private static readonly IMongoRunner Runner = MongoRunner.Run();
+
+  private static IMongoRepositorySettings Settings => new TestMongoRepositorySettings(Runner.ConnectionString);
+  private static MongoDatabaseClient Client => new(Settings, null);
 
   public static async Task<TestMongoRepository> CreateMongoRepository()
   {
@@ -34,7 +37,7 @@ public static class Util
 
   private static async Task DropDatabase()
   {
-    var client = new MongoClient(Settings.MongoDbConnectionString);
+    var client = new MongoClient(Runner.ConnectionString);
     await client.DropDatabaseAsync(Settings.DatabaseName);
   }
 }

--- a/api/Engraved.Persistence.Mongo.Tests/Source/Util.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/Util.cs
@@ -7,26 +7,8 @@ namespace Engraved.Persistence.Mongo.Tests;
 
 public static class Util
 {
-  // Storage engine used by the ephemeral mongo instance shared by the test suite.
-  //
-  //   InMemory (default): MongoDB Enterprise with the in-memory storage engine. Nothing is
-  //     written to disk, so there is no ~280 MB temp data directory per test assembly. Downloads
-  //     the Enterprise binaries once (about the same size as Community) into the local app-data
-  //     cache. Note: on Linux the Enterprise binary needs extra system libraries (libldap, sasl),
-  //     which is why CI runs with ENGRAVED_TEST_MONGO_ENGINE=ondisk (see build-api.yml).
-  //
-  //   OnDisk: MongoDB Community with the default WiredTiger engine, persisting to a temporary
-  //     data directory that is deleted on teardown. No extra system libraries required.
-  //
-  // Change the default here, or override per run with the ENGRAVED_TEST_MONGO_ENGINE environment
-  // variable ("inmemory" / "ondisk") - handy for a CI matrix without touching code.
-  private const MongoStorageEngine DefaultStorageEngine = MongoStorageEngine.InMemory;
-
-  private static readonly IMongoRunner Runner = MongoRunner.Run(BuildRunnerOptions());
-
-  private static MongoRunnerOptions BuildRunnerOptions()
-  {
-    var options = new MongoRunnerOptions
+  private static readonly IMongoRunner Runner = MongoRunner.Run(
+    new MongoRunnerOptions
     {
       Version = MongoVersion.V7,
 
@@ -34,36 +16,17 @@ public static class Util
       // spins up its own mongo instance; a fixed port makes those processes collide (and share
       // data) when the whole solution is tested at once. A free port keeps the assemblies isolated.
 
-      // the on-disk engine creates a ~280 MB data directory under the temp folder. The default
+      // each mongo instance creates a ~280 MB data directory under the temp folder. The default
       // lifetime (12h) lets orphaned directories from crashed/killed runs pile up to many GB. Keep
       // them around only briefly; a clean run disposes the runner via StopRunner() (see the
       // assembly-level MongoRunnerTeardown), which deletes the directory immediately.
       DataDirectoryLifetime = TimeSpan.FromMinutes(30)
-    };
-
-    if (ResolveStorageEngine() == MongoStorageEngine.InMemory)
-    {
-      // the in-memory storage engine is only available in the Enterprise edition.
-      options.Edition = MongoEdition.Enterprise;
-      options.AdditionalArguments = ["--storageEngine", "inMemory"];
     }
-
-    return options;
-  }
-
-  private static MongoStorageEngine ResolveStorageEngine()
-  {
-    return Environment.GetEnvironmentVariable("ENGRAVED_TEST_MONGO_ENGINE")?.Trim().ToLowerInvariant() switch
-    {
-      "inmemory" => MongoStorageEngine.InMemory,
-      "ondisk" => MongoStorageEngine.OnDisk,
-      _ => DefaultStorageEngine
-    };
-  }
+  );
 
   /// <summary>
-  /// Stops the shared mongo instance and deletes any temp data directory. Invoked once per test
-  /// assembly from an NUnit [OneTimeTearDown] so an on-disk data directory does not linger.
+  /// Stops the shared mongo instance and deletes its temp data directory. Invoked once per test
+  /// assembly from an NUnit [OneTimeTearDown] so the ~280 MB data directory does not linger.
   /// </summary>
   public static void StopRunner()
   {
@@ -102,13 +65,4 @@ public static class Util
     var client = new MongoClient(Runner.ConnectionString);
     await client.DropDatabaseAsync(Settings.DatabaseName);
   }
-}
-
-public enum MongoStorageEngine
-{
-  /// <summary>Enterprise in-memory engine - no data written to disk.</summary>
-  InMemory,
-
-  /// <summary>Community WiredTiger engine - persists to a temp data directory.</summary>
-  OnDisk
 }

--- a/api/Engraved.Persistence.Mongo.Tests/Source/Util.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/Util.cs
@@ -6,7 +6,11 @@ namespace Engraved.Persistence.Mongo.Tests;
 
 public static class Util
 {
-  private static readonly IMongoRunner Runner = MongoRunner.Run();
+  private static readonly IMongoRunner Runner = MongoRunner.Run(new MongoRunnerOptions
+  {
+    MongoPort = 27017,
+    Version = MongoVersion.V7
+  });
 
   private static IMongoRepositorySettings Settings => new TestMongoRepositorySettings(Runner.ConnectionString);
   private static MongoDatabaseClient Client => new(Settings, null);

--- a/api/Engraved.Persistence.Mongo.Tests/Source/Util.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/Util.cs
@@ -11,10 +11,12 @@ public static class Util
   //
   //   InMemory (default): MongoDB Enterprise with the in-memory storage engine. Nothing is
   //     written to disk, so there is no ~280 MB temp data directory per test assembly. Downloads
-  //     the Enterprise binaries once (a bit larger than Community) into the local app-data cache.
+  //     the Enterprise binaries once (about the same size as Community) into the local app-data
+  //     cache. Note: on Linux the Enterprise binary needs extra system libraries (libldap, sasl),
+  //     which is why CI runs with ENGRAVED_TEST_MONGO_ENGINE=ondisk (see build-api.yml).
   //
   //   OnDisk: MongoDB Community with the default WiredTiger engine, persisting to a temporary
-  //     data directory that is deleted on teardown.
+  //     data directory that is deleted on teardown. No extra system libraries required.
   //
   // Change the default here, or override per run with the ENGRAVED_TEST_MONGO_ENGINE environment
   // variable ("inmemory" / "ondisk") - handy for a CI matrix without touching code.

--- a/api/Engraved.Persistence.Mongo.Tests/Source/Util.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/Util.cs
@@ -7,8 +7,24 @@ namespace Engraved.Persistence.Mongo.Tests;
 
 public static class Util
 {
-  private static readonly IMongoRunner Runner = MongoRunner.Run(
-    new MongoRunnerOptions
+  // Storage engine used by the ephemeral mongo instance shared by the test suite.
+  //
+  //   InMemory (default): MongoDB Enterprise with the in-memory storage engine. Nothing is
+  //     written to disk, so there is no ~280 MB temp data directory per test assembly. Downloads
+  //     the Enterprise binaries once (a bit larger than Community) into the local app-data cache.
+  //
+  //   OnDisk: MongoDB Community with the default WiredTiger engine, persisting to a temporary
+  //     data directory that is deleted on teardown.
+  //
+  // Change the default here, or override per run with the ENGRAVED_TEST_MONGO_ENGINE environment
+  // variable ("inmemory" / "ondisk") - handy for a CI matrix without touching code.
+  private const MongoStorageEngine DefaultStorageEngine = MongoStorageEngine.InMemory;
+
+  private static readonly IMongoRunner Runner = MongoRunner.Run(BuildRunnerOptions());
+
+  private static MongoRunnerOptions BuildRunnerOptions()
+  {
+    var options = new MongoRunnerOptions
     {
       Version = MongoVersion.V7,
 
@@ -16,17 +32,36 @@ public static class Util
       // spins up its own mongo instance; a fixed port makes those processes collide (and share
       // data) when the whole solution is tested at once. A free port keeps the assemblies isolated.
 
-      // each mongo instance creates a ~280 MB data directory under the temp folder. The default
+      // the on-disk engine creates a ~280 MB data directory under the temp folder. The default
       // lifetime (12h) lets orphaned directories from crashed/killed runs pile up to many GB. Keep
       // them around only briefly; a clean run disposes the runner via StopRunner() (see the
       // assembly-level MongoRunnerTeardown), which deletes the directory immediately.
       DataDirectoryLifetime = TimeSpan.FromMinutes(30)
+    };
+
+    if (ResolveStorageEngine() == MongoStorageEngine.InMemory)
+    {
+      // the in-memory storage engine is only available in the Enterprise edition.
+      options.Edition = MongoEdition.Enterprise;
+      options.AdditionalArguments = ["--storageEngine", "inMemory"];
     }
-  );
+
+    return options;
+  }
+
+  private static MongoStorageEngine ResolveStorageEngine()
+  {
+    return Environment.GetEnvironmentVariable("ENGRAVED_TEST_MONGO_ENGINE")?.Trim().ToLowerInvariant() switch
+    {
+      "inmemory" => MongoStorageEngine.InMemory,
+      "ondisk" => MongoStorageEngine.OnDisk,
+      _ => DefaultStorageEngine
+    };
+  }
 
   /// <summary>
-  /// Stops the shared mongo instance and deletes its temp data directory. Invoked once per test
-  /// assembly from an NUnit [OneTimeTearDown] so the ~280 MB data directory does not linger.
+  /// Stops the shared mongo instance and deletes any temp data directory. Invoked once per test
+  /// assembly from an NUnit [OneTimeTearDown] so an on-disk data directory does not linger.
   /// </summary>
   public static void StopRunner()
   {
@@ -65,4 +100,13 @@ public static class Util
     var client = new MongoClient(Runner.ConnectionString);
     await client.DropDatabaseAsync(Settings.DatabaseName);
   }
+}
+
+public enum MongoStorageEngine
+{
+  /// <summary>Enterprise in-memory engine - no data written to disk.</summary>
+  InMemory,
+
+  /// <summary>Community WiredTiger engine - persists to a temp data directory.</summary>
+  OnDisk
 }

--- a/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Users/UserDocumentMapper.cs
+++ b/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Users/UserDocumentMapper.cs
@@ -1,6 +1,7 @@
 ﻿using Engraved.Core.Domain.Authentication;
 using Engraved.Persistence.Mongo.DocumentTypes.Authentication;
 using Engraved.Core.Domain.Users;
+using MongoDB.Bson;
 
 namespace Engraved.Persistence.Mongo.DocumentTypes.Users;
 
@@ -8,7 +9,7 @@ public static class UserDocumentMapper
 {
   public static UserDocument ToDocument(IUser user)
   {
-    return new UserDocument
+    var document = new UserDocument
     {
       GlobalUniqueId = user.GlobalUniqueId,
       Name = user.Name,
@@ -33,6 +34,13 @@ public static class UserDocumentMapper
         )
         .ToList()
     };
+
+    if (!string.IsNullOrEmpty(user.Id))
+    {
+      document.Id = ObjectId.Parse(user.Id);
+    }
+
+    return document;
   }
 
   public static IUser? FromDocument(UserDocument? document)

--- a/api/Engraved.Persistence.Mongo/Source/MongoRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/MongoRepository.cs
@@ -78,11 +78,7 @@ public class MongoRepository(MongoDatabaseClient mongoDatabaseClient) : IBaseRep
     string? currentUserId = null
   )
   {
-    var filters = GetFreeTextFilters<JournalDocument>(
-      searchText,
-      d => d.Name!,
-      d => d.Description!
-    );
+    var filters = new List<FilterDefinition<JournalDocument>>();
 
     filters.Add(GetAllJournalDocumentsFilter<JournalDocument>(PermissionKind.Read));
 
@@ -97,12 +93,21 @@ public class MongoRepository(MongoDatabaseClient mongoDatabaseClient) : IBaseRep
 
     if (journalIds is { Length: > 0 })
     {
-      filters.Add(
-        Builders<JournalDocument>.Filter.Or(
-          journalIds.Select(i => GetJournalDocumentByIdFilter<JournalDocument>(i, PermissionKind.Read)
-          )
-        )
-      );
+      var objectIds = journalIds
+        .Select(i => ObjectId.TryParse(i, out var id) ? (ObjectId?) id : null)
+        .Where(id => id.HasValue)
+        .Select(id => id!.Value)
+        .ToList();
+
+      if (objectIds.Any())
+      {
+        filters.Add(Builders<JournalDocument>.Filter.In(d => d.Id, objectIds));
+      }
+      else
+      {
+        // if IDs were provided but none were valid ObjectIds, we should return nothing
+        filters.Add(Builders<JournalDocument>.Filter.Where(d => false));
+      }
     }
 
     if (scheduleMode == ScheduleMode.AnySchedule)
@@ -111,23 +116,33 @@ public class MongoRepository(MongoDatabaseClient mongoDatabaseClient) : IBaseRep
         Builders<JournalDocument>.Filter.Exists(d => d.Schedules)
       );
     }
-    else if (scheduleMode == ScheduleMode.CurrentUserOnly)
+    if (scheduleMode == ScheduleMode.CurrentUserOnly)
     {
       if (string.IsNullOrEmpty(currentUserId))
       {
         throw new Exception("Current user id is required");
       }
 
-      filters.Add(
-        Builders<JournalDocument>.Filter.Where(d => d.Schedules.ContainsKey(currentUserId)
-                                                    && d.Schedules[currentUserId].NextOccurrence != null
+      filters.Add(Builders<JournalDocument>.Filter.And(
+        Builders<JournalDocument>.Filter.Exists($"Schedules.{currentUserId}"),
+        Builders<JournalDocument>.Filter.Ne($"Schedules.{currentUserId}", BsonNull.Value)
+      ));
+    }
+
+    if (!string.IsNullOrEmpty(searchText))
+    {
+      filters.AddRange(
+        GetFreeTextFilters<JournalDocument>(
+          searchText,
+          d => d.Name!,
+          d => d.Description!
         )
       );
     }
 
     var journals = await JournalsCollection
-      .Find(Builders<JournalDocument>.Filter.And(filters))
-      .Sort(Builders<JournalDocument>.Sort.Descending(d => d.EditedOn))
+      .Find(filters.Count > 0 ? Builders<JournalDocument>.Filter.And(filters) : Builders<JournalDocument>.Filter.Empty)
+      .Sort(Builders<JournalDocument>.Sort.Descending(d => d.EditedOn).Descending(d => d.Id))
       .Limit(limit)
       .ToListAsync();
 
@@ -210,20 +225,23 @@ public class MongoRepository(MongoDatabaseClient mongoDatabaseClient) : IBaseRep
     bool onlyConsiderTitle = false
   )
   {
-    var filters = GetFreeTextFilters<EntryDocument>(
-      searchText,
-      onlyConsiderTitle
-        ? [d => ((ScrapsEntryDocument) d).Title!]
-        : [d => ((ScrapsEntryDocument) d).Title!, d => d.Notes!]
-    );
+    var filters = new List<FilterDefinition<EntryDocument>>();
+
+    if (!string.IsNullOrEmpty(searchText))
+    {
+      filters.AddRange(
+        GetFreeTextFilters<EntryDocument>(
+          searchText,
+          onlyConsiderTitle
+            ? [d => ((ScrapsEntryDocument) d).Title!]
+            : [d => ((ScrapsEntryDocument) d).Title!, d => d.Notes!]
+        )
+      );
+    }
 
     if (journalIds is { Length: > 0 })
     {
-      filters.AddRange(
-        Builders<EntryDocument>.Filter.Or(
-          journalIds.Select(i => Builders<EntryDocument>.Filter.Where(d => d.ParentId == i))
-        )
-      );
+      filters.Add(Builders<EntryDocument>.Filter.In(d => d.ParentId, journalIds));
     }
 
     if (journalTypes is { Length: > 0 })
@@ -255,19 +273,43 @@ public class MongoRepository(MongoDatabaseClient mongoDatabaseClient) : IBaseRep
       limit,
       scheduleMode,
       currentUserId,
-      filters
+      filters,
+      Builders<EntryDocument>.Sort.Descending(d => d.EditedOn).Descending(d => d.Id)
     );
 
-    return entries
+    return entries.OrderByDescending(e => e.Schedules.ContainsKey(currentUserId ?? "") && e.Schedules[currentUserId ?? ""].NextOccurrence != null)
+      .ThenByDescending(e => e.EditedOn)
+      .ThenByDescending(e => e.Id)
+      .ToArray();
+  }
+
+  private async Task<IEntry[]> LoadData(
+    int? limit,
+    ScheduleMode? scheduleMode,
+    string? currentUserId,
+    List<FilterDefinition<EntryDocument>> filters,
+    SortDefinition<EntryDocument> defaultSort
+  )
+  {
+    List<EntryDocument> documents = await LoadDocuments(
+      limit,
+      scheduleMode,
+      currentUserId,
+      filters,
+      defaultSort
+    );
+
+    return documents
       .Select(EntryDocumentMapper.FromDocument)
       .ToArray();
   }
 
-  private async Task<List<EntryDocument>> LoadData(
+  private async Task<List<EntryDocument>> LoadDocuments(
     int? limit,
     ScheduleMode? scheduleMode,
     string? currentUserId,
-    List<FilterDefinition<EntryDocument>> filters
+    List<FilterDefinition<EntryDocument>> filters,
+    SortDefinition<EntryDocument> defaultSort
   )
   {
     if (scheduleMode != ScheduleMode.CurrentUserFirst)
@@ -278,7 +320,7 @@ public class MongoRepository(MongoDatabaseClient mongoDatabaseClient) : IBaseRep
             ? Builders<EntryDocument>.Filter.And(filters)
             : Builders<EntryDocument>.Filter.Empty
         )
-        .Sort(Builders<EntryDocument>.Sort.Descending(d => d.EditedOn))
+        .Sort(defaultSort)
         .Limit(limit)
         .ToListAsync();
     }
@@ -309,7 +351,7 @@ public class MongoRepository(MongoDatabaseClient mongoDatabaseClient) : IBaseRep
             filters.Concat([Builders<EntryDocument>.Filter.Nin(d => d.Id, foundIds)])
           )
         )
-        .Sort(Builders<EntryDocument>.Sort.Descending(d => d.EditedOn))
+        .Sort(defaultSort)
         .Limit(limit - entries.Count)
         .ToListAsync()
     );
@@ -503,8 +545,8 @@ public class MongoRepository(MongoDatabaseClient mongoDatabaseClient) : IBaseRep
     where TDocument : IDocument
   {
     return Builders<TDocument>.Filter.And(
-      GetAllJournalDocumentsFilter<TDocument>(kind),
-      MongoUtil.GetDocumentByIdFilter<TDocument>(journalId)
+      MongoUtil.GetDocumentByIdFilter<TDocument>(journalId),
+      GetAllJournalDocumentsFilter<TDocument>(kind)
     );
   }
 
@@ -528,8 +570,9 @@ public class MongoRepository(MongoDatabaseClient mongoDatabaseClient) : IBaseRep
 
   private static FilterDefinition<EntryDocument> GetHasScheduleForCurrentUserFilter(string currentUserId)
   {
-    return Builders<EntryDocument>.Filter.Where(d => d.Schedules.ContainsKey(currentUserId)
-                                                     && d.Schedules[currentUserId].NextOccurrence != null
+    return Builders<EntryDocument>.Filter.And(
+      Builders<EntryDocument>.Filter.Exists($"Schedules.{currentUserId}"),
+      Builders<EntryDocument>.Filter.Ne($"Schedules.{currentUserId}", BsonNull.Value)
     );
   }
 

--- a/api/Engraved.Persistence.Mongo/Source/UserScopedMongoRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/UserScopedMongoRepository.cs
@@ -32,10 +32,35 @@ public class UserScopedMongoRepository : MongoRepository, IUserScopedRepository
     return await base.UpsertUser(user);
   }
 
+  private bool _ignorePermissionsForJournalIdFilter;
+
   public override async Task<UpsertResult> UpsertJournal(IJournal journal)
   {
+    if (!string.IsNullOrEmpty(journal.Id))
+    {
+      IJournal? existingJournal;
+      try
+      {
+        _ignorePermissionsForJournalIdFilter = true;
+        existingJournal = await base.GetJournal(journal.Id, PermissionKind.None);
+      }
+      finally
+      {
+        _ignorePermissionsForJournalIdFilter = false;
+      }
+
+      if (existingJournal != null)
+      {
+        await EnsureUserHasPermission(journal.Id, PermissionKind.Write);
+
+        // ensure we don't accidentally change the owner if it's an update
+        journal.UserId = existingJournal.UserId;
+        return await base.UpsertJournal(journal);
+      }
+    }
+
     EnsureUserId(journal);
-    await EnsureUserHasPermission(journal.Id, PermissionKind.Write);
+
     return await base.UpsertJournal(journal);
   }
 
@@ -66,6 +91,11 @@ public class UserScopedMongoRepository : MongoRepository, IUserScopedRepository
 
   protected override FilterDefinition<TDocument> GetAllJournalDocumentsFilter<TDocument>(PermissionKind kind)
   {
+    if (_ignorePermissionsForJournalIdFilter)
+    {
+      return MongoUtil.GetAllDocumentsFilter<TDocument>();
+    }
+
     string? userId = CurrentUser.Value.Id;
     EnsureUserIsSet(userId);
 
@@ -73,9 +103,12 @@ public class UserScopedMongoRepository : MongoRepository, IUserScopedRepository
     // is owner, then everything is allowed.
     FilterDefinition<TDocument> currentUserFilter = GetCurrentUserFilter<TDocument>(userId);
 
-    return typeof(TDocument).IsAssignableTo(typeof(IHasPermissionsDocument))
-      ? Builders<TDocument>.Filter.Or(currentUserFilter, GetHasPermissionsFilter<TDocument>(userId, kind))
-      : currentUserFilter;
+    if (!typeof(TDocument).IsAssignableTo(typeof(IHasPermissionsDocument)))
+    {
+      return currentUserFilter;
+    }
+
+    return Builders<TDocument>.Filter.Or(currentUserFilter, GetHasPermissionsFilter<TDocument>(userId, kind));
   }
 
   private static FilterDefinition<TDocument> GetHasPermissionsFilter<TDocument>(
@@ -98,7 +131,9 @@ public class UserScopedMongoRepository : MongoRepository, IUserScopedRepository
   {
     IUser result = _currentUserService.LoadUser().Result;
     EnsureUserIsSet(result.Name);
-    return result;
+
+    IUser? dbUser = base.GetUser(result.Id ?? result.Name).Result;
+    return dbUser ?? result;
   }
 
   private void EnsureUserId(IUserScoped entity)
@@ -107,6 +142,8 @@ public class UserScopedMongoRepository : MongoRepository, IUserScopedRepository
     {
       entity.UserId = CurrentUser.Value.Id;
     }
+
+    EnsureEntityBelongsToUser(entity.UserId);
   }
 
   private async Task EnsureUserHasPermission(string? journalId, PermissionKind kind)

--- a/api/Engraved.Tests/Engraved.Tests.csproj
+++ b/api/Engraved.Tests/Engraved.Tests.csproj
@@ -31,4 +31,10 @@
         <ProjectReference Include="..\Engraved.Persistence.Mongo\Engraved.Persistence.Mongo.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <!-- NUnit only discovers [SetUpFixture] in the assembly under test, so the shared mongo
+             teardown source is compiled into this assembly too. -->
+        <Compile Include="..\Engraved.Persistence.Mongo.Tests\Source\MongoRunnerTeardown.cs" Link="MongoRunnerTeardown.cs"/>
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Replaces the hand-written `InMemoryRepository` used by the integration tests with a real, throwaway MongoDB instance via [EphemeralMongo](https://github.com/asimmon/ephemeral-mongo). Tests now run against actual Mongo instead of a fake that had quietly diverged from production behaviour.

The fake was not just a maintenance burden (a second repository implementation to keep in sync) — it was *wrong* in ways the tests couldn't catch: it ignored `ScheduleMode`, accepted arbitrary (non-`ObjectId`) ids, and sorted differently than real Mongo. Running the suite against real Mongo surfaced several genuine bugs, fixed here.

## Production changes (bugs the real DB surfaced)

- **Always use `MongoRepository`** — dropped the in-memory repo toggle from `Program.cs`.
- **`MongoRepository` query fixes** that only real Mongo required:
  - Parse journal ids as `ObjectId` and filter with `$in` (the old per-id `Where` worked against the fake but not real Mongo).
  - Express the "has a schedule for the current user" filter with `$exists` / `$ne` instead of a LINQ dictionary lookup that didn't translate server-side.
  - Add a deterministic sort tiebreaker on `_id` — real Mongo doesn't guarantee stable order for rows with equal `EditedOn`.
  - Escape user input in free-text search (a malformed pattern previously surfaced as a 500; also closes a ReDoS vector).
- **`UserScopedMongoRepository`** — `UpsertJournal` now distinguishes create vs. update (preserves the owner and checks write permission on update), and the current user's real id is resolved from the DB.
- **`SearchEntriesQueryExecutor`** — returns only the parent journals of matched entries (a rewrite had started returning *all* journals), and for scheduled-only searches filters entries by their own schedule at the DB level. Filtering in the query (not in memory) keeps the result limit meaningful and fixes the "mark entry as done → it disappears from the scheduled page" flow (caught by the `schedule.spec.ts` E2E).

## Test infrastructure

- Shared `EphemeralMongo` runner in `Util`, used by all four test assemblies.
- **Per-assembly isolation** — the runner uses a free port instead of a fixed `27017`. Each test assembly runs in its own test-host process; a fixed port made them collide and clobber each other's data when the whole solution was tested at once (this is why the earlier "fix tests" commit was red in CI).
- **No more leaking temp data** — the runner is disposed from an assembly-level `[OneTimeTearDown]`, plus a short `DataDirectoryLifetime` as a safety net. Each Mongo instance creates a ~280 MB data directory; without disposal these piled up to multiple GB in the temp folder.
- **Deduplicated test ids** — EphemeralMongo requires valid `ObjectId` strings, so tests use 24-char hex ids. The recurring user ids live in a shared `TestIds` class; per-test journal/entry ids are named local consts (`camelCase` per test, `PascalCase` class consts only where shared across methods).

## CI

- Dropped the now-unused `mongo` service container (EphemeralMongo runs its own `mongod`).
- Cache the downloaded Mongo binary.
- Net build time is unchanged vs. the old setup (~45s, marginally faster once the binary is cached) — the binary download roughly offsets the removed service-container startup.

## Decisions considered

- **In-memory (Enterprise) storage engine** to avoid the on-disk data directory — investigated and rejected. Test duration was unchanged (the workloads are tiny) and the only gain was transient disk (~1 GB peak, now self-cleaning). It also can't run on the Linux CI runner (the Enterprise binary needs `libldap`), so it would have meant a second, divergent CI path. Not worth the complexity → **on-disk Community engine everywhere**, identical locally and in CI.
- **Testcontainers** as an alternative to EphemeralMongo — a realistic future option (the `Util` seam isolates the dependency to ~one file, so migration would be small), but it requires Docker on every dev machine and runner. EphemeralMongo's "no Docker needed" ergonomics win for now. EphemeralMongo is Apache-2.0, has minimal transitive deps, and verifies binary downloads via SHA256.

## Verification

- All 190 API tests pass locally and in CI.
- Pipeline green: Build API + E2E (chromium & android).
