### PR TITLE
Simplify dead undefined check on collapseAll

### DIFF
--- a/app/src/components/details/entriesTable/EntriesTable.tsx
+++ b/app/src/components/details/entriesTable/EntriesTable.tsx
@@ -163,9 +163,7 @@ export const EntriesTable: React.FC<{
             group={group}
             columns={columns}
             showGroupTotals={showGroupTotals}
-            isGroupCollapsed={
-              (collapseAll === undefined ? true : collapseAll) && i !== 0
-            }
+            isGroupCollapsed={collapseAll && i !== 0}
           />
         ))}
       </TableBody>


### PR DESCRIPTION
## Problem

In `EntriesTable`, `collapseAll` is a `useState<boolean>` initialized to `true` and only ever set to another boolean. The `isGroupCollapsed` prop guarded it with `collapseAll === undefined ? true : collapseAll`, but that branch can never be taken.

## Change

Simplify to `collapseAll && i !== 0`. No behavioral change.

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)