### PR TITLE
Fix optimistic entry cache data and stop mutating the journal prop

### DIFF
--- a/app/src/serverApi/reactQuery/mutations/useUpsertEntryMutation.tsx
+++ b/app/src/serverApi/reactQuery/mutations/useUpsertEntryMutation.tsx
@@ -6,6 +6,7 @@ import { useAppContext } from "../../../AppContext";
 import { IEntry } from "../../IEntry";
 import { ICommandResult } from "../../ICommandResult";
 import { IJournalAttributeValues } from "../../IJournalAttributeValues";
+import { IJournalAttributes } from "../../IJournalAttributes";
 import { useEditJournalMutation } from "./useEditJournalMutation";
 import { JournalType } from "../../JournalType";
 import { IJournal } from "../../IJournal";
@@ -38,13 +39,17 @@ export const useUpsertEntryMutation = (
     throwOnError: false,
 
     mutationFn: async (variables: IUpsertEntryCommandVariables) => {
-      if (
-        journal &&
-        hasNewJournalAttributeValues(
-          variables.command.journalAttributeValues ?? {},
-        )
-      ) {
-        await editJournalMutation.mutateAsync({ journal });
+      const journalWithNewValues = journal
+        ? getJournalWithNewAttributeValues(
+            journal,
+            variables.command.journalAttributeValues ?? {},
+          )
+        : null;
+
+      if (journalWithNewValues) {
+        await editJournalMutation.mutateAsync({
+          journal: journalWithNewValues,
+        });
       }
 
       return await ServerApi.upsertEntry(
@@ -125,35 +130,67 @@ export const useUpsertEntryMutation = (
     );
   }
 
-  function createCacheEntry(entry: IEntry, command: IUpsertEntryCommand) {
-    const editedOn = new Date().toString();
+  function createCacheEntry(
+    entry: IEntry,
+    command: IUpsertEntryCommand,
+  ): IEntry {
     return {
       ...entry,
       ...command,
-      dateTime: editedOn,
-      editedOn: editedOn,
+      // command.dateTime is a Date (or absent); IEntry.dateTime is an ISO
+      // string. Keep the date the user actually set instead of overwriting it
+      // with "now", and serialize as ISO to match what the server returns.
+      dateTime: command.dateTime
+        ? new Date(command.dateTime).toISOString()
+        : entry.dateTime,
+      editedOn: new Date().toISOString(),
     };
   }
+};
 
-  function hasNewJournalAttributeValues(
-    attributeValues: IJournalAttributeValues,
-  ) {
-    if (!attributeValues || !journal || journal.type === JournalType.Scraps) {
-      return false;
-    }
+// Returns a copy of the journal with any attribute values that are present on
+// the entry but missing from the journal definition added to it, or null when
+// there is nothing new. Pure: the (query-cached) journal passed in is never
+// mutated in place.
+function getJournalWithNewAttributeValues(
+  journal: IJournal,
+  attributeValues: IJournalAttributeValues,
+): IJournal | null {
+  if (journal.type === JournalType.Scraps) {
+    return null;
+  }
 
-    let hasNewValues = false;
+  const attributes = cloneAttributes(journal.attributes);
 
-    for (const keyInValues in attributeValues) {
-      for (const value of attributeValues[keyInValues]) {
-        if (!journal.attributes?.[keyInValues]?.values[value]) {
-          if (journal.attributes?.[keyInValues])
-            journal.attributes[keyInValues].values[value] = value;
-          hasNewValues = true;
+  let hasNewValues = false;
+
+  for (const keyInValues in attributeValues) {
+    for (const value of attributeValues[keyInValues]) {
+      if (!attributes?.[keyInValues]?.values[value]) {
+        if (attributes?.[keyInValues]) {
+          attributes[keyInValues].values[value] = value;
         }
+        hasNewValues = true;
       }
     }
-
-    return hasNewValues;
   }
-};
+
+  return hasNewValues ? { ...journal, attributes } : null;
+}
+
+function cloneAttributes(
+  attributes: IJournalAttributes | undefined,
+): IJournalAttributes | undefined {
+  if (!attributes) {
+    return attributes;
+  }
+
+  const clone: IJournalAttributes = {};
+  for (const key of Object.keys(attributes)) {
+    clone[key] = {
+      ...attributes[key],
+      values: { ...attributes[key].values },
+    };
+  }
+  return clone;
+}


### PR DESCRIPTION
## Problem

Two issues in `useUpsertEntryMutation`:

1. **Wrong optimistic `dateTime`.** After editing an entry, `createCacheEntry` wrote the optimistic cache row with `dateTime: new Date().toString()` — i.e. the current moment as a locale-formatted string (`"Thu Jul 02 2026 …"`). `IEntry.dateTime` is an ISO string, so the cached value was both the wrong value (now, not the date the user set) and the wrong format, until the follow-up invalidation refetched and masked it.

2. **Mutating the journal prop.** `hasNewJournalAttributeValues` — a query by its name — mutated `journal.attributes` in place to add newly-entered attribute values. That `journal` object is shared with the react-query cache and passed in as a prop, so this was an in-place mutation of cached/shared state.

## Change

1. `createCacheEntry` now keeps the command's `dateTime` (serialized to ISO), falling back to the entry's existing value when the command has none; `editedOn` also uses `toISOString()`.

2. Replaced `hasNewJournalAttributeValues` with a pure `getJournalWithNewAttributeValues` that clones the attributes, returns a **new** journal object (or `null` when nothing is new), and hands that copy to the edit-journal mutation. The detection semantics are preserved exactly — only the mutation-in-place is removed.

## Verification

- `tsc --noEmit`, `eslint`, `prettier` clean.
- Full unit suite green (17 files / 112 tests).

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)