### PR TITLE
Handle rejection of the startup API wake-up ping

### DIFF
--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -14,10 +14,16 @@ createRoot(document.getElementById("root")!).render(getInitialJsx());
 
 function wakeUpApi() {
   const start = performance.now();
-  ServerApi.wakeMeUp().then(() => {
-    const end = performance.now();
-    console.log(`API has woken up after ${Math.round(end - start)}ms`);
-  });
+  ServerApi.wakeMeUp()
+    .then(() => {
+      const end = performance.now();
+      console.log(`API has woken up after ${Math.round(end - start)}ms`);
+    })
+    // Best-effort warm-up ping: if the API is unreachable, log and move on
+    // rather than leaving an unhandled promise rejection at startup.
+    .catch((error) => {
+      console.warn("Failed to wake up API.", error);
+    });
 }
 
 function getInitialJsx() {


### PR DESCRIPTION
## Problem

`index.tsx` fires `ServerApi.wakeMeUp()` on startup to warm up the backend, but only attached a `.then` handler. When the API is unreachable (cold backend still spinning up, offline, or a network error) the promise rejects with nothing to catch it, producing an unhandled promise rejection during app startup — and corresponding noise once App Insights is initialized.

## Change

Add a `.catch` that logs a warning. The wake-up is a best-effort warm-up ping, so swallowing the error (rather than surfacing it) is the correct behavior.

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)