### PR TITLE
Review Program.cs: extract DI wiring, fix JWT nameid bug

### DIFF
--- a/api/Engraved.Api.Tests/Engraved.Api.Tests.csproj
+++ b/api/Engraved.Api.Tests/Engraved.Api.Tests.csproj
@@ -12,12 +12,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <!-- NUnit only discovers [SetUpFixture] in the assembly under test, so the shared mongo
-             teardown source is compiled into this assembly too. -->
-        <Compile Include="..\Engraved.Persistence.Mongo.Tests\Source\MongoRunnerTeardown.cs" Link="MongoRunnerTeardown.cs"/>
-    </ItemGroup>
-
-    <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0"/>
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>
@@ -29,6 +23,12 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Include="..\Engraved.Persistence.Mongo.Tests\Source\MongoRunnerTeardown.cs">
+        <Link>Source\MongoRunnerTeardown.cs</Link>
+      </Compile>
     </ItemGroup>
 
 </Project>

--- a/api/Engraved.Api.Tests/Source/ArchitectureShould.cs
+++ b/api/Engraved.Api.Tests/Source/ArchitectureShould.cs
@@ -22,7 +22,7 @@ public class ArchitectureShould
   {
     string[] allowedConsumers =
     [
-      "Program", // composition root: wires the seam up via DI
+      "PersistenceRegistration", // composition root: wires the seam up via DI
       "RootController", // health endpoint, runs before any user context
       "WakeMeUpController", // keep-alive, runs without a user
       "UserLoader", // authentication, runs before a user context exists

--- a/api/Engraved.Api.Tests/Source/StartupSmokeShould.cs
+++ b/api/Engraved.Api.Tests/Source/StartupSmokeShould.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
 using System.Threading.Tasks;
 using Engraved.Core.Application.Persistence;
 using Engraved.Persistence.Mongo;
@@ -13,6 +17,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Tokens;
 using NUnit.Framework;
 
 namespace Engraved.Api.Tests;
@@ -22,6 +27,8 @@ namespace Engraved.Api.Tests;
 // and serves a request, and pins that the repository seams resolve to the intended concrete types.
 public class StartupSmokeShould
 {
+  private const string JwtSecret = "smoke-test-secret-long-enough-to-be-valid-0123456789";
+
   private WebApplicationFactory<Program> _factory = null!;
 
   [SetUp]
@@ -38,7 +45,7 @@ public class StartupSmokeShould
               new Dictionary<string, string?>
               {
                 ["ConnectionStrings:engraved_db"] = Util.ConnectionString,
-                ["Authentication:JwtSecret"] = "smoke-test-secret-long-enough-to-be-valid-0123456789"
+                ["Authentication:JwtSecret"] = JwtSecret
               }
             );
           }
@@ -79,5 +86,44 @@ public class StartupSmokeShould
 
     // maintenance is inherently unrestricted, so it resolves to the raw UnrestrictedMongoRepository
     services.GetRequiredService<IMaintenanceRepository>().Should().BeOfType<UnrestrictedMongoRepository>();
+  }
+
+  [Test]
+  public async Task Return_Unauthorized_For_ValidlySignedToken_Missing_NameIdClaim()
+  {
+    HttpClient client = _factory.CreateClient();
+    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateTokenWithoutNameIdClaim());
+
+    // any [Authorize] endpoint works - the request must never reach the controller.
+    HttpResponseMessage response = await client.GetAsync("/api/system_info");
+
+    response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+  }
+
+  [Test]
+  public async Task Include_ActionDuration_Header_On_Responses()
+  {
+    HttpClient client = _factory.CreateClient();
+
+    HttpResponseMessage response = await client.GetAsync("/");
+
+    response.Headers.Contains("server-action-duration").Should().BeTrue();
+  }
+
+  private static string CreateTokenWithoutNameIdClaim()
+  {
+    var tokenHandler = new JwtSecurityTokenHandler();
+    var tokenDescriptor = new SecurityTokenDescriptor
+    {
+      Subject = new ClaimsIdentity([new Claim(ClaimTypes.Name, "someone")]),
+      Expires = DateTime.UtcNow.AddMinutes(5),
+      SigningCredentials = new SigningCredentials(
+        new SymmetricSecurityKey(Encoding.ASCII.GetBytes(JwtSecret)),
+        SecurityAlgorithms.HmacSha256Signature
+      )
+    };
+
+    SecurityToken token = tokenHandler.CreateToken(tokenDescriptor);
+    return tokenHandler.WriteToken(token);
   }
 }

