### PR TITLE
Remove always-true null check in AppAlertBar

### DIFF
--- a/app/src/components/errorHandling/AppAlertBar.tsx
+++ b/app/src/components/errorHandling/AppAlertBar.tsx
@@ -23,7 +23,7 @@ export const AppAlertBar: React.FC = () => {
       data-testid={"app-alert-bar"}
       data-related-entity-id={appAlert.relatedEntityId}
       autoHideDuration={
-        appAlert.type === "success" && appAlert.hideDurationSec !== null
+        appAlert.type === "success"
           ? (appAlert.hideDurationSec ?? 3) * 1000
           : null
       }


### PR DESCRIPTION
## Problem

`AppAlertBar` computed `autoHideDuration` with the guard `appAlert.hideDurationSec !== null`. But `hideDurationSec` is typed `number | undefined` and no caller passes `null`, so the comparison is always true — a misleading dead check.

## Change

Remove the `!== null` clause. Behavior is unchanged: success alerts auto-hide after `(hideDurationSec ?? 3)` seconds; non-success alerts stay open. The `?? 3` default still handles the `undefined` case.

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)