### PR TITLE
Inject narrow role repositories into executors (#2877)

### DIFF
--- a/api/Engraved.Api/Source/Program.cs
+++ b/api/Engraved.Api/Source/Program.cs
@@ -116,6 +116,15 @@ builder.Services.AddTransient<Lazy<IUser>>(provider => provider.GetService<IUser
 builder.Services.AddTransient<IRepository>(provider => provider.GetService<IUserScopedRepository>()!
 );
 
+// The narrow, role-based persistence interfaces resolve to the user-scoped repository (same as
+// IRepository), so executors that depend on just the role(s) they use transparently get permission
+// enforcement. The non-scoped IBaseRepository remains for the few consumers that must run without a
+// user context (auth/login, the notification job, health endpoints).
+builder.Services.AddTransient<IUserRepository>(provider => provider.GetService<IUserScopedRepository>()!);
+builder.Services.AddTransient<IJournalRepository>(provider => provider.GetService<IUserScopedRepository>()!);
+builder.Services.AddTransient<IEntryRepository>(provider => provider.GetService<IUserScopedRepository>()!);
+builder.Services.AddTransient<IMaintenanceRepository>(provider => provider.GetService<IUserScopedRepository>()!);
+
 builder.Services.AddSingleton(new E2ETestMode(isE2ETests));
 builder.Services.AddMemoryCache();
 builder.Services.AddTransient<QueryCache>();

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Delete/DeleteEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Delete/DeleteEntryCommandExecutorShould.cs
@@ -46,7 +46,7 @@ public class DeleteEntryCommandExecutorShould
     );
 
     // when
-    CommandResult result = await new DeleteEntryCommandExecutor(_repo, _dateService).Execute(
+    CommandResult result = await new DeleteEntryCommandExecutor(_repo, _repo, _dateService).Execute(
       new DeleteEntryCommand { Id = entryId }
     );
 
@@ -66,7 +66,7 @@ public class DeleteEntryCommandExecutorShould
     const string missingEntryId = "60703c3b0000000000000004";
 
     // when
-    CommandResult result = await new DeleteEntryCommandExecutor(_repo, _dateService).Execute(
+    CommandResult result = await new DeleteEntryCommandExecutor(_repo, _repo, _dateService).Execute(
       new DeleteEntryCommand { Id = missingEntryId }
     );
 

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Move/MoveEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Move/MoveEntryCommandExecutorShould.cs
@@ -48,6 +48,7 @@ public class MoveEntryCommandExecutorShould
     // when
     await new MoveEntryCommandExecutor(
       _repo,
+      _repo,
       _dateService
     ).Execute(
       new MoveEntryCommand

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertCounterEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertCounterEntryCommandExecutorShould.cs
@@ -28,7 +28,7 @@ public class UpsertCounterEntryCommandExecutorShould
     await _testRepository.UpsertJournal(new CounterJournal { Id = journalId });
 
     var command = new UpsertCounterEntryCommand { JournalId = journalId, Notes = "foo" };
-    await new UpsertCounterEntryCommandExecutor(_testRepository, new FakeDateService()).Execute(command);
+    await new UpsertCounterEntryCommandExecutor(_testRepository, _testRepository,new FakeDateService()).Execute(command);
 
     (await _testRepository.CountAllEntries()).Should().Be(1);
     (await _testRepository.GetEntriesForJournal(journalId)).First().Notes.Should().Be("foo");
@@ -44,7 +44,7 @@ public class UpsertCounterEntryCommandExecutorShould
 
     var createCommand = new UpsertGaugeEntryCommand { JournalId = journalId, Notes = "foo", Value = 123 };
 
-    var commandExecutor = new UpsertGaugeEntryCommandExecutor(_testRepository, dateService);
+    var commandExecutor = new UpsertGaugeEntryCommandExecutor(_testRepository, _testRepository,dateService);
     CommandResult result = await commandExecutor.Execute(createCommand);
 
     var updateCommand = new UpsertGaugeEntryCommand
@@ -55,7 +55,7 @@ public class UpsertCounterEntryCommandExecutorShould
       Value = 42
     };
 
-    commandExecutor = new UpsertGaugeEntryCommandExecutor(_testRepository, dateService);
+    commandExecutor = new UpsertGaugeEntryCommandExecutor(_testRepository, _testRepository,dateService);
     await commandExecutor.Execute(updateCommand);
 
     (await _testRepository.CountAllEntries()).Should().Be(1);
@@ -75,7 +75,7 @@ public class UpsertCounterEntryCommandExecutorShould
 
     async Task Action()
     {
-      await new UpsertCounterEntryCommandExecutor(_testRepository, new FakeDateService()).Execute(command);
+      await new UpsertCounterEntryCommandExecutor(_testRepository, _testRepository,new FakeDateService()).Execute(command);
     }
   }
 
@@ -93,7 +93,7 @@ public class UpsertCounterEntryCommandExecutorShould
 
     async Task Action()
     {
-      await new UpsertCounterEntryCommandExecutor(_testRepository, new FakeDateService()).Execute(command);
+      await new UpsertCounterEntryCommandExecutor(_testRepository, _testRepository,new FakeDateService()).Execute(command);
     }
   }
 }

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertGaugeEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertGaugeEntryCommandExecutorShould.cs
@@ -36,7 +36,7 @@ public class UpsertGaugeEntryCommandExecutorShould
     };
 
     CommandResult commandResult =
