### PR TITLE
A scrap list in edit mode should never have zero items (#2926)

### DIFF
--- a/app/src/components/details/scraps/ScrapContextProvider.tsx
+++ b/app/src/components/details/scraps/ScrapContextProvider.tsx
@@ -341,7 +341,10 @@ export const ScrapContextProvider: React.FC<{
   );
 
   async function upsertScrap(notesToOverride?: string, keepEditMode?: boolean) {
-    const notesToSave = notesToOverride ?? scrapToRender.notes;
+    const notesToSave = getNotesToPersist(
+      scrapToRender.scrapType,
+      notesToOverride ?? scrapToRender.notes,
+    );
 
     if (!notesToSave && !scrapToRender.title) {
       return;
@@ -411,6 +414,29 @@ export const ScrapContextProvider: React.FC<{
     return genericNotes.map((s) => s?.trim() ?? "").join("") === "";
   }
 };
+
+// While editing, a list always keeps at least one (possibly blank) line so the
+// user has something to type into. When that lone line is still empty on save,
+// the list is effectively empty and is persisted as such rather than storing a
+// meaningless blank item.
+function getNotesToPersist(scrapType: ScrapType, notes: string | undefined) {
+  if (scrapType !== ScrapType.List || !notes) {
+    return notes;
+  }
+
+  let items: IScrapListItem[];
+  try {
+    items = JSON.parse(notes);
+  } catch {
+    return notes;
+  }
+
+  if (items.length === 1 && !items[0]?.label?.trim()) {
+    return JSON.stringify([]);
+  }
+
+  return notes;
+}
 
 function convertNotesToTargetType(
   targetType: ScrapType,

--- a/app/src/components/details/scraps/list/ListItemCollection.ts
+++ b/app/src/components/details/scraps/list/ListItemCollection.ts
@@ -187,7 +187,29 @@ export class ListItemCollection {
   deleteAllChecked() {
     this.wrappedItems = this.wrappedItems.filter((i) => !i.raw.isCompleted);
 
+    this.addBlankIfEmpty();
+
     this.fireOnChange();
+  }
+
+  // A list in edit mode should never be empty: there must always be at least one
+  // (possibly blank) line to type into. Adds a blank line when the list ran empty.
+  ensureNotEmpty() {
+    if (this.addBlankIfEmpty()) {
+      this.fireOnChange();
+    }
+  }
+
+  private addBlankIfEmpty(): boolean {
+    if (this.wrappedItems.length > 0) {
+      return false;
+    }
+
+    this.wrappedItems.push(
+      new ListItemWrapper({ label: "", isCompleted: false, depth: 0 }, true),
+    );
+
+    return true;
   }
 
   private add(index: number, ...listItems: ListItemWrapper[]) {

--- a/app/src/components/details/scraps/list/ScrapList.tsx
+++ b/app/src/components/details/scraps/list/ScrapList.tsx
@@ -55,6 +55,7 @@ export const ScrapList: React.FC<{ editModeActions?: IAction[] }> = ({
 
   useEffect(() => {
     if (isEditMode) {
+      listItemCollection.ensureNotEmpty();
       listItemCollection.giveFocus(listItemCollection.items.length - 1, "end");
     }
   }, [isEditMode, listItemCollection]);

--- a/app/src/components/details/scraps/list/listItemCollection.test.ts
+++ b/app/src/components/details/scraps/list/listItemCollection.test.ts
@@ -49,6 +49,56 @@ describe("ListItemCollection", () => {
     });
   });
 
+  describe("deleteAllChecked", () => {
+    it("should keep an empty line when all items are deleted", () => {
+      const collection = new ListItemCollection(
+        [createRandomItem("a", 0, true), createRandomItem("b", 0, true)],
+        () => {},
+      );
+
+      collection.deleteAllChecked();
+
+      expect(collection.items.length).toBe(1);
+      expect(collection.items[0].label).toBe("");
+    });
+
+    it("should not add an empty line when items remain", () => {
+      const collection = new ListItemCollection(
+        [createRandomItem("a", 0, true), createRandomItem("b")],
+        () => {},
+      );
+
+      collection.deleteAllChecked();
+
+      expect(collection.items.length).toBe(1);
+      expect(collection.items[0].label).toBe("b");
+    });
+  });
+
+  describe("ensureNotEmpty", () => {
+    it("should add an empty line to an empty collection", () => {
+      const collection = new ListItemCollection([], () => {});
+
+      collection.ensureNotEmpty();
+
+      expect(collection.items.length).toBe(1);
+      expect(collection.items[0].label).toBe("");
+    });
+
+    it("should not change a non-empty collection", () => {
+      let wasChanged = false;
+      const collection = new ListItemCollection([createRandomItem("a")], () => {
+        wasChanged = true;
+      });
+
+      collection.ensureNotEmpty();
+
+      expect(collection.items.length).toBe(1);
+      expect(collection.items[0].label).toBe("a");
+      expect(wasChanged).toBe(false);
+    });
+  });
+
   describe("moveItem...", () => {
     it("...down: move item down", () => {
       new ListItemCollection(
@@ -148,10 +198,10 @@ describe("ListItemCollection", () => {
   });
 });
 
-function createRandomItem(label = "x", depth = 0) {
+function createRandomItem(label = "x", depth = 0, isCompleted = false) {
   return {
     label: label,
-    isCompleted: false,
+    isCompleted: isCompleted,
     depth: depth,
   };
 }

--- a/tests/tests/scrapList.spec.ts
+++ b/tests/tests/scrapList.spec.ts
@@ -169,6 +169,40 @@ test("Enter only adds one empty line", async ({ page, testData }) => {
   expect(await scrapList.getItemCount()).toBe(2);
 });
 
+test("deleting all checked items keeps one empty line, which is not persisted", async ({
+  page,
+  testData,
+}) => {
+  const scrapsJournalPage = await openScrapsJournal(page, testData);
+  await scrapsJournalPage.expectIsEmpty();
+
+  const scrapList = await scrapsJournalPage.addList();
+  await scrapList.typeTitle("This is my title");
+  await scrapList.typeListItem(firstItemText);
+  await scrapList.clickSave();
+
+  await scrapList.dblClickToEdit();
+
+  // check the only item and delete all checked items - the list must not end up
+  // empty, a single blank line has to remain so there is something to type into.
+  await (await scrapList.getListItemByText(firstItemText))
+    .getByRole("checkbox")
+    .check();
+
+  await page.getByLabel("Delete checked").click();
+
+  expect(await scrapList.getItemCount()).toBe(1);
+  await expect(await scrapList.getListItemByText(firstItemText)).toHaveCount(0);
+
+  // saving the lone blank line must not persist it: after a reload no items are
+  // shown.
+  await scrapList.clickSave(true);
+  await page.reload();
+
+  await expect(page.getByText("No items yet.")).toBeVisible();
+  expect(await scrapList.getItemCount()).toBe(0);
+});
+
 test("Backspace on empty item removes item", async ({ page, testData }) => {
   const scrapsJournalPage = await openScrapsJournal(page, testData);
   await scrapsJournalPage.expectIsEmpty();

--- a/tests/tests/scrapList.spec.ts
+++ b/tests/tests/scrapList.spec.ts
@@ -194,10 +194,11 @@ test("deleting all checked items keeps one empty line, which is not persisted", 
   expect(await scrapList.getItemCount()).toBe(1);
   await expect(await scrapList.getListItemByText(firstItemText)).toHaveCount(0);
 
-  // saving the lone blank line must not persist it: after a reload no items are
-  // shown.
+  // saving the lone blank line must not persist it: after a reload the list is
+  // empty (on mobile the scrap is compact, so expand it first to see the body).
   await scrapList.clickSave(true);
   await page.reload();
+  await scrapList.clickToExpand();
 
   await expect(page.getByText("No items yet.")).toBeVisible();
   expect(await scrapList.getItemCount()).toBe(0);


### PR DESCRIPTION
Fixes #2926.

## Problem
While editing a scrap list, the list could end up with **zero items** — most notably when clearing everything via **"Delete checked"** — leaving nothing to type into. Conversely, a list that contains only a single blank line has no meaningful content but was still persisted as a real (empty) item.

## Changes
- **`ListItemCollection`**: `deleteAllChecked()` now re-adds a focused blank line when the filter would empty the list. New `ensureNotEmpty()` helper exposes the same guarantee without an unconditional change notification.
- **`ScrapList`**: on entering edit mode, `ensureNotEmpty()` runs so that editing a list that was persisted empty still shows one blank line.
- **`ScrapContextProvider`**: on save, a lone blank line is stripped and the list is persisted as an empty array, so it renders as "No items yet." instead of storing a meaningless blank item.

## Testing
- Added unit tests for `deleteAllChecked` / `ensureNotEmpty` (empty → one blank line; non-empty → untouched).
- Added an e2e test: check the only item → "Delete checked" → one blank line remains → save → reload shows "No items yet."
- Full `scrapList` e2e suite passes; verified interactively in both the bundled build and the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)