### PR TITLE
Fix MoveEntry computing affected users from the wrong journal

### DIFF
--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Move/MoveEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Move/MoveEntryCommandExecutorShould.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
+using Engraved.Core.Domain.Permissions;
 using Engraved.TestUtils;
 using FluentAssertions;
 using NUnit.Framework;
@@ -64,5 +65,63 @@ public class MoveEntryCommandExecutorShould
 
     sourceEntries = await _repo.GetEntriesForJournal(sourceJournalId);
     sourceEntries.Should().BeEmpty();
+  }
+
+  [Test]
+  public async Task ReturnAffectedUserIds_Of_SourceAndTargetJournal()
+  {
+    const string sourceJournalId = "60703c3b0000000000000001";
+    const string targetJournalId = "60703c3b0000000000000002";
+    const string entryId = "60703c3b0000000000000003";
+
+    // given: a user with permissions on the source journal and another one on the target journal
+    await _repo.UpsertJournal(
+      new CounterJournal
+      {
+        Id = sourceJournalId,
+        Permissions = new UserPermissions
+        {
+          { TestIds.UserId, new PermissionDefinition { Kind = PermissionKind.Read } }
+        }
+      }
+    );
+
+    await _repo.UpsertJournal(
+      new CounterJournal
+      {
+        Id = targetJournalId,
+        Permissions = new UserPermissions
+        {
+          { TestIds.OtherUserId, new PermissionDefinition { Kind = PermissionKind.Read } }
+        }
+      }
+    );
+
+    await _repo.UpsertEntry(
+      new CounterEntry
+      {
+        Id = entryId,
+        ParentId = sourceJournalId,
+        DateTime = _dateService.UtcNow
+      }
+    );
+
+    // when
+    CommandResult result = await new MoveEntryCommandExecutor(
+      _repo,
+      _repo,
+      _dateService
+    ).Execute(
+      new MoveEntryCommand
+      {
+        EntryId = entryId,
+        TargetJournalId = targetJournalId
+      }
+    );
+
+    // then: users of BOTH journals are affected (e.g. for cache invalidation),
+    // especially the ones only having access to the source journal.
+    result.AffectedUserIds.Should().Contain(TestIds.UserId);
+    result.AffectedUserIds.Should().Contain(TestIds.OtherUserId);
   }
 }

--- a/api/Engraved.Core/Source/Application/Commands/Entries/Move/MoveEntryCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Entries/Move/MoveEntryCommandExecutor.cs
@@ -42,25 +42,15 @@ public class MoveEntryCommandExecutor(
     entry.ParentId = targetJournal.Id!;
     await entryRepository.UpsertEntry(entry);
 
-    string[] affectedUserIds = await GetAffectedUserIds(journalRepository, entry, targetJournal);
+    // use the source journal loaded above: entry.ParentId already points to the target here,
+    // so re-loading via the entry would wrongly derive both sides from the target journal.
+    string[] affectedUserIds = targetJournal.Permissions.GetUserIdsWithAccess()
+      .Union(sourceJournal.Permissions.GetUserIdsWithAccess())
+      .ToArray();
 
     return new CommandResult(
       command.EntryId,
       affectedUserIds
     );
-  }
-
-  private static async Task<string[]> GetAffectedUserIds(
-    IJournalRepository repository,
-    IEntry entry,
-    IJournal targetJournal
-  )
-  {
-    IJournal sourceJournal = (await repository.GetJournal(entry.ParentId))!;
-
-    return targetJournal.Permissions.GetUserIdsWithAccess()
-      .Union(sourceJournal.Permissions.GetUserIdsWithAccess())
-      .Distinct()
-      .ToArray();
   }
 }


### PR DESCRIPTION
## Summary

`MoveEntryCommandExecutor.GetAffectedUserIds` re-loaded the "source" journal via `entry.ParentId` AFTER the entry had already been re-parented to the target journal — so both sides of the union were derived from the target. Users who only have access to the source journal were missing from `CommandResult.AffectedUserIds`, leaving their query cache stale after a move.

The fix uses the source journal that was already loaded before the move (which also saves the redundant reload).

## Test plan

New test `ReturnAffectedUserIds_Of_SourceAndTargetJournal` gives the source and target journals different permitted users and asserts both appear in the result — fails on the old code. All existing tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)