### PR TITLE
Reuse getDayKey for entries-table grouping

### DIFF
--- a/app/src/components/details/entriesTable/EntriesTable.tsx
+++ b/app/src/components/details/entriesTable/EntriesTable.tsx
@@ -16,7 +16,6 @@ import {
 } from "@mui/material";
 import { JournalType } from "../../../serverApi/JournalType";
 import { ITimerEntry } from "../../../serverApi/ITimerEntry";
-import { format } from "date-fns";
 import { IJournalType } from "../../../journalTypes/IJournalType";
 import { ActionIconButton } from "../../common/actions/ActionIconButton";
 import { IEntriesTableGroup } from "./IEntriesTableGroup";
@@ -33,6 +32,7 @@ import { IDateConditions } from "../JournalContext";
 import { TotalValue } from "./TotalValue";
 import { Streak } from "./Streak";
 import { getUiSettings } from "../../../util/journalUtils";
+import { getDayKey } from "../../../util/utils";
 
 export const EntriesTable: React.FC<{
   journal: IJournal;
@@ -392,5 +392,5 @@ function getGroupKey(journalType: JournalType, entry: IEntry) {
       ? (entry as ITimerEntry).startDate
       : entry.dateTime;
 
-  return relevantDate ? format(new Date(relevantDate), "u-LL-dd") : "";
+  return relevantDate ? getDayKey(new Date(relevantDate)) : "";
 }


### PR DESCRIPTION
## Problem

`EntriesTable.getGroupKey` built its per-day grouping key with date-fns `"u-LL-dd"`, while the shared `getDayKey` helper in `util/utils.ts` uses `"yyyy-MM-dd"`. Two day-key formats for the same concept.

## Change

Use the shared `getDayKey` in `getGroupKey` and drop the now-unused `format` import. The two format strings produce identical output for real-world dates (`u`≡`yyyy` and `LL`≡`MM` for positive AD years) — verified across a wide sampled date range — so there is no behavioral change.

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)