### PR TITLE
Bypass HTTP cache in the version check

### DIFF
--- a/app/src/VersionChecker.tsx
+++ b/app/src/VersionChecker.tsx
@@ -37,7 +37,11 @@ async function isNewVersionAvailable() {
     return false;
   }
 
-  const response = await fetch("/chunks/envSettings.js");
+  // Bypass the HTTP cache so we always read the freshly deployed chunk;
+  // otherwise a cached response could hide that a new version is available.
+  const response = await fetch("/chunks/envSettings.js", {
+    cache: "no-store",
+  });
   const text = await response.text();
   const match = /version\s*:\s*(["'`])(\d+)\1/m.exec(text);
   const version = match?.[2];


### PR DESCRIPTION
## Problem

`VersionChecker` fetches the built `envSettings.js` chunk and compares its embedded version to the running app's version to decide whether to show the "new version available" prompt. The `fetch` had no cache directive, so the browser could return a cached copy of the chunk and never observe that a newer version had been deployed.

## Change

Pass `cache: "no-store"` so the check always reads the freshly deployed chunk. Scope is deliberately limited to this one line — the broader "serve a version.json instead of regex-scraping the chunk" idea is intentionally left as-is.

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)