### PR TITLE
Drop the forbidden Accept-Encoding request header

### DIFF
--- a/app/src/serverApi/ServerApi.ts
+++ b/app/src/serverApi/ServerApi.ts
@@ -550,7 +550,6 @@ export class ServerApi {
   private static getHeaders() {
     const headers: HeadersInit = {
       "Content-Type": "application/json",
-      "Accept-Encoding": "gzip, deflate, br",
     };
 
     if (ServerApi._jwtToken) {


### PR DESCRIPTION
## Problem

`ServerApi.getHeaders` set `"Accept-Encoding": "gzip, deflate, br"` on every request. `Accept-Encoding` is a [forbidden header name](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name) — the browser controls it and silently discards any value set via `fetch`, so the line never had any effect (the browser already negotiates compression on its own).

## Change

Remove the header. No behavioral change; compression negotiation is unaffected.

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)