### PR TITLE
Guard StorageWrapper.getValue against corrupted JSON

### DIFF
--- a/app/src/util/StorageWrapper.test.ts
+++ b/app/src/util/StorageWrapper.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { StorageWrapper } from "./StorageWrapper";
+
+describe("StorageWrapper", () => {
+  let wrapper: StorageWrapper;
+
+  beforeEach(() => {
+    localStorage.clear();
+    wrapper = new StorageWrapper(localStorage);
+  });
+
+  it("round-trips a stored value", () => {
+    wrapper.setValue("key", { a: 1, b: "two" });
+    expect(wrapper.getValue("key")).toEqual({ a: 1, b: "two" });
+  });
+
+  it("returns undefined for a missing key", () => {
+    expect(wrapper.getValue("missing")).toBeUndefined();
+  });
+
+  it("removes the key when setting null or undefined", () => {
+    wrapper.setValue("key", "value");
+    wrapper.setValue("key", null);
+    expect(localStorage.getItem("key")).toBeNull();
+  });
+
+  it("returns undefined and drops the entry for corrupted JSON", () => {
+    localStorage.setItem("key", "{ not valid json");
+
+    expect(wrapper.getValue("key")).toBeUndefined();
+    expect(localStorage.getItem("key")).toBeNull();
+  });
+});

--- a/app/src/util/StorageWrapper.ts
+++ b/app/src/util/StorageWrapper.ts
@@ -12,6 +12,18 @@ export class StorageWrapper {
 
   getValue<T>(key: string): T | undefined {
     const item = this.storage.getItem(key);
-    return item ? (JSON.parse(item) as T) : undefined;
+    if (!item) {
+      return undefined;
+    }
+
+    try {
+      return JSON.parse(item) as T;
+    } catch {
+      // A corrupted / non-JSON value would otherwise throw here - and this runs
+      // during ServerApi's static initialization. Drop the bad entry and behave
+      // as if it were absent.
+      this.storage.removeItem(key);
+      return undefined;
+    }
   }
 }


### PR DESCRIPTION
## Problem

`StorageWrapper.getValue` called `JSON.parse(item)` without a guard. A single corrupted or non-JSON localStorage entry throws — and this runs during `ServerApi`'s static initialization (reading the `isE2eTest` flag), so a bad value there could break app startup.

## Change

Wrap the parse in `try/catch`. On failure, drop the offending entry and return `undefined`, i.e. behave as if the key were absent (self-healing). Added `StorageWrapper.test.ts` covering round-trip, missing key, `null` removal, and the corrupted-value path (jsdom provides `localStorage`).

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)