-      await new UpsertGaugeEntryCommandExecutor(_testRepository, new FakeDateService()).Execute(command);
+      await new UpsertGaugeEntryCommandExecutor(_testRepository, _testRepository,new FakeDateService()).Execute(command);
 
     commandResult.EntityId.Should().NotBeEmpty();
     (await _testRepository.CountAllEntries()).Should().Be(1);
@@ -64,7 +64,7 @@ public class UpsertGaugeEntryCommandExecutorShould
 
     Assert.ThrowsAsync<InvalidCommandException>(async () =>
       {
-        await new UpsertGaugeEntryCommandExecutor(_testRepository, new FakeDateService()).Execute(command);
+        await new UpsertGaugeEntryCommandExecutor(_testRepository, _testRepository,new FakeDateService()).Execute(command);
       }
     );
   }
@@ -106,7 +106,7 @@ public class UpsertGaugeEntryCommandExecutorShould
       }
     };
 
-    await new UpsertGaugeEntryCommandExecutor(_testRepository, new FakeDateService()).Execute(command);
+    await new UpsertGaugeEntryCommandExecutor(_testRepository, _testRepository,new FakeDateService()).Execute(command);
 
     (await _testRepository.CountAllEntries()).Should().Be(1);
 
@@ -156,7 +156,7 @@ public class UpsertGaugeEntryCommandExecutorShould
 
     Assert.ThrowsAsync<InvalidCommandException>(async () =>
       {
-        await new UpsertGaugeEntryCommandExecutor(_testRepository, new FakeDateService()).Execute(command);
+        await new UpsertGaugeEntryCommandExecutor(_testRepository, _testRepository,new FakeDateService()).Execute(command);
       }
     );
   }

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertLogBookEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertLogBookEntryCommandExecutorShould.cs
@@ -37,7 +37,7 @@ public class UpsertLogBookEntryCommandExecutorShould
     };
 
     CommandResult result =
-      await new UpsertLogBookEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
+      await new UpsertLogBookEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
 
     result.EntityId.Should().NotBeNull();
     (await _testRepository.CountAllEntries()).Should().Be(1);
@@ -55,7 +55,7 @@ public class UpsertLogBookEntryCommandExecutorShould
     };
 
     Func<Task> func = async ()
-      => await new UpsertLogBookEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
+      => await new UpsertLogBookEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
 
     func.Should().ThrowAsync<InvalidCommandException>();
   }
@@ -71,7 +71,7 @@ public class UpsertLogBookEntryCommandExecutorShould
     };
 
     Func<Task> func = async ()
-      => await new UpsertLogBookEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
+      => await new UpsertLogBookEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
 
     func.Should().ThrowAsync<InvalidCommandException>();
   }
@@ -87,7 +87,7 @@ public class UpsertLogBookEntryCommandExecutorShould
     };
 
     Func<Task> func = async ()
-      => await new UpsertLogBookEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
+      => await new UpsertLogBookEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
 
     func.Should().ThrowAsync<InvalidCommandException>();
   }
@@ -102,7 +102,7 @@ public class UpsertLogBookEntryCommandExecutorShould
       DateTime = new DateTime(2026, 4, 9, 13, 37, 42, DateTimeKind.Utc)
     };
 
-    await new UpsertLogBookEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
+    await new UpsertLogBookEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
 
     IEntry entry = (await _testRepository.GetEntriesForJournal(JournalId)).Single();
     entry.DateTime.Should().Be(new DateTime(2026, 4, 9, 0, 0, 0, DateTimeKind.Utc));
@@ -133,7 +133,7 @@ public class UpsertLogBookEntryCommandExecutorShould
     };
 
     var func = async ()
-      => await new UpsertLogBookEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
+      => await new UpsertLogBookEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
 
     await func.Should().ThrowAsync<InvalidCommandException>();
   }
@@ -162,7 +162,7 @@ public class UpsertLogBookEntryCommandExecutorShould
       DateTime = existingDate
     };
 
-    await new UpsertLogBookEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
+    await new UpsertLogBookEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
 
     (await _testRepository.CountAllEntries()).Should().Be(1);
     (await _testRepository.GetEntriesForJournal(JournalId)).First().Notes.Should().Be("updated notes");

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertTimerEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertTimerEntryCommandExecutorShould.cs
@@ -38,7 +38,7 @@ public class UpsertTimerEntryCommandExecutorShould
     };
 
     CommandResult result =
-      await new UpsertTimerEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
+      await new UpsertTimerEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
 
     result.EntityId.Should().NotBeNull();
     (await _testRepository.CountAllEntries()).Should().Be(1);
@@ -56,7 +56,7 @@ public class UpsertTimerEntryCommandExecutorShould
     var command = new UpsertTimerEntryCommand { JournalId = JournalId };
 
     CommandResult result =
-      await new UpsertTimerEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
+      await new UpsertTimerEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
 
     result.EntityId.Should().NotBeNull();
     (await _testRepository.CountAllEntries()).Should().Be(1);
@@ -85,7 +85,7 @@ public class UpsertTimerEntryCommandExecutorShould
     var command = new UpsertTimerEntryCommand { JournalId = JournalId };
 
     CommandResult result =
-      await new UpsertTimerEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
+      await new UpsertTimerEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
 
     result.EntityId.Should().NotBeNull();
     (await _testRepository.CountAllEntries()).Should().Be(1);
@@ -125,7 +125,7 @@ public class UpsertTimerEntryCommandExecutorShould
     };
 
     CommandResult result =
