### PR TITLE
Allow OneSignal API host in CSP script-src

### DIFF
--- a/app/public/staticwebapp.config.json
+++ b/app/public/staticwebapp.config.json
@@ -4,7 +4,7 @@
     "exclude": ["*.{css,scss,js,png,gif,ico,jpg,svg}"]
   },
   "globalHeaders": {
-    "Content-Security-Policy": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.onesignal.com; connect-src 'self' https://engraved.azurewebsites.net https://engraved-lnx.azurewebsites.net https://accounts.google.com https://*.onesignal.com https://js.monitor.azure.com https://*.in.applicationinsights.azure.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; font-src 'self'; img-src 'self' data: https:; frame-src https://accounts.google.com; worker-src 'self'; manifest-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.onesignal.com https://api.onesignal.com; connect-src 'self' https://engraved.azurewebsites.net https://engraved-lnx.azurewebsites.net https://accounts.google.com https://*.onesignal.com https://js.monitor.azure.com https://*.in.applicationinsights.azure.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; font-src 'self'; img-src 'self' data: https:; frame-src https://accounts.google.com; worker-src 'self'; manifest-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'",
     "X-Content-Type-Options": "nosniff",
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload"


### PR DESCRIPTION
## Problem

The browser console showed OneSignal being blocked:

> Loading the script 'https://api.onesignal.com/sync/.../web?callback=__jp0' violates the following Content Security Policy directive: "script-src 'self' https://accounts.google.com https://cdn.onesignal.com".

OneSignal loads a JSONP sync script from `api.onesignal.com`, but only `cdn.onesignal.com` was whitelisted in `script-src`.

## Fix

Add `https://api.onesignal.com` to the `script-src` directive in `staticwebapp.config.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)