### PR TITLE
Show offline placeholder when data is not cached

### DIFF
--- a/app/src/OfflineIndicator.tsx
+++ b/app/src/OfflineIndicator.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { ActionIconButton } from "./components/common/actions/ActionIconButton";
 import { FadeInContainer } from "./components/common/FadeInContainer";
 import { ActionFactory } from "./components/common/actions/ActionFactory";
+import { useIsOffline } from "./components/common/useIsOffline";
 
 export const OfflineIndicator: React.FC = () => {
   const isOffline = useIsOffline();
@@ -15,23 +16,3 @@ export const OfflineIndicator: React.FC = () => {
     </FadeInContainer>
   );
 };
-
-function useIsOffline(): boolean {
-  const [isOffline, setIsOffline] = useState(
-    typeof navigator !== "undefined" ? !navigator.onLine : false,
-  );
-
-  useEffect(() => {
-    const update = () => setIsOffline(!navigator.onLine);
-
-    window.addEventListener("online", update);
-    window.addEventListener("offline", update);
-
-    return () => {
-      window.removeEventListener("online", update);
-      window.removeEventListener("offline", update);
-    };
-  }, []);
-
-  return isOffline;
-}

--- a/app/src/components/common/search/OfflinePlaceholder.tsx
+++ b/app/src/components/common/search/OfflinePlaceholder.tsx
@@ -2,13 +2,11 @@ import CloudOffOutlined from "@mui/icons-material/CloudOffOutlined";
 import React from "react";
 import { GenericEmptyPlaceholder } from "./GenericEmptyPlaceholder";
 
-// Shown when a view's data has not been cached yet and cannot be loaded
-// because the app is offline (see useIsOffline).
 export const OfflinePlaceholder: React.FC = () => {
   return (
     <GenericEmptyPlaceholder
       icon={CloudOffOutlined}
-      message="Data not available as offline."
+      message="Data is not available as you are offline."
     />
   );
 };

--- a/app/src/components/common/search/OfflinePlaceholder.tsx
+++ b/app/src/components/common/search/OfflinePlaceholder.tsx
@@ -1,0 +1,14 @@
+import CloudOffOutlined from "@mui/icons-material/CloudOffOutlined";
+import React from "react";
+import { GenericEmptyPlaceholder } from "./GenericEmptyPlaceholder";
+
+// Shown when a view's data has not been cached yet and cannot be loaded
+// because the app is offline (see useIsOffline).
+export const OfflinePlaceholder: React.FC = () => {
+  return (
+    <GenericEmptyPlaceholder
+      icon={CloudOffOutlined}
+      message="Data not available as offline."
+    />
+  );
+};

--- a/app/src/components/common/useIsOffline.ts
+++ b/app/src/components/common/useIsOffline.ts
@@ -1,9 +1,5 @@
 import { useEffect, useState } from "react";
 
