### PR TITLE
Split IBaseRepository into role-based interfaces (#2877)

### DIFF
--- a/api/Engraved.Core/Source/Application/Persistence/IBaseRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IBaseRepository.cs
@@ -1,66 +1,10 @@
-using Engraved.Core.Domain.Entries;
-using Engraved.Core.Domain.Journals;
-using Engraved.Core.Domain.Permissions;
-using Engraved.Core.Domain.Users;
-
 namespace Engraved.Core.Application.Persistence;
 
+// Composes the cohesive, role-based persistence interfaces. Kept as an umbrella
+// so existing consumers (and the DI markers IRepository / IUserScopedRepository)
+// continue to see the full surface, while new code can depend on just the
+// narrow role interface(s) it actually needs.
 public interface IBaseRepository
+  : IUserRepository, IJournalRepository, IEntryRepository, IMaintenanceRepository
 {
-  Task<IUser?> GetUser(string nameOrId);
-
-  Task<UpsertResult> UpsertUser(IUser user);
-
-  Task<IUser[]> GetUsers(params string[] userIds);
-
-  Task<IUser[]> GetAllUsers();
-
-  Task<IJournal[]> GetAllJournals(
-    string? searchText = null,
-    ScheduleMode? scheduleMode = null,
-    JournalType[]? journalTypes = null,
-    string[]? journalIds = null,
-    int? limit = null,
-    string? currentUserId = null
-  );
-
-  Task<IJournal?> GetJournal(string journalId);
-
-  Task<UpsertResult> UpsertJournal(IJournal journal);
-
-  Task DeleteJournal(string journalId);
-
-  Task ModifyJournalPermissions(string journalId, Dictionary<string, PermissionKind> permissions);
-
-  Task<IEntry[]> GetEntriesForJournal(
-    string journalId,
-    DateTime? fromDate = null,
-    DateTime? toDate = null,
-    IDictionary<string, string[]>? attributeValues = null,
-    string? searchText = null
-  );
-
-  Task<IEntry[]> SearchEntries(
-    string? searchText = null,
-    ScheduleMode? scheduleMode = null,
-    JournalType[]? journalTypes = null,
-    string[]? journalIds = null,
-    int? limit = null,
-    string? currentUserId = null,
-    bool onlyConsiderTitle = false
-  );
-
-  Task<UpsertResult> UpsertEntry<TEntry>(TEntry entry) where TEntry : IEntry;
-
-  Task DeleteEntry(string entryId);
-
-  Task<IEntry?> GetEntry(string entryId);
-
-  Task WakeMeUp();
-
-  Task<long> CountAllUsers();
-
-  Task<long> CountAllEntries();
-
-  Task<long> CountAllJournals();
 }

--- a/api/Engraved.Core/Source/Application/Persistence/IEntryRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IEntryRepository.cs
@@ -1,0 +1,33 @@
+using Engraved.Core.Domain.Entries;
+using Engraved.Core.Domain.Journals;
+
+namespace Engraved.Core.Application.Persistence;
+
+public interface IEntryRepository
+{
+  Task<IEntry[]> GetEntriesForJournal(
+    string journalId,
+    DateTime? fromDate = null,
+    DateTime? toDate = null,
+    IDictionary<string, string[]>? attributeValues = null,
+    string? searchText = null
+  );
+
+  Task<IEntry[]> SearchEntries(
+    string? searchText = null,
+    ScheduleMode? scheduleMode = null,
+    JournalType[]? journalTypes = null,
+    string[]? journalIds = null,
+    int? limit = null,
+    string? currentUserId = null,
+    bool onlyConsiderTitle = false
+  );
+
+  Task<UpsertResult> UpsertEntry<TEntry>(TEntry entry) where TEntry : IEntry;
+
+  Task DeleteEntry(string entryId);
+
+  Task<IEntry?> GetEntry(string entryId);
+
+  Task<long> CountAllEntries();
+}

--- a/api/Engraved.Core/Source/Application/Persistence/IJournalRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IJournalRepository.cs
@@ -1,0 +1,26 @@
+using Engraved.Core.Domain.Journals;
+using Engraved.Core.Domain.Permissions;
+
+namespace Engraved.Core.Application.Persistence;
+
+public interface IJournalRepository
+{
+  Task<IJournal[]> GetAllJournals(
+    string? searchText = null,
+    ScheduleMode? scheduleMode = null,
+    JournalType[]? journalTypes = null,
+    string[]? journalIds = null,
+    int? limit = null,
+    string? currentUserId = null
+  );
+
+  Task<IJournal?> GetJournal(string journalId);
+
+  Task<UpsertResult> UpsertJournal(IJournal journal);
+
+  Task DeleteJournal(string journalId);
+
+  Task ModifyJournalPermissions(string journalId, Dictionary<string, PermissionKind> permissions);
+
+  Task<long> CountAllJournals();
+}

--- a/api/Engraved.Core/Source/Application/Persistence/IMaintenanceRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IMaintenanceRepository.cs
@@ -1,0 +1,6 @@
+namespace Engraved.Core.Application.Persistence;
+
+public interface IMaintenanceRepository
+{
+  Task WakeMeUp();
+}

--- a/api/Engraved.Core/Source/Application/Persistence/IUserRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IUserRepository.cs
@@ -1,0 +1,16 @@
+using Engraved.Core.Domain.Users;
+
+namespace Engraved.Core.Application.Persistence;
+
+public interface IUserRepository
+{
+  Task<IUser?> GetUser(string nameOrId);
+
+  Task<UpsertResult> UpsertUser(IUser user);
+
+  Task<IUser[]> GetUsers(params string[] userIds);
+
+  Task<IUser[]> GetAllUsers();
+
+  Task<long> CountAllUsers();
+}


### PR DESCRIPTION
Implements the lower-risk first step discussed in #2877: split the fat `IBaseRepository` contract into cohesive, role-based interfaces.

## What
- New role interfaces in `Engraved.Core`: `IUserRepository`, `IJournalRepository`, `IEntryRepository`, `IMaintenanceRepository`.
- `IBaseRepository` now simply **composes** them and has no members of its own.

## Why this is low-risk
- All existing consumers and the DI markers (`IRepository` / `IUserScopedRepository`) still see the exact same surface, so there are **no DI changes and no behavioral change**.
- Single implementation: `MongoRepository` keeps implementing the whole surface via the composed interface.
- New code can now depend on just the narrow role interface(s) it actually needs.

## Scope / caveats
- This is consumer-facing interface segregation (ISP). It deliberately does **not** migrate consumers yet, and it does **not** shrink `MongoRepository.cs` — physically splitting the implementation is a separate, optional later step.
- Migrating consumers to narrow interfaces still needs the scoped-vs-unscoped DI resolution worked out (the design question raised in the issue).

## Verification
- `Engraved.Core` builds clean.
- Core unit tests: 76 passed. EphemeralMongo integration tests: 91 passed.

Refs #2877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
