### PR TITLE
Extract shared mutation onError and user-reload helpers

### DIFF
--- a/app/src/serverApi/reactQuery/mutations/getErrorAlert.ts
+++ b/app/src/serverApi/reactQuery/mutations/getErrorAlert.ts
@@ -1,0 +1,13 @@
+import { IAppAlert } from "../../../components/errorHandling/AppAlertBar";
+
+// Builds the standard "something failed" alert for a mutation's onError handler,
+// normalizing how the message is extracted from an unknown thrown value
+// (Error.message - which for our ApiError is "<status>: <message>" - otherwise
+// its string form).
+export function getErrorAlert(title: string, error: unknown): IAppAlert {
+  return {
+    title,
+    message: error instanceof Error ? error.message : String(error),
+    type: "error",
+  };
+}

--- a/app/src/serverApi/reactQuery/mutations/useAddJournalMutation.ts
+++ b/app/src/serverApi/reactQuery/mutations/useAddJournalMutation.ts
@@ -4,6 +4,7 @@ import { ServerApi } from "../../ServerApi";
 import { ICommandResult } from "../../ICommandResult";
 import { JournalType } from "../../JournalType";
 import { useAppContext } from "../../../AppContext";
+import { getErrorAlert } from "./getErrorAlert";
 
 export const useAddJournalMutation = (
   name: string,
@@ -29,11 +30,7 @@ export const useAddJournalMutation = (
         type: "success",
       });
     },
-    onError: (error: Error) =>
-      setAppAlert({
-        title: "Failed to add journal",
-        message: error.message,
-        type: "error",
-      }),
+    onError: (error) =>
+      setAppAlert(getErrorAlert("Failed to add journal", error)),
   });
 };

--- a/app/src/serverApi/reactQuery/mutations/useAddJournalToFavoritesMutation.ts
+++ b/app/src/serverApi/reactQuery/mutations/useAddJournalToFavoritesMutation.ts
@@ -1,24 +1,16 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { queryKeysFactory } from "../queryKeysFactory";
 import { ServerApi } from "../../ServerApi";
-import { useAppContext } from "../../../AppContext";
+import { useReloadUser } from "./useReloadUser";
 
 export const useAddJournalToFavoritesMutation = (journalId: string) => {
-  const queryClient = useQueryClient();
-
-  const { setUser } = useAppContext();
+  const reloadUser = useReloadUser();
 
   return useMutation({
     mutationKey: queryKeysFactory.modifyUser(),
 
     mutationFn: () => ServerApi.addJournalToFavorites(journalId),
 
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: queryKeysFactory.modifyUser(),
-      });
-      const updatedUser = await ServerApi.getCurrentUser();
-      setUser(updatedUser);
-    },
+    onSuccess: () => reloadUser(),
   });
 };

--- a/app/src/serverApi/reactQuery/mutations/useEditJournalMutation.ts
+++ b/app/src/serverApi/reactQuery/mutations/useEditJournalMutation.ts
@@ -3,10 +3,13 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { queryKeysFactory } from "../queryKeysFactory";
 import { ServerApi } from "../../ServerApi";
 import { IJournal } from "../../IJournal";
+import { useReloadUser } from "./useReloadUser";
+import { getErrorAlert } from "./getErrorAlert";
 
 export const useEditJournalMutation = (journalId: string) => {
-  const { setAppAlert, setUser } = useAppContext();
+  const { setAppAlert } = useAppContext();
   const queryClient = useQueryClient();
+  const reloadUser = useReloadUser();
 
   return useMutation({
     mutationKey: queryKeysFactory.editJournal(journalId),
@@ -42,29 +45,14 @@ export const useEditJournalMutation = (journalId: string) => {
           queryKey: queryKeysFactory.journal(journalId),
         }),
 
-        reloadUser(variables.tagIds),
+        // Editing tags changes user-scoped data, so refresh the current user.
+        variables.tagIds ? reloadUser() : Promise.resolve(),
       ]);
 
       variables.onSuccess?.();
     },
 
     onError: (error) =>
-      setAppAlert({
-        title: `Failed to edit journal`,
-        message: error.toString(),
-        type: "error",
-      }),
+      setAppAlert(getErrorAlert("Failed to edit journal", error)),
   });
-
-  async function reloadUser(changedTagNames: string[] | undefined) {
-    if (!changedTagNames) {
-      return;
-    }
-
-    await queryClient.invalidateQueries({
-      queryKey: queryKeysFactory.modifyUser(),
-    });
-    const updatedUser = await ServerApi.getCurrentUser();
-    setUser(updatedUser);
-  }
 };