-// Tracks the browser's online/offline state. Used to render offline-specific
-// UI (header indicator, "data not available offline" placeholders). Note that
-// navigator.onLine only knows about the network interface - it cannot detect
-// an unreachable server.
 export function useIsOffline(): boolean {
   const [isOffline, setIsOffline] = useState(
     typeof navigator !== "undefined" ? !navigator.onLine : false,

--- a/app/src/components/common/useIsOffline.ts
+++ b/app/src/components/common/useIsOffline.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+// Tracks the browser's online/offline state. Used to render offline-specific
+// UI (header indicator, "data not available offline" placeholders). Note that
+// navigator.onLine only knows about the network interface - it cannot detect
+// an unreachable server.
+export function useIsOffline(): boolean {
+  const [isOffline, setIsOffline] = useState(
+    typeof navigator !== "undefined" ? !navigator.onLine : false,
+  );
+
+  useEffect(() => {
+    const update = () => setIsOffline(!navigator.onLine);
+
+    window.addEventListener("online", update);
+    window.addEventListener("offline", update);
+
+    return () => {
+      window.removeEventListener("online", update);
+      window.removeEventListener("offline", update);
+    };
+  }, []);
+
+  return isOffline;
+}

--- a/app/src/components/details/JournalDetails.tsx
+++ b/app/src/components/details/JournalDetails.tsx
@@ -12,6 +12,8 @@ import { JournalViewPage } from "./JournalViewPage";
 import { ScrapsViewPage } from "./scraps/ScrapsViewPage";
 import { addRecentlyViewedJournal } from "../layout/menu/useRecentlyViewedJournals";
 import { LogBookViewPage } from "./scraps/LogBookViewPage";
+import { OfflinePlaceholder } from "../common/search/OfflinePlaceholder";
+import { useIsOffline } from "../common/useIsOffline";
 
 export const JournalDetailsEdit: React.FC = () => {
   const { journal } = useJournalContext();
@@ -48,9 +50,12 @@ export const JournalDetails: React.FC = () => {
   const { journal } = useJournalContext();
   const journalProperties = useJournalProperties(journal);
   const deviceWidth = useDeviceWidth();
+  const isOffline = useIsOffline();
 
   if (!journal) {
-    return null;
+    // undefined means not loaded (yet) - when offline that is because the
+    // journal has not been cached and cannot be fetched until back online.
+    return isOffline ? <OfflinePlaceholder /> : null;
   }
 
   return (

--- a/app/src/components/details/JournalViewPage.tsx
+++ b/app/src/components/details/JournalViewPage.tsx
@@ -11,6 +11,8 @@ import { Page } from "../layout/pages/Page";
 import { JournalPageTitle } from "./JournalPageTitle";
 import { createDateConditions } from "./filters/createDateConditions";
 import { GenericEmptyPlaceholder } from "../common/search/GenericEmptyPlaceholder";
+import { OfflinePlaceholder } from "../common/search/OfflinePlaceholder";
+import { useIsOffline } from "../common/useIsOffline";
 import { MyChartType } from "./chart/grouping/ChartTypeSelector";
 import { ActionFactory } from "../common/actions/ActionFactory";
 import { IAction } from "../common/actions/IAction";
@@ -35,6 +37,7 @@ import { isEntryFilterApplied } from "./filters/isEntryFilterApplied";
 export const JournalViewPage: React.FC = () => {
   const deviceWidth = useDeviceWidth();
   const { user } = useAppContext();
+  const isOffline = useIsOffline();
 
   const {
     journal,
@@ -222,6 +225,10 @@ export const JournalViewPage: React.FC = () => {
             </PageSection>
           )}
         </>
+      ) : isOffline ? (
+        // While offline, missing entries (almost) always mean they have not
+        // been cached yet - "No entries available." would be misleading.
+        <OfflinePlaceholder />
       ) : (
         <GenericEmptyPlaceholder
           icon={LocalHotelOutlined}

--- a/app/src/components/overview/entries/Entries.tsx
+++ b/app/src/components/overview/entries/Entries.tsx
@@ -3,18 +3,26 @@ import { useAllEntriesQuery } from "../../../serverApi/reactQuery/queries/useAll
 import { IEntry } from "../../../serverApi/IEntry";
 import { usePageContext } from "../../layout/pages/PageContext";
 import { NoResultsFound } from "../../common/search/NoResultsFound";
+import { OfflinePlaceholder } from "../../common/search/OfflinePlaceholder";
+import { useIsOffline } from "../../common/useIsOffline";
 import { OverviewList } from "../overviewList/OverviewList";
 import { EntryListItem } from "./EntryListItem";
 
 export const Entries: React.FC = () => {
   const { searchText, journalTypes } = usePageContext();
+  const isOffline = useIsOffline();
   const queryResult = useAllEntriesQuery(searchText, journalTypes);
 
   if (!queryResult) {
-    return null;
+    // undefined means not loaded (yet) - when offline that is because the
+    // query is paused until the network is back.
+    return isOffline ? <OfflinePlaceholder /> : null;
   }
 
-  if (!queryResult.entries.length && searchText) {
+  // While offline an empty result means the data is not cached (queries are
+  // paused), not that nothing matches - so fall through to the OverviewList,
+  // which renders the offline placeholder.
+  if (!queryResult.entries.length && searchText && !isOffline) {
     return <NoResultsFound />;
   }
 

--- a/app/src/components/overview/journals/Journals.tsx
+++ b/app/src/components/overview/journals/Journals.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { usePageContext } from "../../layout/pages/PageContext";
 import { useJournalsQuery } from "../../../serverApi/reactQuery/queries/useJournalsQuery";
 import { NoResultsFound } from "../../common/search/NoResultsFound";
+import { useIsOffline } from "../../common/useIsOffline";
 import { OverviewList } from "../overviewList/OverviewList";
 import { JournalListItem } from "./JournalListItem";
 import { IJournal } from "../../../serverApi/IJournal";
@@ -12,6 +13,7 @@ export const Journals: React.FC<{
   journalIds?: string[];
 }> = ({ favoritesOnly, journalIds }) => {
   const { searchText, journalTypes } = usePageContext();
+  const isOffline = useIsOffline();
 
   const journals = useJournalsQuery(
     searchText,
@@ -24,7 +26,10 @@ export const Journals: React.FC<{
     return null;
   }
 
-  if (!journals.length && searchText) {
+  // While offline an empty result means the data is not cached (queries are
+  // paused), not that nothing matches - so fall through to the OverviewList,
+  // which renders the offline placeholder.
+  if (!journals.length && searchText && !isOffline) {
     return <NoResultsFound />;
   }
 

--- a/app/src/components/overview/overviewList/OverviewList.tsx
+++ b/app/src/components/overview/overviewList/OverviewList.tsx
@@ -11,6 +11,8 @@ import HistoryToggleOff from "@mui/icons-material/HistoryToggleOff";
 import { differenceInDays } from "date-fns";
 import { FadeInContainer } from "../../common/FadeInContainer";
 import { LazyLoadSuspender } from "../../common/LazyLoadSuspender";
+import { OfflinePlaceholder } from "../../common/search/OfflinePlaceholder";
+import { useIsOffline } from "../../common/useIsOffline";
 
 interface IOverviewListProps {
   items: IEntity[];
@@ -49,6 +51,8 @@ const OverviewListInternal: React.FC<IOverviewListProps> = ({
 }) => {
   const { user } = useAppContext();
 
+  const isOffline = useIsOffline();
+
   const {
     setActiveItemId,
     activeItemId,
@@ -58,15 +62,25 @@ const OverviewListInternal: React.FC<IOverviewListProps> = ({
     setShowAll,
   } = useOverviewListContext();
 
+  // While offline an empty list (almost) always means the data has not been
+  // cached yet - queries are paused and will resume when back online.
+  const showOfflinePlaceholder =
+    isOffline && !itemsToShow.length && !hiddenItemsCount;
+
   return (
     <LazyLoadSuspender>
       <FadeInContainer
         isReady={
-          itemsToShow.length > 0 || hiddenItemsCount > 0 || !!renderBeforeList
+          itemsToShow.length > 0 ||
+          hiddenItemsCount > 0 ||
+          !!renderBeforeList ||
+          showOfflinePlaceholder
         }
       >
         <Host className="overview-list">
           {renderBeforeList?.((i) => setActiveItemId(itemsToShow[i]?.id ?? ""))}
+
+          {showOfflinePlaceholder ? <OfflinePlaceholder /> : null}
 
           {itemsToShow.map((item, index) => {
             const hasFocus = activeItemId === item.id;


### PR DESCRIPTION
Follow-up to #2934 (local-first Phase 0, see #2933): while offline, views whose data was never cached rendered **nothing** (blank page) or **misleading messages** ("No entries available.", "Nothing found. Try again."). This adds an explicit placeholder for that state.

## What it does
- New **`OfflinePlaceholder`** — `GenericEmptyPlaceholder` style (`CloudOffOutlined` + "Data not available as offline."). Wording/icon centralised in one component for easy tweaking.
- **`useIsOffline`** extracted from `OfflineIndicator` into a shared hook.

Shown when offline with nothing to display:
- **`OverviewList`** — covers journals, entries, go-to, search and scrap views in one place; rendered inside the list host so `renderBeforeList` (e.g. go-to input) stays visible.
- **`JournalViewPage`** — instead of "No entries available." when entries are not cached.
- **`JournalDetails`** — instead of a blank page when the journal itself is not cached.
- **`Journals`/`Entries`** — skip "Nothing found. Try again." while offline (it would be a lie) and fall through to the placeholder.

## Known trade-off
The signal is `navigator.onLine` + "nothing to show", not React Query's per-query `isPaused` state. A journal that is cached but **genuinely empty** therefore shows the offline placeholder while offline, instead of "No entries available.". Chosen deliberately: the precise signal would require changing the return shape of `useJournalsQuery`/`useJournalEntriesQuery` and threading state through `JournalContext`. Upgrade path exists if the imprecision bothers us in practice.

## Verified
- `tsc --noEmit` ✅ · `vite build` ✅ · `vitest` ✅ (120/120)

## Testing
`npm run build && npx vite preview`, load once online, then DevTools → Network → Offline and navigate to a journal/view you have not opened before.

Refs #2933

🤖 Generated with [Claude Code](https://claude.com/claude-code)
