### PR TITLE
Fix scheduled/entries tab regressions from the EphemeralMongo test migration

### DIFF
--- a/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_GetAllJournals_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_GetAllJournals_Should.cs
@@ -108,4 +108,42 @@ public class MongoRepositoryBase_GetAllJournals_Should
     );
     results.Length.Should().Be(1);
   }
+
+  [Test]
+  public async Task ReturnAllJournals_SchedulesOnly_ExcludesFiredSchedules()
+  {
+    // pending schedule for "max"
+    await _repository.UpsertJournal(
+      new GaugeJournal
+      {
+        Schedules = new Dictionary<string, Schedule>
+        {
+          { "max", new Schedule { NextOccurrence = DateTime.Now.AddDays(3) } }
+        }
+      }
+    );
+
+    // schedule for "max" that has already fired (sub-document kept, but no pending occurrence)
+    await _repository.UpsertJournal(
+      new GaugeJournal
+      {
+        Schedules = new Dictionary<string, Schedule>
+        {
+          { "max", new Schedule { NextOccurrence = null } }
+        }
+      }
+    );
+
+    IJournal[] results = await _repository.GetAllJournals(
+      null,
+      ScheduleMode.CurrentUserOnly,
+      null,
+      null,
+      null,
+      "max"
+    );
+
+    // only the journal with a pending occurrence counts as "scheduled"
+    results.Length.Should().Be(1);
+  }
 }

--- a/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_SearchEntries_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_SearchEntries_Should.cs
@@ -237,4 +237,94 @@ public class MongoRepositoryBase_SearchEntries_Should
     ((ScrapsEntry)results[1]).Title.Should().Be("WithOtherUserSchedule");
     ((ScrapsEntry)results[5]).Title.Should().Be("WithoutSchedule");
   }
+
+  [Test]
+  public async Task ScheduleModeNone_SortsPurelyByEditedOn_WithoutFloatingScheduled()
+  {
+    // The "entries" tab uses ScheduleMode.None and must be sorted purely by edited date descending.
+    // A scheduled entry that was edited long ago must NOT be floated to the top.
+    var currentUserId = ObjectId.GenerateNewId().ToString();
+
+    UpsertResult journal = await _repository.UpsertJournal(
+      new ScrapsJournal { Name = "Tab", UserId = currentUserId }
+    );
+
+    await _repository.UpsertEntry(
+      new ScrapsEntry
+      {
+        ParentId = journal.EntityId,
+        ScrapType = ScrapType.List,
+        Title = "OldButScheduled",
+        EditedOn = DateTime.Now.AddDays(-100),
+        Schedules = { { currentUserId, new Schedule { NextOccurrence = DateTime.Now.AddDays(1) } } }
+      }
+    );
+
+    await _repository.UpsertEntry(
+      new ScrapsEntry
+      {
+        ParentId = journal.EntityId,
+        ScrapType = ScrapType.List,
+        Title = "RecentUnscheduled",
+        EditedOn = DateTime.Now.AddDays(-1)
+      }
+    );
+
+    IEntry[] results = await _repository.SearchEntries(
+      null,
+      ScheduleMode.None,
+      null,
+      [journal.EntityId],
+      20,
+      currentUserId
+    );
+
+    results.Length.Should().Be(2);
+    ((ScrapsEntry)results[0]).Title.Should().Be("RecentUnscheduled");
+    ((ScrapsEntry)results[1]).Title.Should().Be("OldButScheduled");
+  }
+
+  [Test]
+  public async Task ScheduleModeCurrentUserOnly_ExcludesEntriesWhoseScheduleHasNoPendingOccurrence()
+  {
+    // The "scheduled" tab uses ScheduleMode.CurrentUserOnly. A schedule sub-document is kept after it
+    // has fired (NextOccurrence nulled out), so such an entry must NOT be returned as "scheduled".
+    var currentUserId = ObjectId.GenerateNewId().ToString();
+
+    UpsertResult journal = await _repository.UpsertJournal(
+      new ScrapsJournal { Name = "Tab", UserId = currentUserId }
+    );
+
+    await _repository.UpsertEntry(
+      new ScrapsEntry
+      {
+        ParentId = journal.EntityId,
+        ScrapType = ScrapType.List,
+        Title = "Pending",
+        Schedules = { { currentUserId, new Schedule { NextOccurrence = DateTime.Now.AddDays(1) } } }
+      }
+    );
+
+    await _repository.UpsertEntry(
+      new ScrapsEntry
+      {
+        ParentId = journal.EntityId,
+        ScrapType = ScrapType.List,
+        Title = "AlreadyFired",
+        Schedules = { { currentUserId, new Schedule { NextOccurrence = null } } }
+      }
+    );
+
+    IEntry[] results = await _repository.SearchEntries(
+      null,
+      ScheduleMode.CurrentUserOnly,
+      null,
+      [journal.EntityId],
+      20,
+      currentUserId
+    );
+
+    results.Length.Should().Be(1);
+    ((ScrapsEntry)results[0]).Title.Should().Be("Pending");
+  }
 }

