### PR TITLE
Fix missing LogBook case in journal/entry type filters

### DIFF
--- a/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_GetAllJournals_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_GetAllJournals_Should.cs
@@ -69,6 +69,17 @@ public class MongoRepositoryBase_GetAllJournals_Should
   }
 
   [Test]
+  public async Task Return_Matching_JournalTypes_LogBook()
+  {
+    await _repository.UpsertJournal(new LogBookJournal { Name = "LogBook" });
+
+    IJournal[] results = await _repository.GetAllJournals(null, null, [JournalType.LogBook]);
+
+    results.Length.Should().Be(1);
+    results[0].Should().BeOfType<LogBookJournal>();
+  }
+
+  [Test]
   public async Task Return_Matching_JournalId()
   {
     IJournal[] results = await _repository.GetAllJournals(null, null, null, [_gaugeJournalId], 10);

--- a/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_SearchEntries_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_SearchEntries_Should.cs
@@ -173,6 +173,28 @@ public class MongoRepositoryBase_SearchEntries_Should
   }
 
   [Test]
+  public async Task Consider_JournalTypes_LogBook()
+  {
+    var journal = new LogBookJournal { Name = "My LogBook" };
+    UpsertResult result = await _repository.UpsertJournal(journal);
+
+    await _repository.UpsertEntry(
+      new LogBookEntry { ParentId = result.EntityId, Notes = "log book entry" }
+    );
+
+    IEntry[] results = await _repository.SearchEntries(
+      null,
+      null,
+      [JournalType.LogBook],
+      null,
+      10
+    );
+
+    results.Length.Should().Be(1);
+    results[0].Should().BeOfType<LogBookEntry>();
+  }
+
+  [Test]
   public async Task Sort_Scheduled_Before_EditedOn()
   {
     var currentUserId = ObjectId.GenerateNewId().ToString();

--- a/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
+++ b/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
@@ -463,6 +463,7 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
       JournalType.Gauge => d => d.GetType() == typeof(GaugeJournalDocument),
       JournalType.Timer => d => d.GetType() == typeof(TimerJournalDocument),
       JournalType.Scraps => d => d.GetType() == typeof(ScrapsJournalDocument),
+      JournalType.LogBook => d => d.GetType() == typeof(LogBookJournalDocument),
       _ => throw new ArgumentOutOfRangeException(
         nameof(journalType),
         journalType,
@@ -483,6 +484,8 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
         return d => d.GetType() == typeof(TimerEntryDocument);
       case JournalType.Scraps:
         return d => d.GetType() == typeof(ScrapsEntryDocument);
+      case JournalType.LogBook:
+        return d => d.GetType() == typeof(LogBookEntryDocument);
       default:
         throw new ArgumentOutOfRangeException(
           nameof(journalType),


### PR DESCRIPTION
## Summary

`GetIsJournalTypeExpression` and `GetIsEntryTypeExpression` in `MongoRepositoryBase` did not handle `JournalType.LogBook`, so filtering by that type (e.g. `?journalTypes=LogBook` on the API) threw `ArgumentOutOfRangeException` and surfaced as a 500.

## Test plan

New tests `Return_Matching_JournalTypes_LogBook` (journals) and `Consider_JournalTypes_LogBook` (entries) run the filter against the real (ephemeral) Mongo — both fail on the old code. All existing tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)