### PR TITLE
Create a DI scope per notification job run

### DIFF
--- a/api/Engraved.Api/Source/Jobs/ScheduledNotificationJob.cs
+++ b/api/Engraved.Api/Source/Jobs/ScheduledNotificationJob.cs
@@ -1,10 +1,10 @@
-﻿using Engraved.Core.Application.Jobs;
+using Engraved.Core.Application.Jobs;
 using Microsoft.Extensions.Options;
 
 namespace Engraved.Api.Jobs;
 
 public class ScheduledNotificationJob(
-  NotificationJob notificationJob,
+  IServiceScopeFactory serviceScopeFactory,
   IOptions<NotificationsJobConfig> notificationsJobConfig
 )
   : BackgroundService
@@ -22,7 +22,14 @@ public class ScheduledNotificationJob(
       while (!stoppingToken.IsCancellationRequested && await timer.WaitForNextTickAsync(stoppingToken))
       {
         bool isDryRun = notificationsJobConfig.Value.Mode == NotificationsJobMode.DryRun;
-        await notificationJob.Execute(isDryRun);
+
+        // a fresh scope per run so the job and its dependencies (repository, date service, ...)
+        // are created anew every time instead of being captured once by this singleton.
+        using (IServiceScope scope = serviceScopeFactory.CreateScope())
+        {
+          var notificationJob = scope.ServiceProvider.GetRequiredService<NotificationJob>();
+          await notificationJob.Execute(isDryRun);
+        }
       }
     }
   }

--- a/api/Engraved.Core.Tests/Source/Application/DateServiceShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/DateServiceShould.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -7,11 +7,9 @@ namespace Engraved.Core.Application;
 public class DateServiceShould
 {
   [Test]
-  public void SetUtcDate_WhenUpdateDateIsCalled()
+  public void ProvideUtcDate()
   {
     var service = new DateService();
-
-    service.UpdateDate();
 
     service.UtcNow.Kind.Should().Be(DateTimeKind.Utc);
   }

--- a/api/Engraved.Core/Source/Application/IDateService.cs
+++ b/api/Engraved.Core/Source/Application/IDateService.cs
@@ -1,20 +1,13 @@
-﻿namespace Engraved.Core.Application;
+namespace Engraved.Core.Application;
 
 public interface IDateService
 {
   public DateTime UtcNow { get; }
-
-  public void UpdateDate();
 }
 
 public class DateService : IDateService
 {
-  public DateTime UtcNow { get; private set; } = DateTime.UtcNow;
-
-  public void UpdateDate()
-  {
-    UtcNow = DateTime.UtcNow;
-  }
+  public DateTime UtcNow { get; } = DateTime.UtcNow;
 }
 
 public class FakeDateService(DateTime initialDate) : IDateService
@@ -22,11 +15,6 @@ public class FakeDateService(DateTime initialDate) : IDateService
   public FakeDateService() : this(DateTime.UtcNow) { }
 
   public DateTime UtcNow { get; set; } = initialDate;
-
-  public void UpdateDate()
-  {
-    UtcNow = DateTime.UtcNow;
-  }
 
   public void SetNext(int remainingSteps)
   {
@@ -57,6 +45,4 @@ public class SelfIncrementingDateService : IDateService
       return next;
     }
   }
-
-  public void UpdateDate() { }
 }

--- a/api/Engraved.Core/Source/Application/Jobs/NotificationJob.cs
+++ b/api/Engraved.Core/Source/Application/Jobs/NotificationJob.cs
@@ -19,10 +19,6 @@ public class NotificationJob(
 {
   public async Task<NotificationJobResult> Execute(bool isDryRun)
   {
-    // as the date service is created and inject once at the start of the
-    // job, we need to make sure, that we always use the current date.
-    dateService.UpdateDate();
-
     var result = new NotificationJobResult();
 
     try


### PR DESCRIPTION
## Summary

`ScheduledNotificationJob` (a singleton hosted service) previously captured one transient `NotificationJob` instance — and thereby one repository and one `DateService` — for the entire application lifetime. The `IDateService.UpdateDate()` method existed solely to compensate for the stale captured timestamp.

- `ScheduledNotificationJob` now injects `IServiceScopeFactory` and creates a fresh DI scope for every run, resolving `NotificationJob` and its dependencies anew each tick (the standard ASP.NET pattern for hosted services).
- Removed the `dateService.UpdateDate()` call from `NotificationJob` and removed `UpdateDate()` from `IDateService` and all implementations.
- `DateService.UtcNow` is now a plain get-only property; the `DateServiceShould` test was updated accordingly.

## Test plan

- Full solution builds clean.
- All test projects pass (109 tests), including the `NotificationJobShould` suite and the startup smoke test that boots the real host and validates DI wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)