### PR TITLE
Use short entity id for test notifications to fix collapse_id overflow

### DIFF
--- a/api/Engraved.Api/Source/Controllers/NotificationsController.cs
+++ b/api/Engraved.Api/Source/Controllers/NotificationsController.cs
@@ -32,7 +32,9 @@ public class NotificationsController(
         Title = "Test message (Title)",
         Message = "Sent from engraved OneSignal (Message)."
       },
-      Guid.NewGuid().ToString(),
+      // short constant instead of a real entity id: a GUID here would push the
+      // OneSignal collapse_id ("<entityId>::<userId>") over its 64-byte limit
+      "test",
       false
     );
   }


### PR DESCRIPTION
## Problem

Sending a test notification via `POST /api/notifications/send_test` always failed with:

```
500: Error calling CreateNotification: {"errors":["Option collapse_id can not be over 64 bytes!"]}
```

The OneSignal collapse id is built as `<entityId>::<userId>` with dashes stripped. The test endpoint passed a fresh GUID as entity id, making the key 66 bytes — over OneSignal's 64-byte limit. Real notifications use a 24-char Mongo ObjectId (58 bytes total) and were never affected.

## Fix

Pass the short constant `"test"` as the entity id in the test endpoint. This keeps the readable key format (`test::<userid>`, ~38 bytes) and makes repeated test notifications collapse into each other instead of stacking up.

Note: the service itself still has no length guard, so a future caller passing an entity id longer than ~30 chars would hit the same error — deliberately left as-is to keep the readable ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)