### PR TITLE
Resolve loadGoogleScript when the script is already present

### DIFF
--- a/app/src/serverApi/authentication/registerGooglePrompt.ts
+++ b/app/src/serverApi/authentication/registerGooglePrompt.ts
@@ -48,6 +48,9 @@ export function registerGooglePrompt(
 function loadGoogleScript(): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     if (getGoogleScriptTag()) {
+      // Script already present (e.g. a second registration): resolve instead of
+      // leaving the promise - and the prompt-registration chain - pending forever.
+      resolve();
       return;
     }
 


### PR DESCRIPTION
## Problem

`loadGoogleScript` returns a promise that resolves from the `onload` handler of a freshly created `<script>` tag. When the Google GSI script tag already exists, the function took an early `return` **without** calling `resolve()`. The promise therefore never settled, and the `.then(...)` chain that registers the Google prompt (`google.accounts.id.initialize`, `renderButton`, `googlePrompt()`) never ran.

This is latent today because registration happens exactly once, so the tag never pre-exists on that call — but it's a trap for any future second invocation.

## Change

Call `resolve()` in the already-present branch, since the script is loaded (or loading and about to be usable) at that point.

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)