--- a/api/Engraved.Api/Source/Bootstrap/AuthenticationRegistration.cs
+++ b/api/Engraved.Api/Source/Bootstrap/AuthenticationRegistration.cs
@@ -1,0 +1,85 @@
+using System.Security.Claims;
+using System.Text;
+using Engraved.Api.Authentication;
+using Engraved.Api.Authentication.Basic;
+using Engraved.Api.Settings;
+using Engraved.Core.Application;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Engraved.Api.Bootstrap;
+
+public static class AuthenticationRegistration
+{
+  public static void RegisterAuthentication(
+    IServiceCollection services,
+    IConfigurationSection authConfigSection,
+    bool isE2ETests
+  )
+  {
+    if (isE2ETests)
+    {
+      services.AddAuthentication("BasicAuthentication")
+        .AddScheme<AuthenticationSchemeOptions, BasicAuthenticationHandler>("BasicAuthentication", null);
+      return;
+    }
+
+    services.AddAuthentication(options =>
+        {
+          options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+          options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        }
+      )
+      .AddJwtBearer(options =>
+        {
+          options.RequireHttpsMetadata = false;
+          options.SaveToken = true;
+          options.TokenValidationParameters = new TokenValidationParameters
+          {
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(GetJwtSecret(authConfigSection))),
+            ValidateAudience = false,
+            ValidateIssuer = false,
+            ValidateIssuerSigningKey = true,
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.Zero
+          };
+          options.Events = new JwtBearerEvents { OnTokenValidated = OnTokenValidated };
+        }
+      );
+  }
+
+  private static Task OnTokenValidated(TokenValidatedContext context)
+  {
+    var jwtToken = (JsonWebToken) context.SecurityToken;
+    Claim? nameClaim = jwtToken.Claims.FirstOrDefault(c => c.Type == "nameid");
+    if (nameClaim == null)
+    {
+      // a validly-signed token without a "nameid" claim should never happen for tokens we issue
+      // ourselves (JwtTokenFactory always adds it), but failing the handshake here turns a
+      // malformed/foreign token into a clean 401 instead of an unhandled exception.
+      context.Fail("Token does not contain a \"nameid\" claim.");
+      return Task.CompletedTask;
+    }
+
+    context.HttpContext.RequestServices
+      .GetRequiredService<ICurrentUserService>()
+      .SetUserName(nameClaim.Value);
+
+    return Task.CompletedTask;
+  }
+
+  private static string GetJwtSecret(IConfigurationSection configurationSection)
+  {
+    var jwtSecret = configurationSection.GetValue<string>(nameof(AuthenticationConfig.JwtSecret));
+    if (string.IsNullOrEmpty(jwtSecret))
+    {
+      throw new Exception("App Service Config: No JWT Secret available.");
+    }
+
+    return jwtSecret;
+  }
+}

--- a/api/Engraved.Api/Source/Bootstrap/PersistenceRegistration.cs
+++ b/api/Engraved.Api/Source/Bootstrap/PersistenceRegistration.cs
@@ -3,8 +3,6 @@ using Engraved.Core.Application;
 using Engraved.Core.Application.Persistence;
 using Engraved.Core.Domain.Users;
 using Engraved.Persistence.Mongo;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Engraved.Api.Bootstrap;
 
@@ -22,18 +20,13 @@ public static class PersistenceRegistration
       )
     );
 
-    // The explicit unrestricted seam: resolves to the raw UnrestrictedMongoRepository (no permission/
-    // user scoping). Injected only by consumers that deliberately run without a current user (the
-    // notification job, auth/login, health endpoints). It is a distinct type from the scoped
-    // IUserRestrictedRepository, so
-    // unrestricted access is always a conscious, greppable choice and can never be obtained by accident.
-    services.AddTransient<IUnrestrictedRepository>(provider =>
-      {
-        var mongoDbClient = provider.GetService<MongoDatabaseClient>()!;
-        return new UnrestrictedMongoRepository(mongoDbClient);
-      }
-    );
+    RegisterUserRestrictedRepository(services);
 
