### PR TITLE
Seed loaded journals into the correct query cache key

### DIFF
--- a/app/src/serverApi/reactQuery/queries/useJournalsQuery.ts
+++ b/app/src/serverApi/reactQuery/queries/useJournalsQuery.ts
@@ -40,11 +40,11 @@ export const useJournalsQuery = (
 
     for (const loadedJournal of journals) {
       queryClient.setQueryData(
-        queryKeysFactory.journals(loadedJournal.id, journalTypes),
+        queryKeysFactory.journal(loadedJournal.id),
         () => loadedJournal,
       );
     }
-  }, [isSuccess, journalTypes, journals, queryClient]);
+  }, [isSuccess, journals, queryClient]);
 
   return journals ?? [];
 };


### PR DESCRIPTION
## Problem

After loading the journals list, `useJournalsQuery` tries to pre-populate the individual-journal cache so a subsequent navigation to a journal detail page can render immediately. But it seeded the data under `queryKeysFactory.journals(loadedJournal.id, journalTypes)` — the **list** key factory, with the journal id passed into the `searchText` slot. That yields a key like `["journals","all",<id>,"",false,""]` that no hook ever reads.

`useJournalQuery(id)` reads `queryKeysFactory.journal(id)` → `["journals",<id>]`. Because the seeded data lived under a different key, the seeding was effectively a no-op and the detail page always refetched.

## Change

Seed under `queryKeysFactory.journal(loadedJournal.id)` so the data lands where `useJournalQuery` looks for it. `journalTypes` is no longer used inside the effect, so it is removed from the dependency array.

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)