### PR TITLE
Improve loading behavior: reveal lists complete, in one motion

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { IUser } from "./serverApi/IUser";
 import { styled } from "@mui/material";
 import { AddJournalPage } from "./components/overview/AddJournalPage";
@@ -34,6 +34,7 @@ import { TagPage } from "./components/overview/tags/TagPage";
 import { GoToPage } from "./components/overview/goto/GoToPage";
 import { QuickAddPage } from "./components/details/scraps/QuickAddPage";
 import { FloatingHistoryNavigation } from "./components/layout/FloatingHistoryNavigation";
+import { LazyLoadSuspender } from "./components/common/LazyLoadSuspender";
 import { validateAppSearch } from "./components/common/actions/searchParamHooks";
 
 // Defined before RootLayout so the component reference is available
@@ -53,7 +54,9 @@ const RootLayout: React.FC = () => (
             <AppAlertBar />
             <AppContent scope="body">
               <AppErrorBoundary>
-                <Outlet />
+                <LazyLoadSuspender>
+                  <Outlet />
+                </LazyLoadSuspender>
               </AppErrorBoundary>
             </AppContent>
             <FloatingHistoryNavigation />
@@ -176,8 +179,14 @@ declare module "@tanstack/react-router" {
   }
 }
 
-export const App: React.FC<{ user: IUser }> = ({ user }) => (
-  <AppContextProvider user={user}>
-    <RouterProvider router={router} />
-  </AppContextProvider>
-);
+export const App: React.FC<{ user: IUser }> = ({ user }) => {
+  useEffect(() => {
+    import("./components/details/scraps/markdown/LazyMarkdown");
+  }, []);
+
+  return (
+    <AppContextProvider user={user}>
+      <RouterProvider router={router} />
+    </AppContextProvider>
+  );
+};

--- a/app/src/components/common/FadeInContainer.tsx
+++ b/app/src/components/common/FadeInContainer.tsx
@@ -4,12 +4,17 @@ import { styled, SxProps } from "@mui/material";
 export const FadeInContainer: React.FC<{
   children: ReactNode;
   doPulsate?: boolean;
+  isReady?: boolean;
   sx?: SxProps;
   testId?: string;
-}> = ({ children, doPulsate, sx, testId }) => {
+}> = ({ children, doPulsate, isReady = true, sx, testId }) => {
   const [isRendered, setIsRendered] = useState(false);
 
   useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+
     const timeout = window.setTimeout(() => setIsRendered(true), 20);
 
     let interval: number;
@@ -24,7 +29,7 @@ export const FadeInContainer: React.FC<{
       window.clearTimeout(timeout);
       window.clearInterval(interval);
     };
-  }, [doPulsate]);
+  }, [doPulsate, isReady]);
 
   return (
     <ContainerSection

--- a/app/src/components/details/scraps/EditLogBookProperties.tsx
+++ b/app/src/components/details/scraps/EditLogBookProperties.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ILogBookJournal } from "../../../serverApi/ILogBookJournal";
-import LazyRichTextEditor from "../../common/LazyRichTextEditor";
+import { RichTextEditor } from "../../common/RichTextEditor";
 import { PageSection } from "../../layout/pages/PageSection";
 import { FormControl } from "@mui/material";
 import { CopyAllOutlined } from "@mui/icons-material";
