### PR TITLE
Escape the dot in the email validation regex

### DIFF
--- a/app/src/util/utils.ts
+++ b/app/src/util/utils.ts
@@ -55,7 +55,7 @@ export function isValidEmail(address: string): boolean {
   // https://stackoverflow.com/a/8829363/4092115
   return !!address.match(
     new RegExp(
-      "^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$",
+      "^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$",
     ),
   );
 }


### PR DESCRIPTION
## Problem

`isValidEmail` constructs its `RegExp` from a string literal. The domain-label separator was written as `(?:.[a-zA-Z0-9]…)` — an **unescaped** `.`, which in a regex matches any character. In a JS string the pattern needs `\.` to represent a literal dot; the backslash was lost when the regex from the referenced Stack Overflow answer was transcribed into a string.

Consequence: addresses whose domain labels are joined by something other than a dot (e.g. `a@b!c`) passed validation.

## Change

Escape the separator as `\.` so only a real dot separates domain labels.

Verified against a set of samples:
- Still valid: `a@b.com`, `a@b.co.uk`, `a.b@c.io`, and `a@localhost` (this SO pattern deliberately allows a bare hostname with no dot).
- Now correctly rejected: `a@b!c`, `a@b_c`, `a@b..c`, `plain`.

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)