### PR TITLE
Only log ServerApi per-request perf data in dev

### DIFF
--- a/app/src/serverApi/ServerApi.ts
+++ b/app/src/serverApi/ServerApi.ts
@@ -602,6 +602,10 @@ export class ServerApi {
     response: Response,
     start: number,
   ) {
+    if (!envSettings.isDev) {
+      return;
+    }
+
     const total = Math.round(performance.now() - start);
     const server = Number(response.headers.get("server-action-duration"));
     const network = total - server;


### PR DESCRIPTION
## Problem

`ServerApi.printPerfData` ran `console.info(...)` for every request, in all environments. In production this fills end users' consoles with a per-request timing line.

## Change

Return early unless `envSettings.isDev`, so the timing output is dev-only. The perf-measurement work (`performance.now()`, header read) now also only happens in dev.

## Trade-off

If per-request timing was wanted in production for diagnostics, this removes it. Given it goes to the browser console (not telemetry) it's dev-oriented, so gating it to dev seems right — happy to route it to App Insights instead if production timing is desired.

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)