### PR TITLE
Remove stale knip ignoreDependencies entry

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "workspaces": {
-    ".": {
-      "ignoreDependencies": ["@tanstack/eslint-plugin-query"]
-    },
     "app": {
       "ignore": ["public/OneSignalSDKWorker.js"],
       "ignoreBinaries": ["dotnet"]


### PR DESCRIPTION
## Problem

`npm run knip` emitted a configuration hint:

```
@tanstack/eslint-plugin-query    knip.json  Remove from ignoreDependencies
```

The dependency is now imported in `eslint.config.mjs`, so knip detects it as used and the `ignoreDependencies` entry is stale.

## Change

Remove the entry. That left the root (`.`) workspace block empty, so it's removed as well. `npm run knip` now reports no hints.

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)