### PR TITLE
Pin entry-read permission invariants with tests + docs (#2877)

### DIFF
--- a/api/Engraved.Core/Source/Application/Queries/Entries/Get/GetEntryQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Entries/Get/GetEntryQueryExecutor.cs
@@ -24,7 +24,9 @@ public class GetEntryQueryExecutor(IRepository repository) : IQueryExecutor<IEnt
       return null;
     }
 
-    // permission check
+    // Permission gate (not redundant): GetEntry is an unscoped primitive, so this is where read
+    // access is enforced for the single-entry endpoint. GetJournal is scoped, so it returns null
+    // when the current user cannot read the parent journal - in which case we hide the entry.
     IJournal? journal = await repository.GetJournal(entry.ParentId);
     if (journal == null)
     {

--- a/api/Engraved.Persistence.Mongo.Tests/Source/UserScopedMongoRepository_Permissions_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/UserScopedMongoRepository_Permissions_Should.cs
@@ -321,6 +321,37 @@ public class UserScopedMongoRepository_Permissions_Should
     (await _repository.GetEntry(entryId)).Should().BeNull();
   }
 
+  [Test]
+  public async Task GetEntry_IsUnscoped_ReturnsEntry_EvenWithoutJournalPermission()
+  {
+    // GetEntry is intentionally an unscoped primitive: it does NOT enforce read permission on the
+    // parent journal. Read enforcement for the client-facing single-entry endpoint lives in
+    // GetEntryQueryExecutor (which re-checks via the scoped GetJournal), while write paths enforce
+    // at upsert/delete time. This test pins that contract so moving scoping into the repository
+    // becomes a conscious, test-breaking decision rather than an accidental behavioral change.
+    string journalId = await CreateJournalForOtherUser();
+    string entryId = await AddEntryForOtherUser(journalId);
+
+    IEntry? entry = await _userScopedRepository.GetEntry(entryId);
+
+    entry.Should().NotBeNull();
+  }
+
+  [Test]
+  public async Task SearchEntries_IsUnscoped_TrustsCallerProvidedJournalIds()
+  {
+    // SearchEntries does not enforce journal read-permission; it trusts the journalIds passed by the
+    // caller. SearchEntriesQueryExecutor is responsible for passing only the current user's
+    // accessible journals (obtained via the scoped GetAllJournals). Pinned here so the "unsecured"
+    // contract is explicit rather than accidental.
+    string journalId = await CreateJournalForOtherUser();
+    await AddEntryForOtherUser(journalId);
+
+    IEntry[] entries = await _userScopedRepository.SearchEntries(null, null, null, [journalId]);
+
+    entries.Should().HaveCount(1);
+  }
+
   private async Task<string> AddEntryForOtherUser(string journalId)
   {
     UpsertResult result = await _repository.UpsertEntry(

--- a/api/Engraved.Persistence.Mongo/Source/MongoRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/MongoRepository.cs
@@ -213,8 +213,11 @@ public class MongoRepository(MongoDatabaseClient mongoDatabaseClient) : IBaseRep
       .ToArray();
   }
 
-  // attention: there's no security here for the moment. might not be required as
-  // you explicitly need to specify the journal IDs.
+  // Unscoped primitive: this method does NOT enforce journal read-permission. It trusts the
+  // journalIds supplied by the caller. The only scoped caller, SearchEntriesQueryExecutor, first
+  // resolves the current user's accessible journals (via the scoped GetAllJournals) and passes
+  // those ids in, so read access is enforced there. Pinned by
+  // UserScopedMongoRepository_Permissions_Should.SearchEntries_IsUnscoped_TrustsCallerProvidedJournalIds.
   public async Task<IEntry[]> SearchEntries(
     string? searchText,
     ScheduleMode? scheduleMode = null,
@@ -423,6 +426,11 @@ public class MongoRepository(MongoDatabaseClient mongoDatabaseClient) : IBaseRep
     await EntriesCollection.DeleteOneAsync(MongoUtil.GetDocumentByIdFilter<EntryDocument>(entryId));
   }
 
+  // Unscoped primitive: GetEntry does NOT enforce read-permission on the parent journal (note it is
+  // not overridden in UserScopedMongoRepository). The client-facing single-entry read enforces
+  // access in GetEntryQueryExecutor; command executors use it as a load-for-modify primitive and
+  // rely on the subsequent UpsertEntry/DeleteEntry write checks. Pinned by
+  // UserScopedMongoRepository_Permissions_Should.GetEntry_IsUnscoped_ReturnsEntry_EvenWithoutJournalPermission.
   public async Task<IEntry?> GetEntry(string entryId)
   {
     if (string.IsNullOrEmpty(entryId))


### PR DESCRIPTION
Addresses the "enforcement is inconsistent" point from #2877 with the **minimal, tests-and-docs-only** option (no runtime behavior change).

## Finding
Entry read-permission enforcement is **correct today**, but it lives implicitly in the executors by convention, which is the real fragility:
- `GetEntryQueryExecutor` re-checks access via the scoped `GetJournal`.
- `SearchEntriesQueryExecutor` restricts the search to the current user's accessible journals before calling `SearchEntries`.

There is **no active leak** — so this PR makes the contract explicit rather than changing behavior.

## What
- **Tests**: two EphemeralMongo tests pinning that scoped `GetEntry` and `SearchEntries` are *unscoped primitives* (enforcement is the caller's/executor's responsibility). This locks the contract so any future move of scoping into the repository becomes a conscious, test-breaking decision.
- **Docs**:
  - Rewrote the misleading `"no security for the moment"` comment on `SearchEntries` to describe the actual contract and where access is enforced.
  - Documented `GetEntry` as an unscoped load-for-modify primitive (note it is intentionally not overridden in `UserScopedMongoRepository`).
  - Clarified in `GetEntryQueryExecutor` that the `GetJournal` call is the read-access gate (not redundant).

## Verification
- EphemeralMongo integration tests: 93 passed (+2 new). Core unit tests: 76 passed.
- No runtime change.

Refs #2877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
