### PR TITLE
Map exceptions to proper HTTP status codes

### DIFF
--- a/api/Engraved.Api.Tests/Source/HttpExceptionFilterShould.cs
+++ b/api/Engraved.Api.Tests/Source/HttpExceptionFilterShould.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using Engraved.Api.Authentication.Google;
+using Engraved.Api.Filters;
+using Engraved.Core.Application.Commands;
+using Engraved.Core.Application.Commands.Journals.Add;
+using Engraved.Core.Application.Persistence;
+using Engraved.Core.Application.Queries;
+using Engraved.Core.Application.Queries.Journals.Get;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using NUnit.Framework;
+
+namespace Engraved.Api.Tests;
+
+// Pins the exception-to-status-code mapping: without it, every failure surfaces as a 500,
+// hiding validation errors (400), permission problems (403) and auth problems (401) from clients.
+public class HttpExceptionFilterShould
+{
+  [Test]
+  public void Map_InvalidCommandException_To_400()
+  {
+    GetStatusCodeFor(new InvalidCommandException(new AddJournalCommand(), "invalid")).Should().Be(400);
+  }
+
+  [Test]
+  public void Map_InvalidQueryException_To_400()
+  {
+    GetStatusCodeFor(new InvalidQueryException(new GetJournalQuery(), "invalid")).Should().Be(400);
+  }
+
+  [Test]
+  public void Map_NotAllowedOperationException_To_403()
+  {
+    GetStatusCodeFor(new NotAllowedOperationException("not allowed")).Should().Be(403);
+  }
+
+  [Test]
+  public void Map_TokenValidationException_To_401()
+  {
+    GetStatusCodeFor(new GoogleTokenValidationException("invalid token")).Should().Be(401);
+  }
+
+  [Test]
+  public void Map_GenericException_To_500()
+  {
+    GetStatusCodeFor(new Exception("boom")).Should().Be(500);
+  }
+
+  [Test]
+  public void DoNothing_WithoutException()
+  {
+    ActionExecutedContext context = CreateContext(null);
+
+    new HttpExceptionFilter().OnActionExecuted(context);
+
+    context.Result.Should().BeNull();
+  }
+
+  private static int? GetStatusCodeFor(Exception exception)
+  {
+    ActionExecutedContext context = CreateContext(exception);
+
+    new HttpExceptionFilter().OnActionExecuted(context);
+
+    context.ExceptionHandled.Should().BeTrue();
+    return ((ObjectResult)context.Result!).StatusCode;
+  }
+
+  private static ActionExecutedContext CreateContext(Exception? exception)
+  {
+    var actionContext = new ActionContext(new DefaultHttpContext(), new RouteData(), new ActionDescriptor());
+    return new ActionExecutedContext(actionContext, new List<IFilterMetadata>(), controller: new object())
+    {
+      Exception = exception
+    };
+  }
+}