--- a/app/src/serverApi/reactQuery/mutations/useModifyJournalPermissionsMutation.ts
+++ b/app/src/serverApi/reactQuery/mutations/useModifyJournalPermissionsMutation.ts
@@ -3,7 +3,7 @@ import { useMutation } from "@tanstack/react-query";
 import { queryKeysFactory } from "../queryKeysFactory";
 import { IUpdatePermissions } from "../../IUpdatePermissions";
 import { useAppContext } from "../../../AppContext";
-import { IAppAlert } from "../../../components/errorHandling/AppAlertBar";
+import { getErrorAlert } from "./getErrorAlert";
 
 export const useModifyJournalPermissionsMutation = (journalId: string) => {
   const { setAppAlert } = useAppContext();
@@ -20,11 +20,7 @@ export const useModifyJournalPermissionsMutation = (journalId: string) => {
         type: "success",
       }),
 
-    onError: (error: IAppAlert) =>
-      setAppAlert({
-        title: "Failed to modify journal permissions",
-        message: error.message,
-        type: "error",
-      }),
+    onError: (error) =>
+      setAppAlert(getErrorAlert("Failed to modify journal permissions", error)),
   });
 };

--- a/app/src/serverApi/reactQuery/mutations/useModifyScheduleMutation.ts
+++ b/app/src/serverApi/reactQuery/mutations/useModifyScheduleMutation.ts
@@ -2,7 +2,7 @@ import { ServerApi } from "../../ServerApi";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { queryKeysFactory } from "../queryKeysFactory";
 import { useAppContext } from "../../../AppContext";
-import { IAppAlert } from "../../../components/errorHandling/AppAlertBar";
+import { getErrorAlert } from "./getErrorAlert";
 import { DateFormat, formatDate } from "../../../components/common/dateTypes";
 import { IScheduleDefinition } from "../../IScheduleDefinition";
 
@@ -41,11 +41,7 @@ export const useModifyScheduleMutation = (
       ]);
     },
 
-    onError: (error: IAppAlert) =>
-      setAppAlert({
-        title: "Failed to modify schedule",
-        message: error.message,
-        type: "error",
-      }),
+    onError: (error) =>
+      setAppAlert(getErrorAlert("Failed to modify schedule", error)),
   });
 };

--- a/app/src/serverApi/reactQuery/mutations/useMoveEntryMutation.tsx
+++ b/app/src/serverApi/reactQuery/mutations/useMoveEntryMutation.tsx
@@ -4,6 +4,7 @@ import { useAppContext } from "../../../AppContext";
 import { queryKeysFactory } from "../queryKeysFactory";
 import { StyledLink } from "./StyledLink";
 import { knownQueryParams } from "../../../components/common/actions/searchParamHooks";
+import { getErrorAlert } from "./getErrorAlert";
 
 export const useMoveEntryMutation = (
   entryId: string,
@@ -52,11 +53,7 @@ export const useMoveEntryMutation = (
     },
 
     onError: (error) => {
-      setAppAlert({
-        title: "Failed to move entry",
-        message: error.toString(),
-        type: "error",
-      });
+      setAppAlert(getErrorAlert("Failed to move entry", error));
     },
   });
 };

--- a/app/src/serverApi/reactQuery/mutations/useReloadUser.ts
+++ b/app/src/serverApi/reactQuery/mutations/useReloadUser.ts
@@ -1,0 +1,20 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeysFactory } from "../queryKeysFactory";
+import { ServerApi } from "../../ServerApi";
+import { useAppContext } from "../../../AppContext";
+
+// Invalidates the current-user query, refetches the user and pushes it into app
+// context. Shared by the mutations that change user-scoped data (favorites,
+// tags, and journal edits that touch tags).
+export const useReloadUser = () => {
+  const queryClient = useQueryClient();
+  const { setUser } = useAppContext();
+
+  return async () => {
+    await queryClient.invalidateQueries({
+      queryKey: queryKeysFactory.modifyUser(),
+    });
+    const updatedUser = await ServerApi.getCurrentUser();
+    setUser(updatedUser);
+  };
+};

--- a/app/src/serverApi/reactQuery/mutations/useRemoveJournalFromFavoritesMutation.ts
+++ b/app/src/serverApi/reactQuery/mutations/useRemoveJournalFromFavoritesMutation.ts
@@ -1,24 +1,16 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { queryKeysFactory } from "../queryKeysFactory";
 import { ServerApi } from "../../ServerApi";
