### PR TITLE
Debounce scrap drafts per cache key

### DIFF
--- a/app/src/components/details/scraps/AddNewScrapStorage.ts
+++ b/app/src/components/details/scraps/AddNewScrapStorage.ts
@@ -5,7 +5,10 @@ export class AddNewScrapStorage {
   private static readonly key_prefix = "engraved::add-new-scrap::journalId=";
   private static readonly storageUtil = new StorageWrapper(window.localStorage);
 
-  private static timer: number;
+  // Debounce timers keyed by cache key, so concurrent editors (e.g. quick-add
+  // and a journal editor active at the same time) each debounce independently
+  // instead of sharing - and cancelling - a single timer.
+  private static readonly timers = new Map<string, number>();
 
   static getForJournal(cacheKey: string): IScrapEntry | undefined {
     return AddNewScrapStorage.storageUtil.getValue<IScrapEntry>(
@@ -14,22 +17,33 @@ export class AddNewScrapStorage {
   }
 
   static setForJournal(cacheKey: string, scrapEntry: IScrapEntry) {
-    window.clearTimeout(AddNewScrapStorage.timer);
+    AddNewScrapStorage.clearTimer(cacheKey);
 
-    AddNewScrapStorage.timer = window.setTimeout(() => {
-      this.storageUtil.setValue(
+    const timer = window.setTimeout(() => {
+      AddNewScrapStorage.timers.delete(cacheKey);
+      AddNewScrapStorage.storageUtil.setValue(
         AddNewScrapStorage.key_prefix + cacheKey,
         scrapEntry,
       );
     }, 1000);
+
+    AddNewScrapStorage.timers.set(cacheKey, timer);
   }
 
   static clearForJournal(cacheKey: string) {
-    window.clearTimeout(AddNewScrapStorage.timer);
+    AddNewScrapStorage.clearTimer(cacheKey);
 
     AddNewScrapStorage.storageUtil.setValue(
       AddNewScrapStorage.key_prefix + cacheKey,
       null,
     );
+  }
+
+  private static clearTimer(cacheKey: string) {
+    const timer = AddNewScrapStorage.timers.get(cacheKey);
+    if (timer !== undefined) {
+      window.clearTimeout(timer);
+      AddNewScrapStorage.timers.delete(cacheKey);
+    }
   }
 }


### PR DESCRIPTION
## Problem

`AddNewScrapStorage` persisted new-scrap drafts to localStorage on a 1s debounce, but the debounce `timer` was a single static field shared across every cache key. If two scrap editors were active within the debounce window — e.g. the quick-add page and a journal editor, which use different cache keys — each `setForJournal` call cleared the other's pending timeout. Only the last-touched draft was persisted; the other was silently dropped.

## Change

Store timers in a `Map<string, number>` keyed by cache key, so each editor debounces independently. A timer removes itself from the map when it fires, and `clearForJournal` cancels only the matching key's timer.

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)