--- a/api/Engraved.Api/Source/Authentication/Basic/BasicAuthenticationHandler.cs
+++ b/api/Engraved.Api/Source/Authentication/Basic/BasicAuthenticationHandler.cs
@@ -31,7 +31,7 @@ public class BasicAuthenticationHandler(
     AuthenticationHeaderValue authHeader = AuthenticationHeaderValue.Parse(value!);
     if (string.IsNullOrEmpty(authHeader.Parameter))
     {
-      throw new Exception("Username must be specified.");
+      return AuthenticateResult.Fail("Username must be specified.");
     }
 
     currentUserService.SetUserName(authHeader.Parameter);

--- a/api/Engraved.Api/Source/Authentication/CurrentUserService.cs
+++ b/api/Engraved.Api/Source/Authentication/CurrentUserService.cs
@@ -13,7 +13,7 @@ public class CurrentUserService(IHttpContextAccessor httpContextAccessor, UserLo
   {
     if (httpContextAccessor.HttpContext == null)
     {
-      throw new Exception("HttpContext is not set");
+      throw new InvalidOperationException("HttpContext is not set");
     }
 
     return httpContextAccessor.HttpContext.Items[Key] as string;
@@ -23,7 +23,7 @@ public class CurrentUserService(IHttpContextAccessor httpContextAccessor, UserLo
   {
     if (httpContextAccessor.HttpContext == null)
     {
-      throw new Exception("HttpContext is not set");
+      throw new InvalidOperationException("HttpContext is not set");
     }
 
     httpContextAccessor.HttpContext.Items[Key] = userName;

--- a/api/Engraved.Api/Source/Authentication/JwtTokenFactory.cs
+++ b/api/Engraved.Api/Source/Authentication/JwtTokenFactory.cs
@@ -39,7 +39,7 @@ public class JwtTokenFactory(AuthenticationConfig configuration, IDateService da
   {
     if (string.IsNullOrEmpty(configuration.JwtSecret))
     {
-      throw new Exception($"\"{nameof(AuthenticationConfig.JwtSecret)}\" must be set on the config.");
+      throw new InvalidOperationException($"\"{nameof(AuthenticationConfig.JwtSecret)}\" must be set on the config.");
     }
 
     return new SigningCredentials(

--- a/api/Engraved.Api/Source/Authentication/LoginHandler.cs
+++ b/api/Engraved.Api/Source/Authentication/LoginHandler.cs
@@ -44,7 +44,7 @@ public class LoginHandler(
   {
     if (string.IsNullOrEmpty(userName))
     {
-      throw new Exception($"{nameof(userName)} is null, maybe you are not running test mode?");
+      throw new ArgumentException($"{nameof(userName)} is null, maybe you are not running test mode?", nameof(userName));
     }
 
     IUser user = await EnsureUser(userName, userName, null);

--- a/api/Engraved.Api/Source/Bootstrap/AuthenticationRegistration.cs
+++ b/api/Engraved.Api/Source/Bootstrap/AuthenticationRegistration.cs
@@ -77,7 +77,7 @@ public static class AuthenticationRegistration
     var jwtSecret = configurationSection.GetValue<string>(nameof(AuthenticationConfig.JwtSecret));
     if (string.IsNullOrEmpty(jwtSecret))
     {
-      throw new Exception("App Service Config: No JWT Secret available.");
+      throw new InvalidOperationException("App Service Config: No JWT Secret available.");
     }
 
     return jwtSecret;

--- a/api/Engraved.Api/Source/Bootstrap/PersistenceRegistration.cs
+++ b/api/Engraved.Api/Source/Bootstrap/PersistenceRegistration.cs
@@ -68,7 +68,7 @@ public static class PersistenceRegistration
     var connectionString = configuration.GetConnectionString("engraved_db");
     if (string.IsNullOrEmpty(connectionString) && !isE2ETests)
     {
-      throw new Exception("App Service Config: No connection string available.");
+      throw new InvalidOperationException("App Service Config: No connection string available.");
     }
 
     return new MongoRepositorySettings(connectionString ?? "mongodb://localhost:27017");

--- a/api/Engraved.Api/Source/Filters/HttpExceptionFilter.cs
+++ b/api/Engraved.Api/Source/Filters/HttpExceptionFilter.cs
@@ -1,4 +1,7 @@
-﻿using Engraved.Api.Authentication;
+using Engraved.Api.Authentication;
+using Engraved.Core.Application.Commands;
+using Engraved.Core.Application.Persistence;
+using Engraved.Core.Application.Queries;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
@@ -17,9 +20,20 @@ public class HttpExceptionFilter : IActionFilter
 
     context.Result = new ObjectResult(ApiError.FromException(context.Exception))
     {
-      StatusCode = context.Exception is ITokenValidationException ? 401 : 500
+      StatusCode = GetStatusCode(context.Exception)
     };
 
     context.ExceptionHandled = true;
+  }
+
+  private static int GetStatusCode(Exception exception)
+  {
+    return exception switch
+    {
+      ITokenValidationException => StatusCodes.Status401Unauthorized,
+      NotAllowedOperationException => StatusCodes.Status403Forbidden,
+      InvalidCommandException or InvalidQueryException => StatusCodes.Status400BadRequest,
+      _ => StatusCodes.Status500InternalServerError
+    };
   }
 }

--- a/api/Engraved.Core/Source/Application/Commands/Users/CleanupTags/CleanupTagsCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Users/CleanupTags/CleanupTagsCommandExecutor.cs
@@ -11,7 +11,7 @@ public class CleanupTagsCommandExecutor(IUserRestrictedRepository repository)
   {
     if (repository.CurrentUser.Value == null)
     {
-      throw new Exception("No current user");
+      throw new NotAllowedOperationException("Current user is not available.");
     }
 
     IUser currentUser = repository.CurrentUser.Value;

--- a/api/Engraved.Core/Source/Application/Jobs/NotificationJob.cs
+++ b/api/Engraved.Core/Source/Application/Jobs/NotificationJob.cs
@@ -68,7 +68,7 @@ public class NotificationJob(
           IUser? user = await unrestrictedRepository.GetUser(userId);
           if (user == null)
           {
-            throw new Exception($"User \"{userId}\" can not be loaded");
+            throw new InvalidOperationException($"User \"{userId}\" can not be loaded");
           }
 
           if (!isDryRun)

--- a/api/Engraved.Core/Source/Application/Queries/QueryCache.cs
+++ b/api/Engraved.Core/Source/Application/Queries/QueryCache.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Engraved.Core.Application.Persistence;
 using Engraved.Core.Domain.Users;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -179,7 +180,7 @@ public class QueryCache(ILogger<QueryCache> logger, IMemoryCache memoryCache, La
     var userId = currentUser.Value.Id;
     if (string.IsNullOrEmpty(userId))
     {
-      throw new Exception("User ID is not available.");
+      throw new NotAllowedOperationException("User ID is not available.");
     }
 
     return userId;

--- a/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
+++ b/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
@@ -124,7 +124,7 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
     {
       if (string.IsNullOrEmpty(currentUserId))
       {
-        throw new Exception("Current user id is required");
+        throw new ArgumentException("Current user id is required", nameof(currentUserId));
       }
 
       // "scheduled" means a schedule with a pending occurrence: a fired schedule keeps its sub-document
@@ -272,7 +272,7 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
     {
       if (string.IsNullOrEmpty(currentUserId))
       {
-        throw new Exception("Current user id is required");
+        throw new ArgumentException("Current user id is required", nameof(currentUserId));
       }
 
       filters.Add(GetHasScheduleForCurrentUserFilter(currentUserId));
@@ -335,7 +335,7 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
 
     if (string.IsNullOrEmpty(currentUserId))
     {
-      throw new Exception(
+      throw new ArgumentException(
         $"\"{nameof(currentUserId)}\" must be specified when using {ScheduleMode.CurrentUserFirst}."
       );
     }


### PR DESCRIPTION
## Summary

Two tightly-coupled review findings fixed together: the exception filter could only map what the exception types expressed, and the many generic `throw new Exception(...)` calls erased that information.

**Status-code mapping** (`HttpExceptionFilter`) — previously everything but token exceptions returned 500:
- `InvalidCommandException` / `InvalidQueryException` → 400
- `NotAllowedOperationException` → 403
- `ITokenValidationException` → 401 (unchanged)
- everything else → 500

**Specific exception types** at the 13 generic throw sites:
- auth-state problems (`CleanupTagsCommandExecutor`, `QueryCache`) → `NotAllowedOperationException` (now 403, was 500)
- config/invariant violations (JWT secret, connection string, `HttpContext`, NotificationJob user load) → `InvalidOperationException`
- caller-contract violations (`LoginForTests` userName, `MongoRepositoryBase` currentUserId) → `ArgumentException`
- `BasicAuthenticationHandler` (e2e only) fails the handshake with `AuthenticateResult.Fail` (401) instead of throwing (500)

## Client safety

`ServerApi.ts` only special-cases 401 (token refresh + retry, unchanged) and handles all other error codes generically, so responses moving from 500 to 400/403 are safe.

## Test plan

New `HttpExceptionFilterShould` pins all mappings plus the no-exception passthrough. Full solution builds with 0 warnings; all 225 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)