-import { useAppContext } from "../../../AppContext";
+import { useReloadUser } from "./useReloadUser";
 
 export const useRemoveJournalFromFavoritesMutation = (journalId: string) => {
-  const queryClient = useQueryClient();
-
-  const { setUser } = useAppContext();
+  const reloadUser = useReloadUser();
 
   return useMutation({
     mutationKey: queryKeysFactory.modifyUser(),
 
     mutationFn: () => ServerApi.removeJournalFromFavorites(journalId),
 
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: queryKeysFactory.modifyUser(),
-      });
-      const updatedUser = await ServerApi.getCurrentUser();
-      setUser(updatedUser);
-    },
+    onSuccess: () => reloadUser(),
   });
 };

--- a/app/src/serverApi/reactQuery/mutations/useUpsertEntryMutation.tsx
+++ b/app/src/serverApi/reactQuery/mutations/useUpsertEntryMutation.tsx
@@ -12,6 +12,7 @@ import { IJournal } from "../../IJournal";
 import { useMatchRoute } from "@tanstack/react-router";
 import { knownQueryParams } from "../../../components/common/actions/searchParamHooks";
 import { StyledLink } from "./StyledLink";
+import { getErrorAlert } from "./getErrorAlert";
 
 interface IUpsertEntryCommandVariables {
   command: IUpsertEntryCommand;
@@ -101,12 +102,8 @@ export const useUpsertEntryMutation = (
       ]);
     },
 
-    onError: (error: unknown) => {
-      setAppAlert({
-        title: "Failed to upsert entry",
-        message: (error as Error)?.toString?.() ?? String(error),
-        type: "error",
-      });
+    onError: (error) => {
+      setAppAlert(getErrorAlert("Failed to upsert entry", error));
     },
   });
 

--- a/app/src/serverApi/reactQuery/mutations/useUpsertUserTagsMutation.ts
+++ b/app/src/serverApi/reactQuery/mutations/useUpsertUserTagsMutation.ts
@@ -1,11 +1,11 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { queryKeysFactory } from "../queryKeysFactory";
 import { ServerApi } from "../../ServerApi";
-import { useAppContext } from "../../../AppContext";
+import { useReloadUser } from "./useReloadUser";
 
 export const useUpdateUserTagsMutation = () => {
   const queryClient = useQueryClient();
-  const { setUser } = useAppContext();
+  const reloadUser = useReloadUser();
 
   return useMutation({
     mutationKey: queryKeysFactory.modifyUser(),
@@ -22,12 +22,4 @@ export const useUpdateUserTagsMutation = () => {
       ]);
     },
   });
-
-  async function reloadUser() {
-    await queryClient.invalidateQueries({
-      queryKey: queryKeysFactory.modifyUser(),
-    });
-    const updatedUser = await ServerApi.getCurrentUser();
-    setUser(updatedUser);
-  }
 };


### PR DESCRIPTION
## Problem

The react-query mutation hooks repeated two blocks nearly verbatim:

1. **The `onError` error alert** (6 hooks). Beyond the duplication, the error-message extraction had drifted — `error.message` (×3), `error.toString()` (×2), and a mixed `(error as Error)?.toString?.() ?? String(error)` (×1) — and two handlers mistyped the thrown error's parameter as `IAppAlert` (it's really the `Error`; it only compiled because both have `.message`).

2. **The "reload the current user" sequence** (4 hooks): invalidate `modifyUser` → `getCurrentUser` → `setUser`. `useAddJournalToFavoritesMutation` and `useRemoveJournalFromFavoritesMutation` had byte-for-byte identical bodies.

## Change

Two small shared helpers (kept colocated with the hooks):

- **`getErrorAlert(title, error)`** — builds the standard error-type `IAppAlert`. Applied to the 6 error-alert hooks. Normalizes message extraction onto one rule: `Error.message`, else `String(error)`. For our `ApiError` this yields `"<status>: <message>"` and drops the redundant `"Error: "` prefix that `.toString()` used to add. Also fixes the two mistyped `IAppAlert` params.
- **`useReloadUser()`** — encapsulates the invalidate→refetch→`setUser` sequence, used by the favorites, tag-update, and edit-journal (tag) mutations. The two favorites hooks now reduce to a `mutationFn` plus `onSuccess: () => reloadUser()`.

Net ~20 fewer lines and two real consistency bugs fixed (error typing + message format). The full `useEngravedMutation` wrapper idea was deliberately **not** pursued — the success-alert/invalidation variety across hooks would make its config awkward for little gain.

## Verification

- `tsc --noEmit`, `eslint`, `prettier`, `knip` all clean.
- Full unit suite green (18 files / 116 tests).

## Trade-off / note

The only user-visible change is error-alert text: hooks that previously showed `"Error: 500: …"` now show `"500: …"`, consistent with the ones that already used `.message`.

No related GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)