### PR TITLE
Await fire-and-forget async calls in controllers

### DIFF
--- a/api/Engraved.Api/Source/Controllers/NotificationsController.cs
+++ b/api/Engraved.Api/Source/Controllers/NotificationsController.cs
@@ -20,12 +20,12 @@ public class NotificationsController(
   public async Task SendNotification()
   {
     IUser user = await currentUserService.LoadUser();
-    SendNotificationToUser(user.GlobalUniqueId);
+    await SendNotificationToUser(user.GlobalUniqueId);
   }
 
-  private void SendNotificationToUser(Guid? uniqueUserId)
+  private async Task SendNotificationToUser(Guid? uniqueUserId)
   {
-    notificationService.SendNotification(
+    await notificationService.SendNotification(
       new ClientNotification
       {
         UserId = uniqueUserId?.ToString(),

--- a/api/Engraved.Api/Source/Controllers/RootController.cs
+++ b/api/Engraved.Api/Source/Controllers/RootController.cs
@@ -8,10 +8,10 @@ namespace Engraved.Api.Controllers;
 public class RootController(IUnrestrictedRepository unrestrictedRepository) : Controller
 {
   [HttpGet]
-  public void Get()
+  public async Task Get()
   {
     // required to serve keep alive requests from azure. we deliberately
     // call the database in the hope to keep stuff alive.
-    unrestrictedRepository.WakeMeUp();
+    await unrestrictedRepository.WakeMeUp();
   }
 }


### PR DESCRIPTION
## Summary

- `NotificationsController` did not await `SendNotification`: failures were unobserved (lost exceptions) and the request completed before the send actually happened.
- `RootController` did not await `WakeMeUp`, which also defeated its stated keep-alive purpose — the response returned before the database call was made.

## Test plan

Full suite green (215 tests), including the startup smoke test that hits `/` and now exercises the awaited `WakeMeUp` against the ephemeral Mongo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)