### PR TITLE
Fix PermissionsEnsurer aborting on PermissionKind.None

### DIFF
--- a/api/Engraved.Core.Tests/Source/Domain/Permissions/PermissionsEnsurerShould.cs
+++ b/api/Engraved.Core.Tests/Source/Domain/Permissions/PermissionsEnsurerShould.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Engraved.TestUtils;
 using Engraved.Core.Application.Permissions;
@@ -45,6 +46,29 @@ public class PermissionsEnsurerShould
     );
 
     holder.Permissions.Count.Should().Be(0);
+  }
+
+  [Test]
+  public async Task ProcessRemainingUsers_After_RemovingPermissions_With_None()
+  {
+    var holder = new TestPermissionHolder
+    {
+      Permissions = new UserPermissions { { TestIds.UserId, new PermissionDefinition { Kind = PermissionKind.Read } } }
+    };
+
+    // the None entry must not abort processing of the entries after it
+    await _permissionsEnsurer.EnsurePermissions(
+      holder,
+      new Dictionary<string, PermissionKind>
+      {
+        { "mar@foo.ch", PermissionKind.None },
+        { "bar@foo.ch", PermissionKind.Write }
+      }
+    );
+
+    holder.Permissions.Count.Should().Be(1);
+    holder.Permissions.Should().NotContainKey(TestIds.UserId);
+    holder.Permissions.Single().Value.Kind.Should().Be(PermissionKind.Write);
   }
 
   [Test]

--- a/api/Engraved.Core/Source/Application/Permissions/PermissionsEnsurer.cs
+++ b/api/Engraved.Core/Source/Application/Permissions/PermissionsEnsurer.cs
@@ -21,7 +21,7 @@ public class PermissionsEnsurer(
       if (kind == PermissionKind.None)
       {
         permissionHolder.Permissions.Remove(userId);
-        return;
+        continue;
       }
 
       permissionHolder.Permissions[userId] = new PermissionDefinition { Kind = kind };


### PR DESCRIPTION
## Summary

`PermissionsEnsurer.EnsurePermissions` used `return` instead of `continue` when an entry with `PermissionKind.None` was processed, so all users after it in the dictionary were silently skipped when saving permissions for several users at once.

## Test plan

New test `ProcessRemainingUsers_After_RemovingPermissions_With_None` covers a multi-entry dictionary with a `None` entry first — it fails on the old code and passes now. All existing tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)