+    RegisterUnrestrictedRepository(services);
+  }
+
+  private static void RegisterUserRestrictedRepository(IServiceCollection services)
+  {
     services.AddTransient<IUserRestrictedRepository>(provider =>
       {
         var userService = provider.GetService<ICurrentUserService>()!;
@@ -51,9 +44,17 @@ public static class PersistenceRegistration
     services.AddTransient<IUserRepository>(provider => provider.GetService<IUserRestrictedRepository>()!);
     services.AddTransient<IJournalRepository>(provider => provider.GetService<IUserRestrictedRepository>()!);
     services.AddTransient<IEntryRepository>(provider => provider.GetService<IUserRestrictedRepository>()!);
+  }
 
-    // Maintenance is inherently unrestricted (keep-alive, global counts), so it resolves to the
-    // unrestricted repository rather than the user-restricted one.
+  private static void RegisterUnrestrictedRepository(IServiceCollection services)
+  {
+    services.AddTransient<IUnrestrictedRepository>(provider =>
+      {
+        var mongoDbClient = provider.GetService<MongoDatabaseClient>()!;
+        return new UnrestrictedMongoRepository(mongoDbClient);
+      }
+    );
+
     services.AddTransient<IMaintenanceRepository>(provider => provider.GetService<IUnrestrictedRepository>()!);
   }
 

--- a/api/Engraved.Api/Source/Bootstrap/PersistenceRegistration.cs
+++ b/api/Engraved.Api/Source/Bootstrap/PersistenceRegistration.cs
@@ -1,0 +1,75 @@
+using Engraved.Api.Settings;
+using Engraved.Core.Application;
+using Engraved.Core.Application.Persistence;
+using Engraved.Core.Domain.Users;
+using Engraved.Persistence.Mongo;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Engraved.Api.Bootstrap;
+
+public static class PersistenceRegistration
+{
+  public static void RegisterPersistence(IServiceCollection services, IConfiguration configuration, bool isE2ETests)
+  {
+    // it is recommended to only have one instance of the MongoClient:
+    // https://mongodb.github.io/mongo-csharp-driver/2.14/reference/driver/connecting/#re-use
+    // we did nt have this at first and it actually had a bad influence
+    // on performance.
+    services.AddSingleton(_ => new MongoDatabaseClient(
+        CreateRepositorySettings(configuration, isE2ETests),
+        GetMongoDbNameOverride(isE2ETests)
+      )
+    );
+
+    // The explicit unrestricted seam: resolves to the raw UnrestrictedMongoRepository (no permission/
+    // user scoping). Injected only by consumers that deliberately run without a current user (the
+    // notification job, auth/login, health endpoints). It is a distinct type from the scoped
+    // IUserRestrictedRepository, so
+    // unrestricted access is always a conscious, greppable choice and can never be obtained by accident.
+    services.AddTransient<IUnrestrictedRepository>(provider =>
+      {
+        var mongoDbClient = provider.GetService<MongoDatabaseClient>()!;
+        return new UnrestrictedMongoRepository(mongoDbClient);
+      }
+    );
+
+    services.AddTransient<IUserRestrictedRepository>(provider =>
+      {
+        var userService = provider.GetService<ICurrentUserService>()!;
+        var mongoDbClient = provider.GetService<MongoDatabaseClient>()!;
+        return new UserRestrictedMongoRepository(mongoDbClient, userService);
+      }
+    );
+
+    services.AddTransient<Lazy<IUser>>(provider => provider.GetService<IUserRestrictedRepository>()!.CurrentUser);
+
+    // The narrow, role-based persistence interfaces resolve to the user-restricted repository (same as
+    // IUserRestrictedRepository), so executors that depend on just the role(s) they use transparently
+    // get permission enforcement. Consumers that need unrestricted access inject IUnrestrictedRepository
+    // (above) instead.
+    services.AddTransient<IUserRepository>(provider => provider.GetService<IUserRestrictedRepository>()!);
+    services.AddTransient<IJournalRepository>(provider => provider.GetService<IUserRestrictedRepository>()!);
+    services.AddTransient<IEntryRepository>(provider => provider.GetService<IUserRestrictedRepository>()!);
+
+    // Maintenance is inherently unrestricted (keep-alive, global counts), so it resolves to the
+    // unrestricted repository rather than the user-restricted one.
+    services.AddTransient<IMaintenanceRepository>(provider => provider.GetService<IUnrestrictedRepository>()!);
+  }
+
+  private static string? GetMongoDbNameOverride(bool isE2ETests)
+  {
+    return isE2ETests ? "engraved_e2e_tests" : null;
+  }
+
+  private static MongoRepositorySettings CreateRepositorySettings(IConfiguration configuration, bool isE2ETests)
+  {
+    var connectionString = configuration.GetConnectionString("engraved_db");
+    if (string.IsNullOrEmpty(connectionString) && !isE2ETests)
+    {
+      throw new Exception("App Service Config: No connection string available.");
+    }
+
+    return new MongoRepositorySettings(connectionString ?? "mongodb://localhost:27017");
+  }
+}

--- a/api/Engraved.Api/Source/Program.cs
+++ b/api/Engraved.Api/Source/Program.cs
@@ -1,25 +1,16 @@
-using System.Security.Claims;
-using System.Text;
 using System.Text.Json.Serialization;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Engraved.Api.Authentication;
-using Engraved.Api.Authentication.Basic;
 using Engraved.Api.Authentication.Google;
+using Engraved.Api.Bootstrap;
 using Engraved.Api.Filters;
 using Engraved.Api.Jobs;
 using Engraved.Api.Settings;
 using Engraved.Core.Application;
 using Engraved.Core.Application.Jobs;
-using Engraved.Core.Application.Persistence;
 using Engraved.Core.Application.Queries;
 using Engraved.Core.Domain.Notifications;
-using Engraved.Core.Domain.Users;
 using Engraved.Notifications.OneSignal;
-using Engraved.Persistence.Mongo;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.IdentityModel.JsonWebTokens;
-using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 
 var isE2ETests = Environment.GetCommandLineArgs().Any(a => a == "e2e-tests");
@@ -64,7 +55,7 @@ builder.Services.AddHttpContextAccessor();
 IConfigurationSection authConfigSection = builder.Configuration.GetSection("Authentication");
 IConfigurationSection notificationsSection = builder.Configuration.GetSection("Notifications");
 IConfigurationSection oneSignalConfigSection = notificationsSection.GetSection("OneSignal");
-IConfigurationSection notificationsJobConfig = notificationsSection.GetSection("Job");
+IConfigurationSection notificationsJobConfigSection = notificationsSection.GetSection("Job");
 
 // https://learn.microsoft.com/en-us/dotnet/core/extensions/logging?tabs=command-line
 if (!builder.Environment.IsDevelopment() && !isE2ETests)
@@ -74,7 +65,7 @@ if (!builder.Environment.IsDevelopment() && !isE2ETests)
 
 builder.Services.Configure<AuthenticationConfig>(authConfigSection);
 builder.Services.Configure<OneSignalConfig>(oneSignalConfigSection);
-builder.Services.Configure<NotificationsJobConfig>(notificationsJobConfig);
+builder.Services.Configure<NotificationsJobConfig>(notificationsJobConfigSection);
 builder.Services.AddTransient<IDateService, DateService>();
 builder.Services.AddTransient<ICurrentUserService, CurrentUserService>();
 builder.Services.AddTransient<IGoogleTokenValidator, GoogleTokenValidator>();
@@ -85,50 +76,7 @@ builder.Services.AddTransient<ILoginHandler, LoginHandler>();
 builder.Services.AddSingleton<UserLoader>();
 builder.Services.AddHostedService<ScheduledNotificationJob>();
 
-// it is recommended to only have one instance of the MongoClient:
-// https://mongodb.github.io/mongo-csharp-driver/2.14/reference/driver/connecting/#re-use
-// we did nt have this at first and it actually had a bad influence
-// on performance.
-builder.Services.AddSingleton(provider => new MongoDatabaseClient(
-    CreateRepositorySettings(builder),
-    GetMongoDbNameOverride()
-  )
-);
-
-// The explicit unrestricted seam: resolves to the raw UnrestrictedMongoRepository (no permission/
-// user scoping). Injected only by consumers that deliberately run without a current user (the
-// notification job, auth/login, health endpoints). It is a distinct type from the scoped
-// IUserRestrictedRepository, so
-// unrestricted access is always a conscious, greppable choice and can never be obtained by accident.
-builder.Services.AddTransient<IUnrestrictedRepository>(provider =>
-  {
-    var mongoDbClient = provider.GetService<MongoDatabaseClient>()!;
-    return new UnrestrictedMongoRepository(mongoDbClient);
-  }
-);
-
-builder.Services.AddTransient<IUserRestrictedRepository>(provider =>
-  {
-    var userService = provider.GetService<ICurrentUserService>()!;
-    var mongoDbClient = provider.GetService<MongoDatabaseClient>()!;
-    return new UserRestrictedMongoRepository(mongoDbClient, userService);
-  }
-);
-
-builder.Services.AddTransient<Lazy<IUser>>(provider => provider.GetService<IUserRestrictedRepository>()!.CurrentUser
-);
-
-// The narrow, role-based persistence interfaces resolve to the user-restricted repository (same as
-// IUserRestrictedRepository), so executors that depend on just the role(s) they use transparently
-// get permission enforcement. Consumers that need unrestricted access inject IUnrestrictedRepository
-// (above) instead.
-builder.Services.AddTransient<IUserRepository>(provider => provider.GetService<IUserRestrictedRepository>()!);
-builder.Services.AddTransient<IJournalRepository>(provider => provider.GetService<IUserRestrictedRepository>()!);
-builder.Services.AddTransient<IEntryRepository>(provider => provider.GetService<IUserRestrictedRepository>()!);
-
-// Maintenance is inherently unrestricted (keep-alive, global counts), so it resolves to the
-// unrestricted repository rather than the user-restricted one.
-builder.Services.AddTransient<IMaintenanceRepository>(provider => provider.GetService<IUnrestrictedRepository>()!);
+PersistenceRegistration.RegisterPersistence(builder.Services, builder.Configuration, isE2ETests);
 
 builder.Services.AddSingleton(new E2ETestMode(isE2ETests));
 builder.Services.AddMemoryCache();
@@ -137,47 +85,7 @@ builder.Services.AddTransient<Dispatcher>();
 builder.Services.AddTransient<NotificationJob>();
 builder.Services.AddTransient<INotificationService, OneSignalNotificationService>();
 
-if (isE2ETests)
-{
-  builder.Services.AddAuthentication("BasicAuthentication")
-    .AddScheme<AuthenticationSchemeOptions, BasicAuthenticationHandler>("BasicAuthentication", null);
-}
-else
-{
-  builder.Services.AddAuthentication(options =>
-      {
-        options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-        options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-      }
-    )
-    .AddJwtBearer(options =>
-      {
-        options.RequireHttpsMetadata = false;
-        options.SaveToken = true;
-        options.TokenValidationParameters = new TokenValidationParameters
-        {
-          IssuerSigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(GetJwtSecret(authConfigSection))),
-          ValidateAudience = false,
-          ValidateIssuer = false,
-          ValidateIssuerSigningKey = true,
-          ValidateLifetime = true,
-          ClockSkew = TimeSpan.Zero
-        };
-        options.Events = new JwtBearerEvents
-        {
-          OnTokenValidated = context =>
-          {
-            var jwtToken = (JsonWebToken) context.SecurityToken;
-            Claim? nameClaim = jwtToken.Claims.First(c => c.Type == "nameid");
-            context.HttpContext.RequestServices
-              .GetRequiredService<ICurrentUserService>()
-              .SetUserName(nameClaim.Value);
-            return Task.CompletedTask;
-          }
-        };
-      }
-    );
-}
+AuthenticationRegistration.RegisterAuthentication(builder.Services, authConfigSection, isE2ETests);
 
 builder.Services.AddResponseCompression(options => { options.EnableForHttps = true; });
 
@@ -194,6 +102,9 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+// deliberately wide open: auth is bearer-token based (not cookies), so a browser can't get a
+// cross-origin request to carry credentials on its own - the client always has to attach the
+// token itself, which a foreign origin doesn't have.
 app.UseCors(policyBuilder => policyBuilder.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin());
 
 app.UseAuthentication();
@@ -204,33 +115,6 @@ app.UseResponseCompression();
 app.MapControllers();
 
 app.Run();
-
-string? GetMongoDbNameOverride()
-{
-  return isE2ETests ? "engraved_e2e_tests" : null;
-}
-
-MongoRepositorySettings CreateRepositorySettings(WebApplicationBuilder webApplicationBuilder)
-{
-  var connectionString = webApplicationBuilder.Configuration.GetConnectionString("engraved_db");
-  if (string.IsNullOrEmpty(connectionString) && !isE2ETests)
-  {
-    throw new Exception("App Service Config: No connection string available.");
-  }
-
-  return new MongoRepositorySettings(connectionString ?? "mongodb://localhost:27017");
-}
-
-string GetJwtSecret(IConfigurationSection configurationSection)
-{
-  var jwtSecret = configurationSection.GetValue<string>(nameof(AuthenticationConfig.JwtSecret));
-  if (string.IsNullOrEmpty(jwtSecret))
-  {
-    throw new Exception("App Service Config: No JWT Secret available.");
-  }
-
-  return jwtSecret;
-}
 
 // Exposes the implicit entry-point class so WebApplicationFactory<Program> (the startup smoke test)
 // can reference it. Top-level statements otherwise generate an internal Program.

--- a/api/Engraved.Core.Tests/Engraved.Core.Tests.csproj
+++ b/api/Engraved.Core.Tests/Engraved.Core.Tests.csproj
@@ -12,12 +12,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <!-- NUnit only discovers [SetUpFixture] in the assembly under test, so the shared mongo
-             teardown source is compiled into this assembly too. -->
-        <Compile Include="..\Engraved.Persistence.Mongo.Tests\Source\MongoRunnerTeardown.cs" Link="MongoRunnerTeardown.cs"/>
-    </ItemGroup>
-
-    <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0"/>
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>
         <PackageReference Include="FluentAssertions" Version="8.10.0"/>
@@ -28,6 +22,12 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Include="..\Engraved.Persistence.Mongo.Tests\Source\MongoRunnerTeardown.cs">
+        <Link>Source\MongoRunnerTeardown.cs</Link>
+      </Compile>
     </ItemGroup>
 
 </Project>

--- a/api/Engraved.Tests/Engraved.Tests.csproj
+++ b/api/Engraved.Tests/Engraved.Tests.csproj
@@ -32,9 +32,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <!-- NUnit only discovers [SetUpFixture] in the assembly under test, so the shared mongo
-             teardown source is compiled into this assembly too. -->
-        <Compile Include="..\Engraved.Persistence.Mongo.Tests\Source\MongoRunnerTeardown.cs" Link="MongoRunnerTeardown.cs"/>
+      <Compile Include="..\Engraved.Persistence.Mongo.Tests\Source\MongoRunnerTeardown.cs">
+        <Link>Source\MongoRunnerTeardown.cs</Link>
+      </Compile>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Extracts the Mongo/repository-seam DI wiring and the JWT/Basic auth scheme setup out of `Program.cs` into two new classes, `PersistenceRegistration` and `AuthenticationRegistration` (`api/Engraved.Api/Source/Bootstrap/`), mirroring the existing `ExecutorRegistration` pattern. `Program.cs` drops from 237 to 121 lines and now reads as a flat list of registrations plus the middleware pipeline.
- Fixes an unhandled-exception bug: a validly-signed JWT missing the `nameid` claim previously threw inside `OnTokenValidated` and surfaced as an unhandled 500; it now fails the handshake cleanly and returns 401.
- Adds a comment explaining why CORS is wide open (bearer-token auth, not cookies, so cross-origin requests can't carry credentials on their own).
- Fixes a naming inconsistency (`notificationsJobConfig` → `notificationsJobConfigSection`).
- Updates `ArchitectureShould`'s allowlist for the unrestricted-repository seam: `PersistenceRegistration` is now the composition-root consumer instead of `Program`.
- Adds two tests to `StartupSmokeShould`: one pinning the JWT `nameid` fix (verified it fails on the old code), one pinning the `PerfFilter` response header.

Addresses [#2891](https://github.com/PzYon/engraved/issues/2891).

## Test plan
- [x] `dotnet build` on `Engraved.Api` and `Engraved.Api.Tests` — clean, 0 warnings/errors
- [x] `dotnet test Engraved.Api.Tests` — 20/20 passing
- [x] Confirmed the new `Return_Unauthorized_For_ValidlySignedToken_Missing_NameIdClaim` test fails against the pre-fix code and passes against the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)