@@ -12,7 +12,7 @@ export const EditLogBookProperties: React.FC<{
   return (
     <PageSection title={"Entry Template"} icon={<CopyAllOutlined />}>
       <FormControl sx={{ width: "100%" }}>
-        <LazyRichTextEditor
+        <RichTextEditor
           setValue={(value) =>
             setCustomProps({ ...(journal.customProps ?? {}), template: value })
           }

--- a/app/src/components/details/scraps/markdown/Markdown.tsx
+++ b/app/src/components/details/scraps/markdown/Markdown.tsx
@@ -1,5 +1,4 @@
 import React, { MouseEventHandler } from "react";
-import { LazyLoadSuspender } from "../../../common/LazyLoadSuspender";
 
 export interface IMarkdownProps {
   value: string;
@@ -9,14 +8,12 @@ export interface IMarkdownProps {
 
 const LazyMarkdown = React.lazy(() => import("./LazyMarkdown"));
 
-export const Markdown: React.FC<IMarkdownProps> = ({
-  value,
-  onClick,
-  useBasic,
-}) => {
-  return (
-    <LazyLoadSuspender>
-      <LazyMarkdown value={value} onClick={onClick} useBasic={useBasic} />
-    </LazyLoadSuspender>
-  );
-};
+// Intentionally no Suspense boundary here: while the markdown chunk is
+// loading, suspension bubbles up to the nearest ancestor boundary
+// (OverviewList, DialogWrapper or the route outlet in App), so that
+// surrounding content (item frame, title, footer) is held back too and
+// everything appears complete in one go instead of every markdown fragment
+// showing its own spinner.
+export const Markdown: React.FC<IMarkdownProps> = (props) => (
+  <LazyMarkdown {...props} />
+);

--- a/app/src/components/details/scraps/markdown/ScrapMarkdown.tsx
+++ b/app/src/components/details/scraps/markdown/ScrapMarkdown.tsx
@@ -4,7 +4,6 @@ import { ScrapBody } from "../ScrapBody";
 import { useAppContext } from "../../../../AppContext";
 import { useScrapContext } from "../ScrapContext";
 import { RichTextEditor } from "../../../common/RichTextEditor";
-import { FadeInContainer } from "../../../common/FadeInContainer";
 import { Markdown } from "./Markdown";
 import { IAction } from "../../../common/actions/IAction";
 
@@ -30,9 +29,7 @@ export const ScrapMarkdown: React.FC<{ editModeActions?: IAction[] }> = ({
           />
         </div>
       ) : (
-        <FadeInContainer>
-          <Markdown value={notes ?? ""} />
-        </FadeInContainer>
+        <Markdown value={notes ?? ""} />
       )}
     </ScrapBody>
   );

--- a/app/src/components/layout/dialogs/DialogWrapper.tsx
+++ b/app/src/components/layout/dialogs/DialogWrapper.tsx
@@ -10,6 +10,7 @@ import {
 } from "@mui/material";
 import React from "react";
 import { DeviceWidth, useDeviceWidth } from "../../common/useDeviceWidth";
+import { LazyLoadSuspender } from "../../common/LazyLoadSuspender";
 import { AppContent } from "../AppContent";
 
 const SlideUp = React.forwardRef(function Transition(
@@ -54,7 +55,9 @@ export const DialogWrapper: React.FC<{
             <Close />
           </IconButton>
         </Header>
-        <StyledDialogContent>{children}</StyledDialogContent>
+        <StyledDialogContent>
+          <LazyLoadSuspender>{children}</LazyLoadSuspender>
+        </StyledDialogContent>
       </RootBodyElement>
     </Dialog>
   );

--- a/app/src/components/overview/overviewList/OverviewList.tsx
+++ b/app/src/components/overview/overviewList/OverviewList.tsx
@@ -9,6 +9,8 @@ import { OverviewListContextProvider } from "./OverviewListContextProvider";
 import { IEntry } from "../../../serverApi/IEntry";
 import HistoryToggleOff from "@mui/icons-material/HistoryToggleOff";
 import { differenceInDays } from "date-fns";
+import { FadeInContainer } from "../../common/FadeInContainer";
+import { LazyLoadSuspender } from "../../common/LazyLoadSuspender";
 
 interface IOverviewListProps {
   items: IEntity[];
@@ -57,65 +59,73 @@ const OverviewListInternal: React.FC<IOverviewListProps> = ({
   } = useOverviewListContext();
 
   return (
-    <Host className="overview-list">
-      {renderBeforeList?.((i) => setActiveItemId(itemsToShow[i]?.id ?? ""))}
+    <LazyLoadSuspender>
+      <FadeInContainer
+        isReady={
+          itemsToShow.length > 0 || hiddenItemsCount > 0 || !!renderBeforeList
+        }
+      >
+        <Host className="overview-list">
+          {renderBeforeList?.((i) => setActiveItemId(itemsToShow[i]?.id ?? ""))}
 
-      {itemsToShow.map((item, index) => {
-        const hasFocus = activeItemId === item.id;
+          {itemsToShow.map((item, index) => {
+            const hasFocus = activeItemId === item.id;
 
-        return (
-          <React.Fragment
-            key={
-              (item.id ?? "") +
-              "-" +
-              getScheduleForUser(item, user.id ?? "")?.nextOccurrence
-            }
-          >
-            {showDaysBetween && index > 0 ? (
-              <DifferenceInDays
-                lastItem={itemsToShow[index - 1] as IEntry}
-                item={item as IEntry}
-              />
-            ) : null}
-
-            <OverviewListItem
-              showDaysBetween={showDaysBetween}
-              onClick={() => {
-                if (hasFocus) {
-                  return;
+            return (
+              <React.Fragment
+                key={
+                  (item.id ?? "") +
+                  "-" +
+                  getScheduleForUser(item, user.id ?? "")?.nextOccurrence
                 }
+              >
+                {showDaysBetween && index > 0 ? (
+                  <DifferenceInDays
+                    lastItem={itemsToShow[index - 1] as IEntry}
+                    item={item as IEntry}
+                  />
+                ) : null}
 
-                setActiveItemId(item.id ?? "");
-                removeItemParamsFromUrl();
+                <OverviewListItem
+                  showDaysBetween={showDaysBetween}
+                  onClick={() => {
+                    if (hasFocus) {
+                      return;
+                    }
+
+                    setActiveItemId(item.id ?? "");
+                    removeItemParamsFromUrl();
+                  }}
+                  item={item}
+                  hasFocus={hasFocus}
+                >
+                  <RenderItem
+                    item={item}
+                    hasFocus={hasFocus}
+                    index={index}
+                    setActiveItemId={setActiveItemId}
+                    renderItem={renderItem}
+                  />
+                </OverviewListItem>
+              </React.Fragment>
+            );
+          })}
+          {hiddenItemsCount ? (
+            <Typography
+              onClick={() => setShowAll(true)}
+              sx={{
+                cursor: "pointer",
+                textAlign: "center",
+                fontWeight: 200,
+                pb: 3,
               }}
-              item={item}
-              hasFocus={hasFocus}
             >
-              <RenderItem
-                item={item}
-                hasFocus={hasFocus}
-                index={index}
-                setActiveItemId={setActiveItemId}
-                renderItem={renderItem}
-              />
-            </OverviewListItem>
-          </React.Fragment>
-        );
-      })}
-      {hiddenItemsCount ? (
-        <Typography
-          onClick={() => setShowAll(true)}
-          sx={{
-            cursor: "pointer",
-            textAlign: "center",
-            fontWeight: 200,
-            pb: 3,
-          }}
-        >
-          Show {hiddenItemsCount} hidden item(s)
-        </Typography>
-      ) : null}
-    </Host>
+              Show {hiddenItemsCount} hidden item(s)
+            </Typography>
+          ) : null}
+        </Host>
+      </FadeInContainer>
+    </LazyLoadSuspender>
   );
 };
 


### PR DESCRIPTION
## Problem

When loading a list page (e.g. the entries tab), items revealed themselves in stages: first the white item background, then title and footer, then the markdown body - each fragment with its own spinner and an individual 700ms fade.

## Changes

**Make overview lists appear complete in one motion**
- Preload the markdown chunk (marked, DOMPurify, ...) on app mount, so it is usually cached before the first list renders.
- Remove the per-instance Suspense boundary from `Markdown`; suspension now bubbles up to a single boundary per `OverviewList` (with fallback boundaries around the route outlet and in `DialogWrapper`). If the chunk is not ready yet, the whole list is held back and then revealed complete - no more per-item spinners in titles or bodies.
- Move the fade from per item body to the whole list, and start it only once there is content to reveal (`FadeInContainer` gets an `isReady` prop). Lists may mount with zero items while query data is still loading - e.g. journals, where `useJournalsQuery` returns `[]` instead of `undefined` - which previously made the fade run on an empty list and items pop in without any fade.

**Fix ineffective lazy import of RichTextEditor**
- `EditLogBookProperties` imported `LazyRichTextEditor` statically, which kept the whole tiptap subtree in the main bundle despite the `React.lazy` wrapper (the build reported `INEFFECTIVE_DYNAMIC_IMPORT`). Using the lazy `RichTextEditor` wrapper splits it into its own chunk and shrinks the initial payload from 477 kB to 326 kB gzipped (~32%).

## Verification

- `tsc --noEmit`, ESLint, and all 116 unit tests pass.
- Production build: no `INEFFECTIVE_DYNAMIC_IMPORT` warning, `LazyRichTextEditor` in its own chunk (151 kB gzip), main chunk down from 477 kB to 326 kB gzip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)