--- a/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
+++ b/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
@@ -127,9 +127,11 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
         throw new Exception("Current user id is required");
       }
 
+      // "scheduled" means a schedule with a pending occurrence: a fired schedule keeps its sub-document
+      // (with NextOccurrence nulled out), so we must check NextOccurrence rather than mere existence.
       filters.Add(Builders<JournalDocument>.Filter.And(
         Builders<JournalDocument>.Filter.Exists($"Schedules.{currentUserId}"),
-        Builders<JournalDocument>.Filter.Ne($"Schedules.{currentUserId}", BsonNull.Value)
+        Builders<JournalDocument>.Filter.Ne($"Schedules.{currentUserId}.NextOccurrence", BsonNull.Value)
       ));
     }
 
@@ -276,18 +278,17 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
       filters.Add(GetHasScheduleForCurrentUserFilter(currentUserId));
     }
 
-    var entries = await LoadData(
+    // Ordering is done at the DB level (see defaultSort below, and the CurrentUserFirst branch in
+    // LoadDocuments). We deliberately do NOT re-order scheduled entries to the front here: the entries
+    // tab (ScheduleMode.None) must stay sorted purely by edited date, and the scheduled tab
+    // (CurrentUserOnly) already contains only scheduled entries.
+    return await LoadData(
       limit,
       scheduleMode,
       currentUserId,
       filters,
       Builders<EntryDocument>.Sort.Descending(d => d.EditedOn).Descending(d => d.Id)
     );
-
-    return entries.OrderByDescending(e => e.Schedules.ContainsKey(currentUserId ?? "") && e.Schedules[currentUserId ?? ""].NextOccurrence != null)
-      .ThenByDescending(e => e.EditedOn)
-      .ThenByDescending(e => e.Id)
-      .ToArray();
   }
 
   private async Task<IEntry[]> LoadData(
@@ -553,9 +554,12 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
 
   private static FilterDefinition<EntryDocument> GetHasScheduleForCurrentUserFilter(string currentUserId)
   {
+    // "scheduled" means the user has a schedule with a pending occurrence. A schedule sub-document is
+    // kept around after it has fired (with NextOccurrence set to null), so checking mere existence of
+    // the sub-document would wrongly surface already-fired schedules as "scheduled".
     return Builders<EntryDocument>.Filter.And(
       Builders<EntryDocument>.Filter.Exists($"Schedules.{currentUserId}"),
-      Builders<EntryDocument>.Filter.Ne($"Schedules.{currentUserId}", BsonNull.Value)
+      Builders<EntryDocument>.Filter.Ne($"Schedules.{currentUserId}.NextOccurrence", BsonNull.Value)
     );
   }
 


### PR DESCRIPTION
## What broke

Two behavioral regressions traced to **eaeb4479** ("Migrate integration tests from the in-memory fake to EphemeralMongo", #2876). When the queries moved to real MongoDB, the schedule filters were rewritten (the old LINQ `d.Schedules[userId].NextOccurrence` couldn't be translated by the driver), and that rewrite changed behavior. No frontend change was involved.

### 1. "Scheduled" tab leaked already-fired schedules
A schedule sub-document is kept after it fires (retaining `NotifiedOn`/`NotificationId`), with `NextOccurrence` nulled out. The old filter required `NextOccurrence != null`; the rewrite only checked that the sub-document exists:

```
Ne($"Schedules.{userId}", null)               // wrong: matches fired schedules
Ne($"Schedules.{userId}.NextOccurrence", null) // fixed
```

Fixed for **both entries and journals** (the scheduled tab shows both).

### 2. "Entries" tab sorted scheduled entries first
`SearchEntries` gained an unconditional in-memory `OrderByDescending(has-schedule)` that ran for **every** mode — so the entries tab (`ScheduleMode.None`) floated scheduled entries to the top instead of sorting purely by edited date. The original code had no such re-sort; ordering is handled at the DB level (`defaultSort`, plus the `CurrentUserFirst` branch that legitimately does scheduled-first). Removed it.

## Tests

Added 3 regression tests:
- entries tab (`None`) stays in pure edited-date-descending order
- `CurrentUserOnly` excludes fired schedules — for entries and for journals

Full suites green: **Mongo 98, Core 81, Engraved.Tests 8**. The existing `CurrentUserFirst` sort test still passes (its ordering comes from the DB query, not the deleted re-sort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)