-      await new UpsertTimerEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
+      await new UpsertTimerEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
 
     result.EntityId.Should().NotBeNull();
     (await _testRepository.CountAllEntries()).Should().Be(1);
@@ -166,7 +166,7 @@ public class UpsertTimerEntryCommandExecutorShould
     };
 
     CommandResult result =
-      await new UpsertTimerEntryCommandExecutor(_testRepository, _fakeDateService).Execute(command);
+      await new UpsertTimerEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
 
     result.EntityId.Should().NotBeNull();
     (await _testRepository.CountAllEntries()).Should().Be(1);

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Journals/Edit/EditJournalCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Journals/Edit/EditJournalCommandExecutorShould.cs
@@ -72,7 +72,7 @@ public class EditJournalCommandExecutorShould
       }
     );
 
-    await new EditJournalCommandExecutor(_repo, new FakeDateService()).Execute(
+    await new EditJournalCommandExecutor(_repo, _repo, new FakeDateService()).Execute(
       new EditJournalCommand
       {
         JournalId = journalId,
@@ -127,7 +127,7 @@ public class EditJournalCommandExecutorShould
       }
     );
 
-    await new EditJournalCommandExecutor(_repo, new FakeDateService()).Execute(
+    await new EditJournalCommandExecutor(_repo, _repo, new FakeDateService()).Execute(
       new EditJournalCommand
       {
         JournalId = journalId,

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Search/SearchEntitiesQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Search/SearchEntitiesQueryExecutorShould.cs
@@ -84,7 +84,7 @@ public class SearchEntitiesQueryExecutorShould
       }
     );
 
-    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_repo, _dateService);
+    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_repo, _repo, _dateService);
     await addEntryExecutor.Execute(
       new UpsertScrapsEntryCommand
       {
@@ -156,7 +156,7 @@ public class SearchEntitiesQueryExecutorShould
       }
     );
 
-    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_repo, _dateService);
+    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_repo, _repo, _dateService);
     CommandResult entryResult = await addEntryExecutor.Execute(
       new UpsertScrapsEntryCommand
       {
@@ -188,7 +188,7 @@ public class SearchEntitiesQueryExecutorShould
       }
     );
 
-    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_repo, _dateService);
+    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_repo, _repo, _dateService);
     await addEntryExecutor.Execute(
       new UpsertScrapsEntryCommand
       {
@@ -210,7 +210,7 @@ public class SearchEntitiesQueryExecutorShould
       }
     );
 
