### PR TITLE
Don't sort caller's array in place in getNumberOfDays

### DIFF
--- a/app/src/util/utils.ts
+++ b/app/src/util/utils.ts
@@ -64,7 +64,8 @@ export function getNumberOfDays(
   allDates: (Date | string)[],
   overrides: IDateConditions = {},
 ) {
-  const sorted = allDates.sort(
+  // Copy before sorting so we don't reorder the caller's array in place.
+  const sorted = [...allDates].sort(
     (a, b) => ensureDate(a).getTime() - ensureDate(b).getTime(),
   );
 


### PR DESCRIPTION
## Problem

`getNumberOfDays(allDates, overrides)` computed its result by calling `allDates.sort(...)`. `Array.prototype.sort` mutates in place, so simply asking for a day count silently reordered the caller's array. When the passed array is derived from React state or the query cache, that hidden reordering can surface as subtle rendering bugs elsewhere.

## Change

Sort a shallow copy (`[...allDates].sort(...)`) so the input is left untouched.

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)