-    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_repo, _dateService);
+    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_repo, _repo, _dateService);
     await addEntryExecutor.Execute(
       new UpsertScrapsEntryCommand
       {

--- a/api/Engraved.Core/Source/Application/Commands/Entries/Delete/DeleteEntryCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Entries/Delete/DeleteEntryCommandExecutor.cs
@@ -6,25 +6,26 @@ using Engraved.Core.Domain.Notifications;
 namespace Engraved.Core.Application.Commands.Entries.Delete;
 
 public class DeleteEntryCommandExecutor(
-  IRepository repository,
+  IEntryRepository entryRepository,
+  IJournalRepository journalRepository,
   IDateService dateService
 )
   : ICommandExecutor<DeleteEntryCommand>
 {
   public async Task<CommandResult> Execute(DeleteEntryCommand command)
   {
-    IEntry? entry = await repository.GetEntry(command.Id);
+    IEntry? entry = await entryRepository.GetEntry(command.Id);
     if (entry == null)
     {
       return new CommandResult();
     }
 
-    await repository.DeleteEntry(command.Id);
+    await entryRepository.DeleteEntry(command.Id);
 
-    IJournal journal = (await repository.GetJournal(entry.ParentId))!;
+    IJournal journal = (await journalRepository.GetJournal(entry.ParentId))!;
     journal.EditedOn = dateService.UtcNow;
 
-    await repository.UpsertJournal(journal);
+    await journalRepository.UpsertJournal(journal);
 
     return new CommandResult(command.Id, journal.Permissions.GetUserIdsWithAccess());
   }

--- a/api/Engraved.Core/Source/Application/Commands/Entries/Move/MoveEntryCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Entries/Move/MoveEntryCommandExecutor.cs
@@ -4,41 +4,45 @@ using Engraved.Core.Domain.Journals;
 
 namespace Engraved.Core.Application.Commands.Entries.Move;
 
-public class MoveEntryCommandExecutor(IRepository repository, IDateService dateService)
+public class MoveEntryCommandExecutor(
+  IJournalRepository journalRepository,
+  IEntryRepository entryRepository,
+  IDateService dateService
+)
   : ICommandExecutor<MoveEntryCommand>
 {
   public async Task<CommandResult> Execute(MoveEntryCommand command)
   {
     // can user access target journal?
-    IJournal? targetJournal = await repository.GetJournal(command.TargetJournalId);
+    IJournal? targetJournal = await journalRepository.GetJournal(command.TargetJournalId);
     if (targetJournal == null)
     {
       return new CommandResult();
     }
 
     // can user access entry?
-    IEntry? entry = await repository.GetEntry(command.EntryId);
+    IEntry? entry = await entryRepository.GetEntry(command.EntryId);
     if (entry == null)
     {
       return new CommandResult();
     }
 
     // update source journal EditedOn
-    IJournal sourceJournal = (await repository.GetJournal(entry.ParentId))!;
+    IJournal sourceJournal = (await journalRepository.GetJournal(entry.ParentId))!;
     sourceJournal.EditedOn = dateService.UtcNow;
-    await repository.UpsertJournal(sourceJournal);
+    await journalRepository.UpsertJournal(sourceJournal);
 
     // update target journal EditedOn
     targetJournal.EditedOn = dateService.UtcNow;
-    await repository.UpsertJournal(targetJournal);
+    await journalRepository.UpsertJournal(targetJournal);
 
     // update entry
     entry.EditedOn = dateService.UtcNow;
     entry.DateTime = dateService.UtcNow;
     entry.ParentId = targetJournal.Id!;
-    await repository.UpsertEntry(entry);
+    await entryRepository.UpsertEntry(entry);
 
-    string[] affectedUserIds = await GetAffectedUserIds(repository, entry, targetJournal);
+    string[] affectedUserIds = await GetAffectedUserIds(journalRepository, entry, targetJournal);
 
     return new CommandResult(
       command.EntryId,
@@ -47,7 +51,7 @@ public class MoveEntryCommandExecutor(IRepository repository, IDateService dateS
   }
 
   private static async Task<string[]> GetAffectedUserIds(
-    IBaseRepository repository,
+    IJournalRepository repository,
     IEntry entry,
     IJournal targetJournal
   )

--- a/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/BaseUpsertEntryCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/BaseUpsertEntryCommandExecutor.cs
@@ -6,7 +6,8 @@ using Engraved.Core.Domain.Journals;
 namespace Engraved.Core.Application.Commands.Entries.Upsert;
 
 public abstract class BaseUpsertEntryCommandExecutor<TCommand, TEntry, TJournal>(
-  IRepository repository,
+  IJournalRepository journalRepository,
+  IEntryRepository entryRepository,
   IDateService dateService
 ) : ICommandExecutor<TCommand>
   where TCommand : BaseUpsertEntryCommand
@@ -14,17 +15,19 @@ public abstract class BaseUpsertEntryCommandExecutor<TCommand, TEntry, TJournal>
   where TJournal : class, IJournal
 {
   protected readonly IDateService DateService = dateService;
-  protected readonly IBaseRepository Repository = repository;
+  protected readonly IJournalRepository JournalRepository = journalRepository;
+  protected readonly IEntryRepository EntryRepository = entryRepository;
 
   public async Task<CommandResult> Execute(TCommand command)
   {
-    var journal = await JournalCommandUtil.LoadAndValidateJournal<TJournal>(Repository, command, command.JournalId);
+    var journal =
+      await JournalCommandUtil.LoadAndValidateJournal<TJournal>(JournalRepository, command, command.JournalId);
 
     await ValidateCommand(command, journal);
 
     UpsertResult result = await UpsertEntry(command, journal);
 
-    await UpdateJournal(Repository, DateService, journal);
+    await UpdateJournal(JournalRepository, DateService, journal);
 
     return new CommandResult(result.EntityId, journal.Permissions.GetUserIdsWithAccess());
   }
@@ -44,10 +47,10 @@ public abstract class BaseUpsertEntryCommandExecutor<TCommand, TEntry, TJournal>
     SetCommonValues(command, entry);
     SetTypeSpecificValues(command, entry);
 
-    return await Repository.UpsertEntry(entry);
+    return await EntryRepository.UpsertEntry(entry);
   }
 
-  private static async Task UpdateJournal(IBaseRepository repository, IDateService dateService, TJournal journal)
+  private static async Task UpdateJournal(IJournalRepository repository, IDateService dateService, TJournal journal)
   {
     journal.EditedOn = dateService.UtcNow;
     await repository.UpsertJournal(journal);
@@ -130,7 +133,7 @@ public abstract class BaseUpsertEntryCommandExecutor<TCommand, TEntry, TJournal>
   {
     if (!string.IsNullOrEmpty(command.Id))
     {
-      return (TEntry)(await Repository.GetEntry(command.Id))!;
+      return (TEntry)(await EntryRepository.GetEntry(command.Id))!;
     }
 
     return null;

--- a/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/Counter/UpsertCounterEntryCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/Counter/UpsertCounterEntryCommandExecutor.cs
@@ -4,12 +4,16 @@ using Engraved.Core.Domain.Journals;
 
 namespace Engraved.Core.Application.Commands.Entries.Upsert.Counter;
 
-public class UpsertCounterEntryCommandExecutor(IRepository repository, IDateService dateService)
+public class UpsertCounterEntryCommandExecutor(
+  IJournalRepository journalRepository,
+  IEntryRepository entryRepository,
+  IDateService dateService
+)
   : BaseUpsertEntryCommandExecutor<
     UpsertCounterEntryCommand,
     CounterEntry,
     CounterJournal
-  >(repository, dateService)
+  >(journalRepository, entryRepository, dateService)
 {
   protected override void SetTypeSpecificValues(UpsertCounterEntryCommand command, CounterEntry entry) { }
 }

--- a/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/Gauge/UpsertGaugeEntryCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/Gauge/UpsertGaugeEntryCommandExecutor.cs
@@ -4,12 +4,16 @@ using Engraved.Core.Domain.Journals;
 
 namespace Engraved.Core.Application.Commands.Entries.Upsert.Gauge;
 
-public class UpsertGaugeEntryCommandExecutor(IRepository repository, IDateService dateService)
+public class UpsertGaugeEntryCommandExecutor(
+  IJournalRepository journalRepository,
+  IEntryRepository entryRepository,
+  IDateService dateService
+)
   : BaseUpsertEntryCommandExecutor<
     UpsertGaugeEntryCommand,
     GaugeEntry,
     GaugeJournal
-  >(repository, dateService)
+  >(journalRepository, entryRepository, dateService)
 {
   protected override Task PerformTypeSpecificValidation(UpsertGaugeEntryCommand command)
   {

--- a/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/LogBook/UpsertLogBookEntryCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/LogBook/UpsertLogBookEntryCommandExecutor.cs
@@ -4,13 +4,18 @@ using Engraved.Core.Domain.Journals;
 
 namespace Engraved.Core.Application.Commands.Entries.Upsert.LogBook;
 
-public class UpsertLogBookEntryCommandExecutor(IRepository repository, IDateService dateService)
+public class UpsertLogBookEntryCommandExecutor(
+  IJournalRepository journalRepository,
+  IEntryRepository entryRepository,
+  IDateService dateService
+)
   : BaseUpsertEntryCommandExecutor<
     UpsertLogBookEntryCommand,
     LogBookEntry,
     LogBookJournal
   >(
-    repository,
+    journalRepository,
+    entryRepository,
     dateService
   )
 {
@@ -39,7 +44,7 @@ public class UpsertLogBookEntryCommandExecutor(IRepository repository, IDateServ
 
   private async Task<bool> HasEntryForDay(UpsertLogBookEntryCommand command, DateTime entryDate)
   {
-    var entriesOnSameDay = await Repository.GetEntriesForJournal(
+    var entriesOnSameDay = await EntryRepository.GetEntriesForJournal(
       command.JournalId,
       entryDate,
       entryDate

--- a/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/Scraps/UpsertScrapsEntryCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/Scraps/UpsertScrapsEntryCommandExecutor.cs
@@ -4,13 +4,18 @@ using Engraved.Core.Domain.Journals;
 
 namespace Engraved.Core.Application.Commands.Entries.Upsert.Scraps;
 
-public class UpsertScrapsEntryCommandExecutor(IRepository repository, IDateService dateService)
+public class UpsertScrapsEntryCommandExecutor(
+  IJournalRepository journalRepository,
+  IEntryRepository entryRepository,
+  IDateService dateService
+)
   : BaseUpsertEntryCommandExecutor<
     UpsertScrapsEntryCommand,
     ScrapsEntry,
     ScrapsJournal
   >(
-    repository,
+    journalRepository,
+    entryRepository,
     dateService
   )
 {

--- a/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/Timer/UpsertTimerEntryCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/Timer/UpsertTimerEntryCommandExecutor.cs
@@ -4,19 +4,24 @@ using Engraved.Core.Domain.Journals;
 
 namespace Engraved.Core.Application.Commands.Entries.Upsert.Timer;
 
-public class UpsertTimerEntryCommandExecutor(IRepository repository, IDateService dateService)
+public class UpsertTimerEntryCommandExecutor(
+  IJournalRepository journalRepository,
+  IEntryRepository entryRepository,
+  IDateService dateService
+)
   : BaseUpsertEntryCommandExecutor<
     UpsertTimerEntryCommand,
     TimerEntry,
     TimerJournal
   >(
-    repository,
+    journalRepository,
+    entryRepository,
     dateService
   )
 {
   protected override async Task<TimerEntry?> LoadEntryToUpdate(UpsertTimerEntryCommand command, TimerJournal journal)
   {
-    return await GetActiveEntry(Repository, journal);
+    return await GetActiveEntry(EntryRepository, journal);
   }
 
   protected override void SetTypeSpecificValues(UpsertTimerEntryCommand command, TimerEntry entry)
@@ -57,7 +62,7 @@ public class UpsertTimerEntryCommandExecutor(IRepository repository, IDateServic
            && command.EndDate == null;
   }
 
-  public static async Task<TimerEntry?> GetActiveEntry(IBaseRepository repository, TimerJournal journal)
+  public static async Task<TimerEntry?> GetActiveEntry(IEntryRepository repository, TimerJournal journal)
   {
     // we get all entries here from the db and do the following filtering
     // in memory. this could be improved, however it would require new method(s)

--- a/api/Engraved.Core/Source/Application/Commands/Journals/Add/AddJournalCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Journals/Add/AddJournalCommandExecutor.cs
@@ -3,7 +3,7 @@ using Engraved.Core.Domain.Journals;
 
 namespace Engraved.Core.Application.Commands.Journals.Add;
 
-public class AddJournalCommandExecutor(IRepository repository, IDateService dateService)
+public class AddJournalCommandExecutor(IJournalRepository repository, IDateService dateService)
   : ICommandExecutor<AddJournalCommand>
 {
   public async Task<CommandResult> Execute(AddJournalCommand command)

--- a/api/Engraved.Core/Source/Application/Commands/Journals/Delete/DeleteJournalCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Journals/Delete/DeleteJournalCommandExecutor.cs
@@ -4,7 +4,7 @@ using Engraved.Core.Domain.Notifications;
 
 namespace Engraved.Core.Application.Commands.Journals.Delete;
 
-public class DeleteJournalCommandExecutor(IRepository repository)
+public class DeleteJournalCommandExecutor(IJournalRepository repository)
   : ICommandExecutor<DeleteJournalCommand>
 {
   public async Task<CommandResult> Execute(DeleteJournalCommand command)

--- a/api/Engraved.Core/Source/Application/Commands/Journals/Edit/EditJournalCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Journals/Edit/EditJournalCommandExecutor.cs
@@ -4,10 +4,13 @@ using Engraved.Core.Domain.Journals;
 
 namespace Engraved.Core.Application.Commands.Journals.Edit;
 
-public class EditJournalCommandExecutor(IRepository repository, IDateService dateService)
+public class EditJournalCommandExecutor(
+  IJournalRepository journalRepository,
+  IEntryRepository entryRepository,
+  IDateService dateService
+)
   : ICommandExecutor<EditJournalCommand>
 {
-  private readonly IBaseRepository _repository = repository;
 
   public async Task<CommandResult> Execute(EditJournalCommand command)
   {
@@ -21,7 +24,7 @@ public class EditJournalCommandExecutor(IRepository repository, IDateService dat
       throw new InvalidCommandException(command, $"{nameof(EditJournalCommand.Name)} must be specified.");
     }
 
-    IJournal? journal = await _repository.GetJournal(command.JournalId);
+    IJournal? journal = await journalRepository.GetJournal(command.JournalId);
 
     if (journal == null)
     {
@@ -41,7 +44,7 @@ public class EditJournalCommandExecutor(IRepository repository, IDateService dat
     journal.CustomProps = command.CustomProps;
     journal.EditedOn = dateService.UtcNow;
 
-    UpsertResult result = await _repository.UpsertJournal(journal);
+    UpsertResult result = await journalRepository.UpsertJournal(journal);
 
     return new CommandResult(result.EntityId, journal.Permissions.GetUserIdsWithAccess());
   }
@@ -53,7 +56,7 @@ public class EditJournalCommandExecutor(IRepository repository, IDateService dat
       return;
     }
 
-    var entries = await _repository.GetEntriesForJournal(journalId);
+    var entries = await entryRepository.GetEntriesForJournal(journalId);
 
     foreach (IEntry entry in entries)
     {
@@ -65,7 +68,7 @@ public class EditJournalCommandExecutor(IRepository repository, IDateService dat
 
       if (changed)
       {
-        await _repository.UpsertEntry(entry);
+        await entryRepository.UpsertEntry(entry);
       }
     }
   }

--- a/api/Engraved.Core/Source/Application/Commands/Journals/EditPermissions/EditJournalPermissionsCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Journals/EditPermissions/EditJournalPermissionsCommandExecutor.cs
@@ -3,10 +3,10 @@ using Engraved.Core.Domain.Journals;
 
 namespace Engraved.Core.Application.Commands.Journals.EditPermissions;
 
-public class EditJournalPermissionsCommandExecutor(IRepository repository)
+public class EditJournalPermissionsCommandExecutor(IJournalRepository repository)
   : ICommandExecutor<EditJournalPermissionsCommand>
 {
-  private readonly IBaseRepository _repository = repository;
+  private readonly IJournalRepository _repository = repository;
 
   public async Task<CommandResult> Execute(EditJournalPermissionsCommand command)
   {

--- a/api/Engraved.Core/Source/Application/Commands/Journals/JournalCommandUtil.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Journals/JournalCommandUtil.cs
@@ -7,7 +7,7 @@ namespace Engraved.Core.Application.Commands.Journals;
 public static class JournalCommandUtil
 {
   public static async Task<TJournal> LoadAndValidateJournal<TJournal>(
-    IBaseRepository repository,
+    IJournalRepository repository,
     ICommand command,
     string journalId
   )

--- a/api/Engraved.Core/Source/Application/Persistence/IEntryRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IEntryRepository.cs
@@ -28,6 +28,4 @@ public interface IEntryRepository
   Task DeleteEntry(string entryId);
 
   Task<IEntry?> GetEntry(string entryId);
-
-  Task<long> CountAllEntries();
 }

--- a/api/Engraved.Core/Source/Application/Persistence/IJournalRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IJournalRepository.cs
@@ -21,6 +21,4 @@ public interface IJournalRepository
   Task DeleteJournal(string journalId);
 
   Task ModifyJournalPermissions(string journalId, Dictionary<string, PermissionKind> permissions);
-
-  Task<long> CountAllJournals();
 }

--- a/api/Engraved.Core/Source/Application/Persistence/IMaintenanceRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IMaintenanceRepository.cs
@@ -1,6 +1,14 @@
 namespace Engraved.Core.Application.Persistence;
 
+// System/maintenance operations that are not tied to a single entity and are not user-scoped:
+// the keep-alive ping and the global entity counts used for system info.
 public interface IMaintenanceRepository
 {
   Task WakeMeUp();
+
+  Task<long> CountAllUsers();
+
+  Task<long> CountAllJournals();
+
+  Task<long> CountAllEntries();
 }

--- a/api/Engraved.Core/Source/Application/Persistence/IUserRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IUserRepository.cs
@@ -11,6 +11,4 @@ public interface IUserRepository
   Task<IUser[]> GetUsers(params string[] userIds);
 
   Task<IUser[]> GetAllUsers();
-
-  Task<long> CountAllUsers();
 }

--- a/api/Engraved.Core/Source/Application/Queries/Entries/Get/GetEntryQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Entries/Get/GetEntryQueryExecutor.cs
@@ -4,7 +4,8 @@ using Engraved.Core.Domain.Journals;
 
 namespace Engraved.Core.Application.Queries.Entries.Get;
 
-public class GetEntryQueryExecutor(IRepository repository) : IQueryExecutor<IEntry?, GetEntryQuery>
+public class GetEntryQueryExecutor(IEntryRepository entryRepository, IJournalRepository journalRepository)
+  : IQueryExecutor<IEntry?, GetEntryQuery>
 {
   public bool DisableCache => false;
 
@@ -18,7 +19,7 @@ public class GetEntryQueryExecutor(IRepository repository) : IQueryExecutor<IEnt
       );
     }
 
-    IEntry? entry = await repository.GetEntry(query.EntryId);
+    IEntry? entry = await entryRepository.GetEntry(query.EntryId);
     if (entry == null)
     {
       return null;
@@ -27,7 +28,7 @@ public class GetEntryQueryExecutor(IRepository repository) : IQueryExecutor<IEnt
     // Permission gate (not redundant): GetEntry is an unscoped primitive, so this is where read
     // access is enforced for the single-entry endpoint. GetJournal is scoped, so it returns null
     // when the current user cannot read the parent journal - in which case we hide the entry.
-    IJournal? journal = await repository.GetJournal(entry.ParentId);
+    IJournal? journal = await journalRepository.GetJournal(entry.ParentId);
     if (journal == null)
     {
       return null;

--- a/api/Engraved.Core/Source/Application/Queries/Entries/GetActive/GetActiveEntryQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Entries/GetActive/GetActiveEntryQueryExecutor.cs
@@ -5,7 +5,8 @@ using Engraved.Core.Domain.Journals;
 
 namespace Engraved.Core.Application.Queries.Entries.GetActive;
 
-public class GetActiveEntryQueryExecutor(IRepository repository) : IQueryExecutor<IEntry?, GetActiveEntryQuery>
+public class GetActiveEntryQueryExecutor(IJournalRepository journalRepository, IEntryRepository entryRepository)
+  : IQueryExecutor<IEntry?, GetActiveEntryQuery>
 {
   public bool DisableCache => false;
 
@@ -19,7 +20,7 @@ public class GetActiveEntryQueryExecutor(IRepository repository) : IQueryExecuto
       );
     }
 
-    IJournal? journal = await repository.GetJournal(query.JournalId);
+    IJournal? journal = await journalRepository.GetJournal(query.JournalId);
 
     if (journal == null)
     {
@@ -34,6 +35,6 @@ public class GetActiveEntryQueryExecutor(IRepository repository) : IQueryExecuto
       return null;
     }
 
-    return await UpsertTimerEntryCommandExecutor.GetActiveEntry(repository, (TimerJournal)journal);
+    return await UpsertTimerEntryCommandExecutor.GetActiveEntry(entryRepository, (TimerJournal)journal);
   }
 }

--- a/api/Engraved.Core/Source/Application/Queries/Entries/GetAllJournal/GetAllJournalEntriesQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Entries/GetAllJournal/GetAllJournalEntriesQueryExecutor.cs
@@ -4,11 +4,12 @@ using Engraved.Core.Domain.Journals;
 
 namespace Engraved.Core.Application.Queries.Entries.GetAllJournal;
 
-public class GetAllJournalEntriesQueryExecutor(IRepository repository)
+public class GetAllJournalEntriesQueryExecutor(
+  IJournalRepository journalRepository,
+  IEntryRepository entryRepository
+)
   : IQueryExecutor<IEntry[], GetAllJournalEntriesQuery>
 {
-  private readonly IBaseRepository _repository = repository;
-
   public bool DisableCache => false;
 
   public async Task<IEntry[]> Execute(GetAllJournalEntriesQuery query)
@@ -21,7 +22,7 @@ public class GetAllJournalEntriesQueryExecutor(IRepository repository)
       );
     }
 
-    IJournal? journal = await _repository.GetJournal(query.JournalId);
+    IJournal? journal = await journalRepository.GetJournal(query.JournalId);
 
     if (journal == null)
     {
@@ -31,7 +32,7 @@ public class GetAllJournalEntriesQueryExecutor(IRepository repository)
       );
     }
 
-    return await _repository.GetEntriesForJournal(
+    return await entryRepository.GetEntriesForJournal(
       query.JournalId,
       query.FromDate,
       query.ToDate,

--- a/api/Engraved.Core/Source/Application/Queries/Journals/Get/GetJournalQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Journals/Get/GetJournalQueryExecutor.cs
@@ -3,7 +3,8 @@ using Engraved.Core.Domain.Journals;
 
 namespace Engraved.Core.Application.Queries.Journals.Get;
 
-public class GetJournalQueryExecutor(IUserScopedRepository repository) : IQueryExecutor<IJournal?, GetJournalQuery>
+public class GetJournalQueryExecutor(IJournalRepository journalRepository, IUserRepository userRepository)
+  : IQueryExecutor<IJournal?, GetJournalQuery>
 {
   public bool DisableCache => false;
 
@@ -14,13 +15,13 @@ public class GetJournalQueryExecutor(IUserScopedRepository repository) : IQueryE
       throw new InvalidQueryException(query, $"{nameof(query.JournalId)} must be specified.");
     }
 
-    IJournal? journal = await repository.GetJournal(query.JournalId);
+    IJournal? journal = await journalRepository.GetJournal(query.JournalId);
     if (journal == null)
     {
       return null;
     }
 
-    var journalWithEnsuredPermissions = await JournalQueryUtil.EnsurePermissionUsers(repository, journal);
+    var journalWithEnsuredPermissions = await JournalQueryUtil.EnsurePermissionUsers(userRepository, journal);
     return journalWithEnsuredPermissions.First();
   }
 }

--- a/api/Engraved.Core/Source/Application/Queries/Journals/JournalQueryUtil.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Journals/JournalQueryUtil.cs
@@ -8,7 +8,7 @@ namespace Engraved.Core.Application.Queries.Journals;
 public static class JournalQueryUtil
 {
   public static async Task<IJournal[]> EnsurePermissionUsers(
-    IRepository repository,
+    IUserRepository repository,
     params IJournal[] journals
   )
   {

--- a/api/Engraved.Core/Source/Application/Queries/SystemInfo/Get/GetSystemInfoQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/SystemInfo/Get/GetSystemInfoQueryExecutor.cs
@@ -3,11 +3,7 @@ using Engraved.Core.Application.Persistence;
 
 namespace Engraved.Core.Application.Queries.SystemInfo.Get;
 
-public class GetSystemInfoQueryExecutor(
-  IUserRepository userRepository,
-  IJournalRepository journalRepository,
-  IEntryRepository entryRepository
-)
+public class GetSystemInfoQueryExecutor(IMaintenanceRepository maintenanceRepository)
   : IQueryExecutor<SystemInfo, GetSystemInfoQuery>
 {
   private const string DevInformationalVersion =
@@ -21,9 +17,9 @@ public class GetSystemInfoQueryExecutor(
 
     var systemInfo = new SystemInfo
     {
-      JournalsCount = await journalRepository.CountAllJournals(),
-      EntriesCount = await entryRepository.CountAllEntries(),
-      UsersCount = await userRepository.CountAllUsers()
+      JournalsCount = await maintenanceRepository.CountAllJournals(),
+      EntriesCount = await maintenanceRepository.CountAllEntries(),
+      UsersCount = await maintenanceRepository.CountAllUsers()
     };
 
     if (segments.Length == 4)

--- a/api/Engraved.Core/Source/Application/Queries/SystemInfo/Get/GetSystemInfoQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/SystemInfo/Get/GetSystemInfoQueryExecutor.cs
@@ -3,7 +3,11 @@ using Engraved.Core.Application.Persistence;
 
 namespace Engraved.Core.Application.Queries.SystemInfo.Get;
 
-public class GetSystemInfoQueryExecutor(IRepository repository)
+public class GetSystemInfoQueryExecutor(
+  IUserRepository userRepository,
+  IJournalRepository journalRepository,
+  IEntryRepository entryRepository
+)
   : IQueryExecutor<SystemInfo, GetSystemInfoQuery>
 {
   private const string DevInformationalVersion =
@@ -17,9 +21,9 @@ public class GetSystemInfoQueryExecutor(IRepository repository)
 
     var systemInfo = new SystemInfo
     {
-      JournalsCount = await repository.CountAllJournals(),
-      EntriesCount = await repository.CountAllEntries(),
-      UsersCount = await repository.CountAllUsers()
+      JournalsCount = await journalRepository.CountAllJournals(),
+      EntriesCount = await entryRepository.CountAllEntries(),
+      UsersCount = await userRepository.CountAllUsers()
     };
 
     if (segments.Length == 4)


### PR DESCRIPTION
Follow-up to #2882 (now merged). This PR makes the role-interface split actually pay off.

## Problem this solves
#2882 split `IBaseRepository` into role interfaces but, on its own, gained nothing in practice: every executor still injected `IRepository`/`IBaseRepository`, so they all still depended on the whole surface. This PR migrates the consumers so each executor declares only the role(s) it uses.

## What
- **DI** (`Program.cs`): the role interfaces (`IUserRepository`/`IJournalRepository`/`IEntryRepository`/`IMaintenanceRepository`) resolve to the **user-scoped** repository, matching `IRepository`. So narrowing the declared dependency does not change the injected instance — scoped permission enforcement is preserved.
- **Executors/utils**: each now injects just its role interface(s). Examples: `AddJournalCommandExecutor` → `IJournalRepository`; `GetEntryQueryExecutor` → `IEntryRepository` + `IJournalRepository`; `BaseUpsertEntryCommandExecutor` → `IJournalRepository` + `IEntryRepository`.
- **Counts consolidated**: `CountAllUsers`/`CountAllJournals`/`CountAllEntries` are unscoped global aggregates, so they moved off the entity interfaces onto `IMaintenanceRepository` (next to `WakeMeUp`). `GetSystemInfoQueryExecutor` now depends on just `IMaintenanceRepository` instead of all three entity repositories.
- **Unchanged on purpose**:
  - Executors that genuinely need `CurrentUser` stay on `IUserScopedRepository` (the narrowest type that exposes it).
  - The 6 non-scoped consumers stay on `IBaseRepository`: `LoginHandler`, `UserLoader`, `RefreshTokenService`, `NotificationJob`, `WakeMeUpController`, `RootController`.

## Behavior
Behavior-preserving — only the *declared* dependency narrows; the resolved instance is the same scoped repository as before. Direct-construction unit tests were updated for the executors whose constructor arity grew (the ones spanning journal + entry roles).

## Honest scope note
The payoff here is clearer constructor signatures, a narrower mocking surface, and less recompile ripple — moderate, not transformative, in a codebase this size. Scoped-vs-unscoped still rides on the `IUserScopedRepository`/`IBaseRepository` distinction (a role interface is a type; scoping is a registration). Making scoping itself first-class is the larger per-operation "data actions" direction from the issue, out of scope here.

## Verification
Core (76) + EphemeralMongo (93) tests green. Api project compiles with the new DI registrations.

Refs #2877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
