### PR TITLE
Show related items

### DIFF
--- a/api/Engraved.Api/Source/Controllers/SearchController.cs
+++ b/api/Engraved.Api/Source/Controllers/SearchController.cs
@@ -1,5 +1,6 @@
 using Engraved.Core.Application;
 using Engraved.Core.Application.Queries.Search.Entities;
+using Engraved.Core.Application.Queries.Search.Related;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -29,5 +30,18 @@ public class SearchController(Dispatcher dispatcher) : ControllerBase
     };
 
     return await dispatcher.Query<SearchEntitiesResult, SearchEntitiesQuery>(query);
+  }
+
+  [Route("related")]
+  [HttpGet]
+  public async Task<SearchEntitiesResult> GetRelatedEntities(string entityId, EntityType entityType)
+  {
+    var query = new GetRelatedEntitiesQuery
+    {
+      EntityId = entityId,
+      EntityType = entityType
+    };
+
+    return await dispatcher.Query<SearchEntitiesResult, GetRelatedEntitiesQuery>(query);
   }
 }

--- a/api/Engraved.Core.Tests/Source/Application/DispatcherShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/DispatcherShould.cs
@@ -218,7 +218,8 @@ public class FakeUserRestrictedRepository(Lazy<IUser> currentUser) : IUserRestri
     JournalType[]? journalTypes = null,
     string[]? journalIds = null,
     int? limit = null,
-    string? currentUserId = null
+    string? currentUserId = null,
+    bool matchAnyWord = false
   )
   {
     throw new NotImplementedException();
@@ -262,7 +263,8 @@ public class FakeUserRestrictedRepository(Lazy<IUser> currentUser) : IUserRestri
     string[]? journalIds = null,
     int? limit = null,
     string? currentUserId = null,
-    bool onlyConsiderTitle = false
+    bool onlyConsiderTitle = false,
+    bool matchAnyWord = false
   )
   {
     throw new NotImplementedException();

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Search/Related/GetRelatedEntitiesQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Search/Related/GetRelatedEntitiesQueryExecutorShould.cs
@@ -1,0 +1,208 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Engraved.Core.Application.Commands;
+using Engraved.Core.Application.Commands.Entries.Upsert.Gauge;
+using Engraved.Core.Application.Commands.Entries.Upsert.Scraps;
+using Engraved.Core.Application.Commands.Journals.Add;
+using Engraved.Core.Application.Queries.Search.Entities;
+using Engraved.Core.Domain.Entries;
+using Engraved.Core.Domain.Journals;
+using Engraved.Core.Domain.Users;
+using Engraved.TestUtils;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Engraved.Core.Application.Queries.Search.Related;
+
+public class GetRelatedEntitiesQueryExecutorShould
+{
+  private FakeDateService _dateService = null!;
+  private GetRelatedEntitiesQueryExecutor _executor = null!;
+  private TestUserRestrictedMongoRepository _repo = null!;
+
+  [SetUp]
+  public async Task SetUp()
+  {
+    const string userId = TestIds.UserId;
+    _repo = await Util.CreateUserRestrictedMongoRepository(userId, userId, false);
+
+    await _repo.UpsertUser(new User { Id = userId, Name = userId });
+
+    _dateService = new FakeDateService();
+    _executor = new GetRelatedEntitiesQueryExecutor(_repo);
+  }
+
+  [Test]
+  public async Task FindRelatedItemsForEntry_ExcludingItsOwnJournal()
+  {
+    // the parent journal shares a word ("Pasta") with the source entry, but neither
+    // it nor its entries may show up - they are already visible on the current page.
+    var ownJournalId = await AddJournal("Pasta Cooking");
+    var sourceEntryId = await AddScrap(ownJournalId, "Pasta Carbonara Recipe");
+    await AddScrap(ownJournalId, "Pasta Bolognese Recipe");
+
+    var otherJournalId = await AddJournal("Restaurants");
+    await AddScrap(otherJournalId, "Best Carbonara in Town");
+
+    await AddJournal("Pasta Places");
+
+    SearchEntitiesResult result = await _executor.Execute(
+      new GetRelatedEntitiesQuery { EntityType = EntityType.Entry, EntityId = sourceEntryId }
+    );
+
+    result.Entities.Length.Should().Be(2);
+
+    result.Entities
+      .Where(e => e.EntityType == EntityType.Entry)
+      .Select(e => ((ScrapsEntry) e.Entity).Title)
+      .Should()
+      .BeEquivalentTo("Best Carbonara in Town");
+
+    result.Entities
+      .Where(e => e.EntityType == EntityType.Journal)
+      .Select(e => ((IJournal) e.Entity).Name)
+      .Should()
+      .BeEquivalentTo("Pasta Places");
+
+    // parent journals of matched entries are returned so the client can render them together
+    result.Journals.Select(j => j.Name).Should().BeEquivalentTo("Restaurants");
+  }
+
+  [Test]
+  public async Task FindRelatedItemsForJournal_ExcludingItselfAndItsEntries()
+  {
+    var sourceJournalId = await AddJournal("Pasta Recipes");
+    await AddScrap(sourceJournalId, "Pasta Carbonara");
+
+    await AddJournal("Recipes Collection");
+
+    var otherJournalId = await AddJournal("Notes");
+    await AddScrap(otherJournalId, "Pasta Shapes");
+
+    SearchEntitiesResult result = await _executor.Execute(
+      new GetRelatedEntitiesQuery { EntityType = EntityType.Journal, EntityId = sourceJournalId }
+    );
+
+    result.Entities.Length.Should().Be(2);
+
+    result.Entities
+      .Where(e => e.EntityType == EntityType.Journal)
+      .Select(e => ((IJournal) e.Entity).Name)
+      .Should()
+      .BeEquivalentTo("Recipes Collection");
+
+    result.Entities
+      .Where(e => e.EntityType == EntityType.Entry)
+      .Select(e => ((ScrapsEntry) e.Entity).Title)
+      .Should()
+      .BeEquivalentTo("Pasta Shapes");
+  }
+
+  [Test]
+  public async Task RankTitleMatchesAboveNotesMatches()
+  {
+    var sourceJournalId = await AddJournal("Stuff");
+    var sourceEntryId = await AddScrap(sourceJournalId, "Tokyo Journey");
+
+    var otherJournalId = await AddJournal("Other");
+    await AddScrap(otherJournalId, "Random Thoughts", "remember the tokyo trip");
+    await AddScrap(otherJournalId, "Tokyo Itinerary");
+
+    SearchEntitiesResult result = await _executor.Execute(
+      new GetRelatedEntitiesQuery { EntityType = EntityType.Entry, EntityId = sourceEntryId }
+    );
+
+    result.Entities.Length.Should().Be(2);
+    ((ScrapsEntry) result.Entities[0].Entity).Title.Should().Be("Tokyo Itinerary");
+    ((ScrapsEntry) result.Entities[1].Entity).Title.Should().Be("Random Thoughts");
+  }
+
+  [Test]
+  public async Task ReturnNothing_WhenTitleConsistsOfStopWordsOnly()
+  {
+    var sourceJournalId = await AddJournal("Stuff");
+    var sourceEntryId = await AddScrap(sourceJournalId, "the and for");
+
+    var otherJournalId = await AddJournal("Other");
+    await AddScrap(otherJournalId, "the best list");
+
+    SearchEntitiesResult result = await _executor.Execute(
+      new GetRelatedEntitiesQuery { EntityType = EntityType.Entry, EntityId = sourceEntryId }
+    );
+
+    result.Entities.Should().BeEmpty();
+  }
+
+  [Test]
+  public async Task NotReturnEntriesWithoutOwnRoute()
+  {
+    var sourceJournalId = await AddJournal("Plans");
+    var sourceEntryId = await AddScrap(sourceJournalId, "Marathon Training Plan");
+
+    // a gauge entry has no page of its own, so it is no navigation target -
+    // it must not be returned even though its notes match.
+    var gaugeJournalId = await AddJournal("Numbers", JournalType.Gauge);
+    var addGaugeExecutor = new UpsertGaugeEntryCommandExecutor(_repo, _repo, _dateService);
+    await addGaugeExecutor.Execute(
+      new UpsertGaugeEntryCommand
+      {
+        JournalId = gaugeJournalId,
+        Value = 42,
+        Notes = "marathon training today",
+        DateTime = _dateService.UtcNow
+      }
+    );
+
+    var otherJournalId = await AddJournal("Food");
+    await AddScrap(otherJournalId, "Marathon Nutrition");
+
+    SearchEntitiesResult result = await _executor.Execute(
+      new GetRelatedEntitiesQuery { EntityType = EntityType.Entry, EntityId = sourceEntryId }
+    );
+
+    result.Entities.Length.Should().Be(1);
+    ((ScrapsEntry) result.Entities[0].Entity).Title.Should().Be("Marathon Nutrition");
+  }
+
+  [Test]
+  public async Task ReturnNothing_WhenSourceDoesNotExist()
+  {
+    SearchEntitiesResult result = await _executor.Execute(
+      new GetRelatedEntitiesQuery { EntityType = EntityType.Entry, EntityId = "507f1f77bcf86cd799439011" }
+    );
+
+    result.Entities.Should().BeEmpty();
+    result.Journals.Should().BeEmpty();
+  }
+
+  [Test]
+  public void Throw_WhenEntityIdIsMissing()
+  {
+    Assert.ThrowsAsync<InvalidQueryException>(
+      async () => await _executor.Execute(new GetRelatedEntitiesQuery { EntityType = EntityType.Entry })
+    );
+  }
+
+  private async Task<string> AddJournal(string name, JournalType type = JournalType.Scraps)
+  {
+    var addJournalExecutor = new AddJournalCommandExecutor(_repo, _dateService);
+    CommandResult result = await addJournalExecutor.Execute(new AddJournalCommand { Name = name, Type = type });
+    return result.EntityId;
+  }
+
+  private async Task<string> AddScrap(string journalId, string title, string? notes = null)
+  {
+    var addEntryExecutor = new UpsertScrapsEntryCommandExecutor(_repo, _repo, _dateService);
+    CommandResult result = await addEntryExecutor.Execute(
+      new UpsertScrapsEntryCommand
+      {
+        JournalId = journalId,
+        Title = title,
+        Notes = notes,
+        DateTime = _dateService.UtcNow
+      }
+    );
+
+    return result.EntityId;
+  }
+}

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Search/Related/GetRelatedEntitiesQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Search/Related/GetRelatedEntitiesQueryExecutorShould.cs
@@ -118,6 +118,25 @@ public class GetRelatedEntitiesQueryExecutorShould
   }
 
   [Test]
+  public async Task FindItemsMatchingViaUmlautWords()
+  {
+    // words with leading/trailing umlauts break \b-based patterns on mongo's
+    // ASCII-only PCRE2 engine - pinned end-to-end here (see WholeWordRegex).
+    var sourceJournalId = await AddJournal("Sport");
+    var sourceEntryId = await AddScrap(sourceJournalId, "Übung Klettern");
+
+    var otherJournalId = await AddJournal("Fitness");
+    await AddScrap(otherJournalId, "Übung Yoga");
+
+    SearchEntitiesResult result = await _executor.Execute(
+      new GetRelatedEntitiesQuery { EntityType = EntityType.Entry, EntityId = sourceEntryId }
+    );
+
+    result.Entities.Length.Should().Be(1);
+    ((ScrapsEntry) result.Entities[0].Entity).Title.Should().Be("Übung Yoga");
+  }
+
+  [Test]
   public async Task ReturnNothing_WhenTitleConsistsOfStopWordsOnly()
   {
     var sourceJournalId = await AddJournal("Stuff");

--- a/api/Engraved.Core/Source/Application/ExecutorRegistration.cs
+++ b/api/Engraved.Core/Source/Application/ExecutorRegistration.cs
@@ -26,6 +26,7 @@ using Engraved.Core.Application.Queries.Export;
 using Engraved.Core.Application.Queries.Journals.Get;
 using Engraved.Core.Application.Queries.Journals.GetAll;
 using Engraved.Core.Application.Queries.Search.Entities;
+using Engraved.Core.Application.Queries.Search.Related;
 using Engraved.Core.Application.Queries.SystemInfo.Get;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
@@ -73,6 +74,7 @@ public static class ExecutorRegistration
     RegisterQuery<IJournal[], GetAllJournalsQuery, GetAllJournalsQueryExecutor>(services);
     RegisterQuery<IJournal?, GetJournalQuery, GetJournalQueryExecutor>(services);
     RegisterQuery<SearchEntitiesResult, SearchEntitiesQuery, SearchEntitiesQueryExecutor>(services);
+    RegisterQuery<SearchEntitiesResult, GetRelatedEntitiesQuery, GetRelatedEntitiesQueryExecutor>(services);
     RegisterQuery<SystemInfo, GetSystemInfoQuery, GetSystemInfoQueryExecutor>(services);
     RegisterQuery<ExportedDataResult, ExportDataQuery, ExportDataQueryExecutor>(services);
   }

--- a/api/Engraved.Core/Source/Application/Persistence/IEntryRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IEntryRepository.cs
@@ -20,7 +20,8 @@ public interface IEntryRepository
     string[]? journalIds = null,
     int? limit = null,
     string? currentUserId = null,
-    bool onlyConsiderTitle = false
+    bool onlyConsiderTitle = false,
+    bool matchAnyWord = false
   );
 
   Task<UpsertResult> UpsertEntry<TEntry>(TEntry entry) where TEntry : IEntry;

--- a/api/Engraved.Core/Source/Application/Persistence/IJournalRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IJournalRepository.cs
@@ -11,7 +11,8 @@ public interface IJournalRepository
     JournalType[]? journalTypes = null,
     string[]? journalIds = null,
     int? limit = null,
-    string? currentUserId = null
+    string? currentUserId = null,
+    bool matchAnyWord = false
   );
 
   Task<IJournal?> GetJournal(string journalId);

--- a/api/Engraved.Core/Source/Application/Queries/Search/Related/GetRelatedEntitiesQuery.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Search/Related/GetRelatedEntitiesQuery.cs
@@ -1,0 +1,12 @@
+using Engraved.Core.Application.Queries.Search.Entities;
+
+namespace Engraved.Core.Application.Queries.Search.Related;
+
+public class GetRelatedEntitiesQuery : IQuery
+{
+  public EntityType EntityType { get; set; }
+
+  public string? EntityId { get; set; }
+
+  public int? Limit { get; set; }
+}

--- a/api/Engraved.Core/Source/Application/Queries/Search/Related/GetRelatedEntitiesQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Search/Related/GetRelatedEntitiesQueryExecutor.cs
@@ -1,7 +1,6 @@
 using System.Text.RegularExpressions;
 using Engraved.Core.Application.Persistence;
 using Engraved.Core.Application.Queries.Search.Entities;
-using Engraved.Core.Domain;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
 
@@ -49,14 +48,13 @@ public class GetRelatedEntitiesQueryExecutor(IUserRestrictedRepository repositor
       );
     }
 
-    (string? sourceText, string? ownJournalId) = await LoadSource(query);
-    if (ownJournalId == null)
+    SourceContext source = await LoadSource(query);
+    if (source.OwnJournalId == null)
     {
-      // source does not exist or the current user must not see it
       return new SearchEntitiesResult();
     }
 
-    var words = GetWords(sourceText);
+    var words = GetRelevantWords(source.SourceText);
     if (words.Length == 0)
     {
       return new SearchEntitiesResult();
@@ -64,25 +62,26 @@ public class GetRelatedEntitiesQueryExecutor(IUserRestrictedRepository repositor
 
     var searchText = string.Join(" ", words);
 
-    IJournal[] allJournals = await repository.GetAllJournals(null, null, null, null, 1000);
+    var allJournals = await repository.GetAllJournals(null, null, null, null, 1000);
+
     var otherJournalIds = allJournals
       .Select(j => j.Id!)
-      .Where(id => id != ownJournalId)
+      .Where(id => id != source.OwnJournalId)
       .ToArray();
 
-    Task<IJournal[]> journalCandidatesTask = repository.GetAllJournals(
+    var journalCandidatesTask = repository.GetAllJournals(
       searchText,
       null,
       null,
       null,
       CandidateLimit,
       null,
-      matchAnyWord: true
+      true
     );
 
     // passing otherJournalIds both scopes the (unscoped) entry search to journals the
     // user may read AND excludes the source item's own journal (see class comment).
-    Task<IEntry[]> entryCandidatesTask = otherJournalIds.Length > 0
+    var entryCandidatesTask = otherJournalIds.Length > 0
       ? repository.SearchEntries(
         searchText,
         null,
@@ -90,15 +89,15 @@ public class GetRelatedEntitiesQueryExecutor(IUserRestrictedRepository repositor
         otherJournalIds,
         CandidateLimit,
         null,
-        onlyConsiderTitle: false,
-        matchAnyWord: true
+        false,
+        true
       )
       : Task.FromResult<IEntry[]>([]);
 
     await Task.WhenAll(journalCandidatesTask, entryCandidatesTask);
 
-    SearchResultEntity[] rankedEntities = journalCandidatesTask.Result
-      .Where(j => j.Id != ownJournalId)
+    var rankedEntities = journalCandidatesTask.Result
+      .Where(j => j.Id != source.OwnJournalId)
       .Select(j => new
         {
           Entity = new SearchResultEntity { EntityType = EntityType.Journal, Entity = j },
@@ -121,7 +120,7 @@ public class GetRelatedEntitiesQueryExecutor(IUserRestrictedRepository repositor
 
     var parentJournalIds = rankedEntities
       .Where(e => e.EntityType == EntityType.Entry)
-      .Select(e => ((IEntry) e.Entity).ParentId)
+      .Select(e => ((IEntry)e.Entity).ParentId)
       .ToArray();
 
     return new SearchEntitiesResult
@@ -133,14 +132,14 @@ public class GetRelatedEntitiesQueryExecutor(IUserRestrictedRepository repositor
 
   // returns the text to derive the search words from, plus the id of the journal whose
   // items must be excluded (the source journal itself resp. the source entry's parent).
-  // ownJournalId == null means "source not accessible".
-  private async Task<(string? SourceText, string? OwnJournalId)> LoadSource(GetRelatedEntitiesQuery query)
+  // OwnJournalId == null means "source not accessible".
+  private async Task<SourceContext> LoadSource(GetRelatedEntitiesQuery query)
   {
     if (query.EntityType == EntityType.Journal)
     {
       // GetJournal is permission-scoped and returns null if the user may not read it
       IJournal? journal = await repository.GetJournal(query.EntityId!);
-      return (journal?.Name, journal?.Id);
+      return new SourceContext(journal?.Name, journal?.Id);
     }
 
     // GetEntry is an unscoped primitive, so read access is enforced here by loading the
@@ -148,27 +147,23 @@ public class GetRelatedEntitiesQueryExecutor(IUserRestrictedRepository repositor
     IEntry? entry = await repository.GetEntry(query.EntityId!);
     if (entry == null)
     {
-      return (null, null);
+      return SourceContext.Inaccessible;
     }
 
     IJournal? parentJournal = await repository.GetJournal(entry.ParentId);
     if (parentJournal == null)
     {
-      return (null, null);
+      return SourceContext.Inaccessible;
     }
 
     var title = (entry as ScrapsEntry)?.Title;
-    return (string.IsNullOrWhiteSpace(title) ? entry.Notes : title, entry.ParentId);
+    return new SourceContext(string.IsNullOrWhiteSpace(title) ? entry.Notes : title, entry.ParentId);
   }
 
-  private static string[] GetWords(string? text)
+  private static string[] GetRelevantWords(string? text)
   {
-    if (string.IsNullOrWhiteSpace(text))
-    {
-      return [];
-    }
-
-    return Regex.Split(text.ToLowerInvariant(), @"[^\p{L}\p{N}]+")
+    return Regex.Split((text ?? string.Empty).ToLowerInvariant(), @"[^\p{L}\p{N}]+")
+      .Select(word => word.Trim())
       .Where(word => word.Length >= MinWordLength && !StopWords.Contains(word))
       .Distinct()
       .Take(MaxWords)
@@ -179,26 +174,25 @@ public class GetRelatedEntitiesQueryExecutor(IUserRestrictedRepository repositor
   // word (that is what the DB query selected it by), so the minimum score is 1.
   private static int GetScore(string[] words, string? title, string? body)
   {
-    var score = 0;
-
-    foreach (var word in words)
-    {
-      if (ContainsWord(title, word))
-      {
-        score += 3;
-      }
-      else if (ContainsWord(body, word))
-      {
-        score += 1;
-      }
-    }
-
-    return score;
+    return words.Aggregate(
+      0,
+      (score, word) => score + (ContainsWord(title, word) ? 3 : ContainsWord(body, word) ? 1 : 0)
+    );
   }
 
   private static bool ContainsWord(string? text, string word)
   {
     return !string.IsNullOrEmpty(text)
            && Regex.IsMatch(text, $@"\b{Regex.Escape(word)}\b", RegexOptions.IgnoreCase);
+  }
+
+  private sealed class SourceContext(string? sourceText, string? ownJournalId)
+  {
+    public static readonly SourceContext Inaccessible = new(null, null);
+
+    public string? SourceText { get; } = sourceText;
+
+    // null means the source does not exist or the current user must not see it
+    public string? OwnJournalId { get; } = ownJournalId;
   }
 }

--- a/api/Engraved.Core/Source/Application/Queries/Search/Related/GetRelatedEntitiesQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Search/Related/GetRelatedEntitiesQueryExecutor.cs
@@ -1,0 +1,204 @@
+using System.Text.RegularExpressions;
+using Engraved.Core.Application.Persistence;
+using Engraved.Core.Application.Queries.Search.Entities;
+using Engraved.Core.Domain;
+using Engraved.Core.Domain.Entries;
+using Engraved.Core.Domain.Journals;
+
+namespace Engraved.Core.Application.Queries.Search.Related;
+
+// Finds items "related" to a given journal or entry, purely for navigation purposes:
+// the source item's own journal (and its entries) are deliberately excluded, as they
+// are already visible on the page the user is coming from. Relatedness is based on
+// word overlap: candidates are fetched with a single match-any-word query and then
+// ranked in memory (no $text/Atlas Search available on the Cosmos DB Mongo API).
+public class GetRelatedEntitiesQueryExecutor(IUserRestrictedRepository repository)
+  : IQueryExecutor<SearchEntitiesResult, GetRelatedEntitiesQuery>
+{
+  private const int MaxWords = 10;
+  private const int MinWordLength = 3;
+  private const int CandidateLimit = 50;
+  private const int DefaultResultLimit = 10;
+
+  // only entries of these types have their own routes in the app, so only they
+  // are valid navigation targets. journals of ALL types are considered.
+  private static readonly JournalType[] NavigableEntryTypes = [JournalType.Scraps, JournalType.LogBook];
+
+  private static readonly HashSet<string> StopWords =
+  [
+    // english
+    "the", "and", "for", "with", "this", "that", "these", "those", "from", "are",
+    "was", "were", "has", "have", "had", "not", "you", "your", "all", "any",
+    "can", "will", "one", "how", "what", "when", "where", "why", "who", "which",
+    // german
+    "und", "der", "die", "das", "den", "dem", "des", "ein", "eine", "einen",
+    "einem", "einer", "ist", "sind", "war", "mit", "von", "für", "auf", "aus",
+    "bei", "nach", "über", "unter", "nicht", "auch", "wie", "was", "wann", "wer",
+    "oder", "aber", "als", "zum", "zur", "ich", "sie", "wir"
+  ];
+
+  public bool DisableCache => false;
+
+  public async Task<SearchEntitiesResult> Execute(GetRelatedEntitiesQuery query)
+  {
+    if (string.IsNullOrEmpty(query.EntityId))
+    {
+      throw new InvalidQueryException(
+        query,
+        $"{nameof(GetRelatedEntitiesQuery.EntityId)} must be specified."
+      );
+    }
+
+    (string? sourceText, string? ownJournalId) = await LoadSource(query);
+    if (ownJournalId == null)
+    {
+      // source does not exist or the current user must not see it
+      return new SearchEntitiesResult();
+    }
+
+    var words = GetWords(sourceText);
+    if (words.Length == 0)
+    {
+      return new SearchEntitiesResult();
+    }
+
+    var searchText = string.Join(" ", words);
+
+    IJournal[] allJournals = await repository.GetAllJournals(null, null, null, null, 1000);
+    var otherJournalIds = allJournals
+      .Select(j => j.Id!)
+      .Where(id => id != ownJournalId)
+      .ToArray();
+
+    Task<IJournal[]> journalCandidatesTask = repository.GetAllJournals(
+      searchText,
+      null,
+      null,
+      null,
+      CandidateLimit,
+      null,
+      matchAnyWord: true
+    );
+
+    // passing otherJournalIds both scopes the (unscoped) entry search to journals the
+    // user may read AND excludes the source item's own journal (see class comment).
+    Task<IEntry[]> entryCandidatesTask = otherJournalIds.Length > 0
+      ? repository.SearchEntries(
+        searchText,
+        null,
+        NavigableEntryTypes,
+        otherJournalIds,
+        CandidateLimit,
+        null,
+        onlyConsiderTitle: false,
+        matchAnyWord: true
+      )
+      : Task.FromResult<IEntry[]>([]);
+
+    await Task.WhenAll(journalCandidatesTask, entryCandidatesTask);
+
+    SearchResultEntity[] rankedEntities = journalCandidatesTask.Result
+      .Where(j => j.Id != ownJournalId)
+      .Select(j => new
+        {
+          Entity = new SearchResultEntity { EntityType = EntityType.Journal, Entity = j },
+          Score = GetScore(words, j.Name, j.Description)
+        }
+      )
+      .Concat(
+        entryCandidatesTask.Result.Select(e => new
+          {
+            Entity = new SearchResultEntity { EntityType = EntityType.Entry, Entity = e },
+            Score = GetScore(words, (e as ScrapsEntry)?.Title, e.Notes)
+          }
+        )
+      )
+      .OrderByDescending(x => x.Score)
+      .ThenByDescending(x => x.Entity.Entity.EditedOn)
+      .Take(query.Limit ?? DefaultResultLimit)
+      .Select(x => x.Entity)
+      .ToArray();
+
+    var parentJournalIds = rankedEntities
+      .Where(e => e.EntityType == EntityType.Entry)
+      .Select(e => ((IEntry) e.Entity).ParentId)
+      .ToArray();
+
+    return new SearchEntitiesResult
+    {
+      Entities = rankedEntities,
+      Journals = allJournals.Where(j => parentJournalIds.Contains(j.Id)).ToArray()
+    };
+  }
+
+  // returns the text to derive the search words from, plus the id of the journal whose
+  // items must be excluded (the source journal itself resp. the source entry's parent).
+  // ownJournalId == null means "source not accessible".
+  private async Task<(string? SourceText, string? OwnJournalId)> LoadSource(GetRelatedEntitiesQuery query)
+  {
+    if (query.EntityType == EntityType.Journal)
+    {
+      // GetJournal is permission-scoped and returns null if the user may not read it
+      IJournal? journal = await repository.GetJournal(query.EntityId!);
+      return (journal?.Name, journal?.Id);
+    }
+
+    // GetEntry is an unscoped primitive, so read access is enforced here by loading the
+    // parent journal through the scoped GetJournal (same pattern as GetEntryQueryExecutor).
+    IEntry? entry = await repository.GetEntry(query.EntityId!);
+    if (entry == null)
+    {
+      return (null, null);
+    }
+
+    IJournal? parentJournal = await repository.GetJournal(entry.ParentId);
+    if (parentJournal == null)
+    {
+      return (null, null);
+    }
+
+    var title = (entry as ScrapsEntry)?.Title;
+    return (string.IsNullOrWhiteSpace(title) ? entry.Notes : title, entry.ParentId);
+  }
+
+  private static string[] GetWords(string? text)
+  {
+    if (string.IsNullOrWhiteSpace(text))
+    {
+      return [];
+    }
+
+    return Regex.Split(text.ToLowerInvariant(), @"[^\p{L}\p{N}]+")
+      .Where(word => word.Length >= MinWordLength && !StopWords.Contains(word))
+      .Distinct()
+      .Take(MaxWords)
+      .ToArray();
+  }
+
+  // title matches weigh more than body matches; every candidate matches at least one
+  // word (that is what the DB query selected it by), so the minimum score is 1.
+  private static int GetScore(string[] words, string? title, string? body)
+  {
+    var score = 0;
+
+    foreach (var word in words)
+    {
+      if (ContainsWord(title, word))
+      {
+        score += 3;
+      }
+      else if (ContainsWord(body, word))
+      {
+        score += 1;
+      }
+    }
+
+    return score;
+  }
+
+  private static bool ContainsWord(string? text, string word)
+  {
+    return !string.IsNullOrEmpty(text)
+           && Regex.IsMatch(text, $@"\b{Regex.Escape(word)}\b", RegexOptions.IgnoreCase);
+  }
+}

--- a/api/Engraved.Core/Source/Application/Queries/Search/Related/GetRelatedEntitiesQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Search/Related/GetRelatedEntitiesQueryExecutor.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using Engraved.Core.Application.Persistence;
 using Engraved.Core.Application.Queries.Search.Entities;
+using Engraved.Core.Application.Search;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
 
@@ -171,19 +172,15 @@ public class GetRelatedEntitiesQueryExecutor(IUserRestrictedRepository repositor
   }
 
   // title matches weigh more than body matches; every candidate matches at least one
-  // word (that is what the DB query selected it by), so the minimum score is 1.
+  // word (the DB query selected it with the same WholeWordRegex pattern), so the
+  // minimum score is 1.
   private static int GetScore(string[] words, string? title, string? body)
   {
     return words.Aggregate(
       0,
-      (score, word) => score + (ContainsWord(title, word) ? 3 : ContainsWord(body, word) ? 1 : 0)
+      (score, word) =>
+        score + (WholeWordRegex.IsMatch(title, word) ? 3 : WholeWordRegex.IsMatch(body, word) ? 1 : 0)
     );
-  }
-
-  private static bool ContainsWord(string? text, string word)
-  {
-    return !string.IsNullOrEmpty(text)
-           && Regex.IsMatch(text, $@"\b{Regex.Escape(word)}\b", RegexOptions.IgnoreCase);
   }
 
   private sealed class SourceContext(string? sourceText, string? ownJournalId)

--- a/api/Engraved.Core/Source/Application/Search/WholeWordRegex.cs
+++ b/api/Engraved.Core/Source/Application/Search/WholeWordRegex.cs
@@ -1,0 +1,26 @@
+using System.Text.RegularExpressions;
+
+namespace Engraved.Core.Application.Search;
+
+// Builds the regex for whole-word matching. \b must NOT be used for this: MongoDB's
+// PCRE2 engine treats \b as ASCII-only (umlauts etc. are "non-word" characters there),
+// so \b-based patterns silently fail to match words like "übung" in the DB while
+// .NET's Unicode-aware \b matches them in memory. Explicit Unicode classes behave
+// identically in both engines.
+//
+// Both the mongo free-text filter (candidate selection) and the related-items scoring
+// (ranking) must use this same pattern: a candidate returned by the DB must score at
+// least 1 in memory, otherwise ranking silently degrades.
+public static class WholeWordRegex
+{
+  public static string BuildPattern(string word)
+  {
+    return $@"(^|[^\p{{L}}\p{{N}}]){Regex.Escape(word)}($|[^\p{{L}}\p{{N}}])";
+  }
+
+  public static bool IsMatch(string? text, string word)
+  {
+    return !string.IsNullOrEmpty(text)
+           && Regex.IsMatch(text, BuildPattern(word), RegexOptions.IgnoreCase | RegexOptions.Multiline);
+  }
+}

--- a/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_SearchEntries_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_SearchEntries_Should.cs
@@ -87,6 +87,44 @@ public class MongoRepositoryBase_SearchEntries_Should
   }
 
   [Test]
+  public async Task MatchAnyWord_FindsEntriesMatchingAnyOfTheWords()
+  {
+    // "alpha" and "heiri" occur in two different entries; with match-any
+    // semantics both entries are returned (regular search would return none).
+    IEntry[] results = await _repository.SearchEntries(
+      "alpha heiri",
+      null,
+      null,
+      [_journalId],
+      10,
+      null,
+      onlyConsiderTitle: false,
+      matchAnyWord: true
+    );
+
+    results.Length.Should().Be(2);
+  }
+
+  [Test]
+  public async Task MatchAnyWord_MatchesWholeWordsOnly()
+  {
+    // "gam" is a substring of "Gamma"; unlike the regular (substring) search,
+    // match-any only matches whole words.
+    IEntry[] results = await _repository.SearchEntries(
+      "gam",
+      null,
+      null,
+      [_journalId],
+      10,
+      null,
+      onlyConsiderTitle: false,
+      matchAnyWord: true
+    );
+
+    results.Should().BeEmpty();
+  }
+
+  [Test]
   public async Task TreatRegexMetacharactersLiterally()
   {
     await _repository.UpsertEntry(

--- a/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_SearchEntries_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_SearchEntries_Should.cs
@@ -125,6 +125,37 @@ public class MongoRepositoryBase_SearchEntries_Should
   }
 
   [Test]
+  public async Task MatchAnyWord_MatchesWordsWithLeadingOrTrailingUmlauts()
+  {
+    // mongo's PCRE2 engine treats \b as ASCII-only, so a \b-based pattern never finds
+    // a word boundary next to an umlaut. This pins that the whole-word pattern matches
+    // words like "Übung" (see WholeWordRegex).
+    await _repository.UpsertEntry(
+      new GaugeEntry
+      {
+        ParentId = _journalId,
+        Value = 5,
+        Notes = "Übung Klettern",
+        EditedOn = DateTime.Now.AddDays(-4)
+      }
+    );
+
+    IEntry[] results = await _repository.SearchEntries(
+      "übung",
+      null,
+      null,
+      [_journalId],
+      10,
+      null,
+      onlyConsiderTitle: false,
+      matchAnyWord: true
+    );
+
+    results.Length.Should().Be(1);
+    results[0].GetValue().Should().Be(5);
+  }
+
+  [Test]
   public async Task TreatRegexMetacharactersLiterally()
   {
     await _repository.UpsertEntry(

--- a/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
+++ b/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
@@ -2,6 +2,7 @@ using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 using Engraved.Core.Application.Permissions;
 using Engraved.Core.Application.Persistence;
+using Engraved.Core.Application.Search;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Permissions;
@@ -574,8 +575,8 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
   // matchAnyWord = false: every word must match somewhere (one AND-ed filter per word,
   // substring semantics) - this is the regular search behavior.
   // matchAnyWord = true: a single filter matching documents that contain ANY of the words,
-  // as whole words (\b-anchored) - used to collect candidates for "related items", where
-  // requiring all words would be far too strict and substring matches are mostly noise.
+  // as whole words (via WholeWordRegex) - used to collect candidates for "related items",
+  // where requiring all words would be far too strict and substring matches are mostly noise.
   private static List<FilterDefinition<T>> GetFreeTextFilters<T>(
     string? searchText,
     bool matchAnyWord,
@@ -594,7 +595,7 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
           // regex engine unescaped allowed malformed patterns (exceptions) and
           // catastrophic-backtracking patterns (ReDoS) to be injected via search.
           var pattern = matchAnyWord
-            ? $@"\b{Regex.Escape(segment)}\b"
+            ? WholeWordRegex.BuildPattern(segment)
             : Regex.Escape(segment);
 
           return Builders<T>.Filter.Or(

--- a/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
+++ b/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
@@ -79,7 +79,8 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
     JournalType[]? journalTypes = null,
     string[]? journalIds = null,
     int? limit = null,
-    string? currentUserId = null
+    string? currentUserId = null,
+    bool matchAnyWord = false
   )
   {
     var filters = new List<FilterDefinition<JournalDocument>>();
@@ -140,6 +141,7 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
       filters.AddRange(
         GetFreeTextFilters<JournalDocument>(
           searchText,
+          matchAnyWord,
           d => d.Name!,
           d => d.Description!
         )
@@ -184,6 +186,7 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
       filters.AddRange(
         GetFreeTextFilters<EntryDocument>(
           searchText,
+          false,
           d => d.Notes!,
           d => ((ScrapsEntryDocument) d).Title!
         )
@@ -231,7 +234,8 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
     string[]? journalIds = null,
     int? limit = null,
     string? currentUserId = null,
-    bool onlyConsiderTitle = false
+    bool onlyConsiderTitle = false,
+    bool matchAnyWord = false
   )
   {
     var filters = new List<FilterDefinition<EntryDocument>>();
@@ -241,6 +245,7 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
       filters.AddRange(
         GetFreeTextFilters<EntryDocument>(
           searchText,
+          matchAnyWord,
           onlyConsiderTitle
             ? [d => ((ScrapsEntryDocument) d).Title!]
             : [d => ((ScrapsEntryDocument) d).Title!, d => d.Notes!]
@@ -566,8 +571,14 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
     );
   }
 
+  // matchAnyWord = false: every word must match somewhere (one AND-ed filter per word,
+  // substring semantics) - this is the regular search behavior.
+  // matchAnyWord = true: a single filter matching documents that contain ANY of the words,
+  // as whole words (\b-anchored) - used to collect candidates for "related items", where
+  // requiring all words would be far too strict and substring matches are mostly noise.
   private static List<FilterDefinition<T>> GetFreeTextFilters<T>(
     string? searchText,
+    bool matchAnyWord,
     params Expression<Func<T, object>>[] fieldNameExpressions
   ) where T : IDocument
   {
@@ -576,17 +587,21 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
       return [];
     }
 
-    return searchText.Split(" ")
+    List<FilterDefinition<T>> perWordFilters = searchText.Split(" ")
       .Select(segment =>
         {
           // Escape the user input so it is matched literally. Passing it to the
           // regex engine unescaped allowed malformed patterns (exceptions) and
           // catastrophic-backtracking patterns (ReDoS) to be injected via search.
+          var pattern = matchAnyWord
+            ? $@"\b{Regex.Escape(segment)}\b"
+            : Regex.Escape(segment);
+
           return Builders<T>.Filter.Or(
             fieldNameExpressions.Select(exp => Builders<T>.Filter.Regex(
                 exp,
                 new BsonRegularExpression(
-                  new Regex(Regex.Escape(segment), RegexOptions.IgnoreCase | RegexOptions.Multiline)
+                  new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Multiline)
                 )
               )
             )
@@ -594,5 +609,9 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
         }
       )
       .ToList();
+
+    return matchAnyWord
+      ? [Builders<T>.Filter.Or(perWordFilters)]
+      : perWordFilters;
   }
 }

--- a/app/src/components/common/actions/ActionFactory.tsx
+++ b/app/src/components/common/actions/ActionFactory.tsx
@@ -13,6 +13,7 @@ import FilterAltOutlined from "@mui/icons-material/FilterAltOutlined";
 import FormatLineSpacingOutlined from "@mui/icons-material/FormatLineSpacingOutlined";
 import FunctionsOutlined from "@mui/icons-material/FunctionsOutlined";
 import HistoryToggleOff from "@mui/icons-material/HistoryToggleOff";
+import Hub from "@mui/icons-material/Hub";
 import MessageOutlined from "@mui/icons-material/MessageOutlined";
 import PanToolOutlined from "@mui/icons-material/PanToolOutlined";
 import PlaylistAdd from "@mui/icons-material/PlaylistAdd";
@@ -287,6 +288,15 @@ export class ActionFactory {
       label: "Move to another scrap",
       icon: <Redo fontSize="small" />,
       search: getItemActionQueryParams("move", scrap.id),
+    };
+  }
+
+  static showRelatedItems(itemId: string): IAction {
+    return {
+      key: "related",
+      label: "Show related items",
+      icon: <Hub fontSize="small" />,
+      search: getItemActionQueryParams("related", itemId),
     };
   }
 

--- a/app/src/components/common/actions/searchParamHooks.ts
+++ b/app/src/components/common/actions/searchParamHooks.ts
@@ -16,6 +16,7 @@ const actionKeys = [
   "add-entry",
   "move",
   "edit",
+  "related",
 ] as const;
 
 export type ActionKey = (typeof actionKeys)[number];

--- a/app/src/components/common/entries/EntrySubRoutes.tsx
+++ b/app/src/components/common/entries/EntrySubRoutes.tsx
@@ -5,6 +5,7 @@ import { IEntry } from "../../../serverApi/IEntry";
 import React from "react";
 import { UpsertEntryAction } from "../../details/add/UpsertEntryAction";
 import { DeleteEntryAction } from "../../details/edit/DeleteEntryAction";
+import { RelatedItemsAction } from "../../details/related/RelatedItemsAction";
 import { knownQueryParams, useItemAction } from "../actions/searchParamHooks";
 import { NavigationActionContainer } from "../actions/NavigationActionContainer";
 
@@ -50,6 +51,13 @@ export const EntrySubRoutes: React.FC<{
         return (
           <NavigationActionContainer>
             <UpsertEntryAction entry={entry} />
+          </NavigationActionContainer>
+        );
+
+      case "related":
+        return (
+          <NavigationActionContainer>
+            <RelatedItemsAction entityId={entry.id ?? ""} entityType="Entry" />
           </NavigationActionContainer>
         );
 

--- a/app/src/components/common/itemRows/GoToItemRow.tsx
+++ b/app/src/components/common/itemRows/GoToItemRow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { styled, Typography } from "@mui/material";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { useEngravedHotkeys } from "../../common/actions/useEngravedHotkeys";
+import { useEngravedHotkeys } from "../actions/useEngravedHotkeys";
 
 export const GoToItemRow: React.FC<{
   children: React.ReactNode;

--- a/app/src/components/common/itemRows/JournalGoToItemRow.tsx
+++ b/app/src/components/common/itemRows/JournalGoToItemRow.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { IJournal } from "../../../serverApi/IJournal";
+import { JournalType } from "../../../serverApi/JournalType";
+import { GoToItemRow } from "./GoToItemRow";
+import { JournalIcon } from "../../overview/journals/JournalIcon";
+import { IconStyle } from "../IconStyle";
+import { ActionFactory } from "../actions/ActionFactory";
+import { ActionIconButton } from "../actions/ActionIconButton";
+import { DeviceWidth, useDeviceWidth } from "../useDeviceWidth";
+import { isTypeThatCanShowAddEntryRow } from "../../../util/journalUtils";
+
+export const JournalGoToItemRow: React.FC<{
+  journal: IJournal;
+  hasFocus: boolean;
+  onClick?: () => void;
+}> = ({ journal, hasFocus, onClick }) => {
+  const deviceWidth = useDeviceWidth();
+
+  return (
+    <GoToItemRow
+      url={`/journals/details/${journal.id}`}
+      onClick={onClick}
+      hasFocus={hasFocus}
+      icon={<JournalIcon journal={journal} iconStyle={IconStyle.Small} />}
+      renderAtEnd={() => {
+        return journal.type !== JournalType.Scraps ? (
+          <ActionIconButton
+            action={
+              deviceWidth === DeviceWidth.Normal &&
+              isTypeThatCanShowAddEntryRow(journal.type)
+                ? ActionFactory.goToJournal(journal.id ?? "", false)
+                : ActionFactory.addEntry(journal, false, () => {}, true)
+            }
+          />
+        ) : null;
+      }}
+    >
+      {`${journal.name}`}
+    </GoToItemRow>
+  );
+};

--- a/app/src/components/common/itemRows/ScrapEntryGoToItemRow.tsx
+++ b/app/src/components/common/itemRows/ScrapEntryGoToItemRow.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import Check from "@mui/icons-material/Check";
+import Notes from "@mui/icons-material/Notes";
+import { IScrapEntry } from "../../../serverApi/IScrapEntry";
+import { IJournal } from "../../../serverApi/IJournal";
+import { GoToItemRow } from "./GoToItemRow";
+import { Icon } from "../Icon";
+import { IconStyle } from "../IconStyle";
+import { knownQueryParams } from "../actions/searchParamHooks";
+
+export const ScrapEntryGoToItemRow: React.FC<{
+  scrapEntry: IScrapEntry;
+  journal?: IJournal;
+  hasFocus: boolean;
+  onClick?: () => void;
+}> = ({ scrapEntry, journal, hasFocus, onClick }) => {
+  return (
+    <GoToItemRow
+      icon={
+        <Icon style={IconStyle.Small}>
+          {scrapEntry.scrapType === "List" ? <Check /> : <Notes />}
+        </Icon>
+      }
+      url={`/journals/details/${scrapEntry.parentId}?${knownQueryParams.selectedItemId}=${scrapEntry.id}`}
+      hasFocus={hasFocus}
+      onClick={onClick}
+    >
+      <span style={{ display: "flex", alignItems: "center" }}>
+        {scrapEntry.title || getNotesExcerpt(scrapEntry.notes) || scrapEntry.id}
+        <span
+          style={{ fontSize: "smaller", color: "initial", paddingLeft: "10px" }}
+        >
+          {journal?.name}
+        </span>
+      </span>
+    </GoToItemRow>
+  );
+};
+
+// log book entries have no title, so we show the beginning of their notes instead
+function getNotesExcerpt(notes: string | undefined): string | undefined {
+  if (!notes) {
+    return undefined;
+  }
+
+  const firstLine = notes.split("\n")[0];
+  return firstLine.length > 60 ? firstLine.substring(0, 60) + "..." : firstLine;
+}

--- a/app/src/components/details/related/RelatedItemsAction.tsx
+++ b/app/src/components/details/related/RelatedItemsAction.tsx
@@ -1,15 +1,10 @@
 import React from "react";
 import { Typography } from "@mui/material";
-import Check from "@mui/icons-material/Check";
-import Notes from "@mui/icons-material/Notes";
 import { useRelatedEntitiesQuery } from "../../../serverApi/reactQuery/queries/useRelatedEntitiesQuery";
 import { IJournal } from "../../../serverApi/IJournal";
 import { IScrapEntry } from "../../../serverApi/IScrapEntry";
-import { GoToItemRow } from "../../overview/goto/GoToItemRow";
-import { JournalIcon } from "../../overview/journals/JournalIcon";
-import { Icon } from "../../common/Icon";
-import { IconStyle } from "../../common/IconStyle";
-import { knownQueryParams } from "../../common/actions/searchParamHooks";
+import { JournalGoToItemRow } from "../../common/itemRows/JournalGoToItemRow";
+import { ScrapEntryGoToItemRow } from "../../common/itemRows/ScrapEntryGoToItemRow";
 
 export const RelatedItemsAction: React.FC<{
   entityId: string;
@@ -36,60 +31,24 @@ export const RelatedItemsAction: React.FC<{
         if (searchResultEntity.entityType === "Journal") {
           const journal = searchResultEntity.entity as IJournal;
           return (
-            <GoToItemRow
+            <JournalGoToItemRow
               key={journal.id}
-              url={`/journals/details/${journal.id}`}
+              journal={journal}
               hasFocus={false}
-              icon={
-                <JournalIcon journal={journal} iconStyle={IconStyle.Small} />
-              }
-            >
-              {journal.name}
-            </GoToItemRow>
+            />
           );
         }
 
         const entry = searchResultEntity.entity as IScrapEntry;
-        const parentJournal = result.journals.find(
-          (j) => j.id === entry.parentId,
-        );
-
         return (
-          <GoToItemRow
+          <ScrapEntryGoToItemRow
             key={entry.id}
-            url={`/journals/details/${entry.parentId}?${knownQueryParams.selectedItemId}=${entry.id}`}
+            scrapEntry={entry}
+            journal={result.journals.find((j) => j.id === entry.parentId)}
             hasFocus={false}
-            icon={
-              <Icon style={IconStyle.Small}>
-                {entry.scrapType === "List" ? <Check /> : <Notes />}
-              </Icon>
-            }
-          >
-            <span style={{ display: "flex", alignItems: "center" }}>
-              {entry.title || getNotesExcerpt(entry.notes) || entry.id}
-              <span
-                style={{
-                  fontSize: "smaller",
-                  color: "initial",
-                  paddingLeft: "10px",
-                }}
-              >
-                {parentJournal?.name}
-              </span>
-            </span>
-          </GoToItemRow>
+          />
         );
       })}
     </div>
   );
 };
-
-// log book entries have no title, so we show the beginning of their notes instead
-function getNotesExcerpt(notes: string | undefined): string | undefined {
-  if (!notes) {
-    return undefined;
-  }
-
-  const firstLine = notes.split("\n")[0];
-  return firstLine.length > 60 ? firstLine.substring(0, 60) + "..." : firstLine;
-}

--- a/app/src/components/details/related/RelatedItemsAction.tsx
+++ b/app/src/components/details/related/RelatedItemsAction.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { Typography } from "@mui/material";
+import Check from "@mui/icons-material/Check";
+import Notes from "@mui/icons-material/Notes";
+import { useRelatedEntitiesQuery } from "../../../serverApi/reactQuery/queries/useRelatedEntitiesQuery";
+import { IJournal } from "../../../serverApi/IJournal";
+import { IScrapEntry } from "../../../serverApi/IScrapEntry";
+import { GoToItemRow } from "../../overview/goto/GoToItemRow";
+import { JournalIcon } from "../../overview/journals/JournalIcon";
+import { Icon } from "../../common/Icon";
+import { IconStyle } from "../../common/IconStyle";
+import { knownQueryParams } from "../../common/actions/searchParamHooks";
+
+export const RelatedItemsAction: React.FC<{
+  entityId: string;
+  entityType: "Journal" | "Entry";
+}> = ({ entityId, entityType }) => {
+  const { data: result, isFetching } = useRelatedEntitiesQuery(
+    entityId,
+    entityType,
+  );
+
+  if (!result) {
+    return isFetching ? (
+      <Typography>Looking for related items...</Typography>
+    ) : null;
+  }
+
+  if (!result.entities?.length) {
+    return <Typography>No related items found.</Typography>;
+  }
+
+  return (
+    <div>
+      {result.entities.map((searchResultEntity) => {
+        if (searchResultEntity.entityType === "Journal") {
+          const journal = searchResultEntity.entity as IJournal;
+          return (
+            <GoToItemRow
+              key={journal.id}
+              url={`/journals/details/${journal.id}`}
+              hasFocus={false}
+              icon={
+                <JournalIcon journal={journal} iconStyle={IconStyle.Small} />
+              }
+            >
+              {journal.name}
+            </GoToItemRow>
+          );
+        }
+
+        const entry = searchResultEntity.entity as IScrapEntry;
+        const parentJournal = result.journals.find(
+          (j) => j.id === entry.parentId,
+        );
+
+        return (
+          <GoToItemRow
+            key={entry.id}
+            url={`/journals/details/${entry.parentId}?${knownQueryParams.selectedItemId}=${entry.id}`}
+            hasFocus={false}
+            icon={
+              <Icon style={IconStyle.Small}>
+                {entry.scrapType === "List" ? <Check /> : <Notes />}
+              </Icon>
+            }
+          >
+            <span style={{ display: "flex", alignItems: "center" }}>
+              {entry.title || getNotesExcerpt(entry.notes) || entry.id}
+              <span
+                style={{
+                  fontSize: "smaller",
+                  color: "initial",
+                  paddingLeft: "10px",
+                }}
+              >
+                {parentJournal?.name}
+              </span>
+            </span>
+          </GoToItemRow>
+        );
+      })}
+    </div>
+  );
+};
+
+// log book entries have no title, so we show the beginning of their notes instead
+function getNotesExcerpt(notes: string | undefined): string | undefined {
+  if (!notes) {
+    return undefined;
+  }
+
+  const firstLine = notes.split("\n")[0];
+  return firstLine.length > 60 ? firstLine.substring(0, 60) + "..." : firstLine;
+}

--- a/app/src/components/details/scraps/ScrapBody.tsx
+++ b/app/src/components/details/scraps/ScrapBody.tsx
@@ -97,6 +97,10 @@ export const ScrapBody: React.FC<{
 
     if (scrapToRender.id) {
       allActions.push(ActionFactory.deleteEntry(scrapToRender, hasFocus));
+
+      if (!isEditMode) {
+        allActions.push(ActionFactory.showRelatedItems(scrapToRender.id));
+      }
     }
 
     return allActions;

--- a/app/src/components/overview/getCommonJournalActions.tsx
+++ b/app/src/components/overview/getCommonJournalActions.tsx
@@ -26,6 +26,7 @@ export function getCommonJournalActions(
   actions.push(
     ActionFactory.editJournal(journal.id ?? "", enableHotkeys),
     ActionFactory.deleteJournal(journal.id ?? "", enableHotkeys),
+    ActionFactory.showRelatedItems(journal.id ?? ""),
   );
 
   return actions;

--- a/app/src/components/overview/goto/GoToSimple.tsx
+++ b/app/src/components/overview/goto/GoToSimple.tsx
@@ -1,21 +1,13 @@
 import { IEntity } from "../../../serverApi/IEntity";
 import { IJournal } from "../../../serverApi/IJournal";
 import { OverviewList } from "../overviewList/OverviewList";
-import { GoToItemRow } from "./GoToItemRow";
+import { GoToItemRow } from "../../common/itemRows/GoToItemRow";
+import { JournalGoToItemRow } from "../../common/itemRows/JournalGoToItemRow";
+import { ScrapEntryGoToItemRow } from "../../common/itemRows/ScrapEntryGoToItemRow";
 import { IScrapEntry } from "../../../serverApi/IScrapEntry";
 import { knownQueryParams } from "../../common/actions/searchParamHooks";
-import { JournalIcon } from "../journals/JournalIcon";
-import { IconStyle } from "../../common/IconStyle";
-import { Icon } from "../../common/Icon";
-import Check from "@mui/icons-material/Check";
-import Notes from "@mui/icons-material/Notes";
 import SearchOutlined from "@mui/icons-material/SearchOutlined";
 import { useGoToNavigationItems } from "./useGoToNavigationItems";
-import { ActionFactory } from "../../common/actions/ActionFactory";
-import { ActionIconButton } from "../../common/actions/ActionIconButton";
-import { DeviceWidth, useDeviceWidth } from "../../common/useDeviceWidth";
-import { isTypeThatCanShowAddEntryRow } from "../../../util/journalUtils";
-import { JournalType } from "../../../serverApi/JournalType";
 import { useEffect } from "react";
 
 const emptyListItemId = "empty-list-item-id";
@@ -81,82 +73,20 @@ export const GoToSimple: React.FC<{
         <JournalGoToItemRow
           journal={entity as IJournal}
           hasFocus={hasFocus}
-          onClick={onClick ?? (() => {})}
+          onClick={onClick}
         />
       );
     }
 
     return (
       <ScrapEntryGoToItemRow
-        journal={
-          goto.journalsForEntries.find(
-            (j) => j.id === (entity as IScrapEntry).parentId,
-          )!
-        }
+        journal={goto.journalsForEntries.find(
+          (j) => j.id === (entity as IScrapEntry).parentId,
+        )}
         scrapEntry={entity as IScrapEntry}
         hasFocus={hasFocus}
-        onClick={onClick ?? (() => {})}
+        onClick={onClick}
       />
     );
   }
-};
-
-const ScrapEntryGoToItemRow: React.FC<{
-  scrapEntry: IScrapEntry;
-  journal: IJournal;
-  hasFocus: boolean;
-  onClick: () => void;
-}> = ({ scrapEntry, journal, hasFocus, onClick }) => {
-  return (
-    <GoToItemRow
-      icon={
-        <Icon style={IconStyle.Small}>
-          {scrapEntry.scrapType === "List" ? <Check /> : <Notes />}
-        </Icon>
-      }
-      url={`/journals/details/${scrapEntry.parentId}?${knownQueryParams.selectedItemId}=${scrapEntry.id}`}
-      hasFocus={hasFocus}
-      onClick={onClick}
-    >
-      <span style={{ display: "flex", alignItems: "center" }}>
-        {`${scrapEntry.title || scrapEntry.id}`}
-        <span
-          style={{ fontSize: "smaller", color: "initial", paddingLeft: "10px" }}
-        >
-          {journal.name}
-        </span>
-      </span>
-    </GoToItemRow>
-  );
-};
-
-const JournalGoToItemRow: React.FC<{
-  journal: IJournal;
-  hasFocus: boolean;
-  onClick: () => void;
-}> = ({ journal, hasFocus, onClick }) => {
-  const deviceWidth = useDeviceWidth();
-
-  return (
-    <GoToItemRow
-      url={`/journals/details/${journal.id}`}
-      onClick={onClick}
-      hasFocus={hasFocus}
-      icon={<JournalIcon journal={journal} iconStyle={IconStyle.Small} />}
-      renderAtEnd={() => {
-        return journal.type !== JournalType.Scraps ? (
-          <ActionIconButton
-            action={
-              deviceWidth === DeviceWidth.Normal &&
-              isTypeThatCanShowAddEntryRow(journal.type)
-                ? ActionFactory.goToJournal(journal.id ?? "", false)
-                : ActionFactory.addEntry(journal, false, () => {}, true)
-            }
-          />
-        ) : null;
-      }}
-    >
-      {`${journal.name}`}
-    </GoToItemRow>
-  );
 };

--- a/app/src/components/overview/journals/JournalSubRoutes.tsx
+++ b/app/src/components/overview/journals/JournalSubRoutes.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../common/actions/searchParamHooks";
 import { NavigationActionContainer } from "../../common/actions/NavigationActionContainer";
 import { JournalType } from "../../../serverApi/JournalType";
+import { RelatedItemsAction } from "../../details/related/RelatedItemsAction";
 
 export const JournalSubRoutes: React.FC<{
   journal: IJournal;
@@ -39,6 +40,16 @@ export const JournalSubRoutes: React.FC<{
       return (
         <NavigationActionContainer>
           <EditScheduleAction journal={journal} />
+        </NavigationActionContainer>
+      );
+
+    case "related":
+      return (
+        <NavigationActionContainer>
+          <RelatedItemsAction
+            entityId={journal.id ?? ""}
+            entityType="Journal"
+          />
         </NavigationActionContainer>
       );
 

--- a/app/src/serverApi/ServerApi.ts
+++ b/app/src/serverApi/ServerApi.ts
@@ -468,6 +468,19 @@ export class ServerApi {
     return await ServerApi.executeRequest(`/search/entities${params}`);
   }
 
+  static async getRelatedEntities(
+    entityId: string,
+    entityType: "Journal" | "Entry",
+  ): Promise<ISearchEntitiesResult> {
+    const urlParams = new URLSearchParams();
+    urlParams.set("entityId", entityId);
+    urlParams.set("entityType", entityType);
+
+    return await ServerApi.executeRequest(
+      `/search/related${toQueryString(urlParams)}`,
+    );
+  }
+
   static async exportData() {
     return await ServerApi.executeRequest(`/user/export-data`, "GET");
   }

--- a/app/src/serverApi/reactQuery/queries/useRelatedEntitiesQuery.ts
+++ b/app/src/serverApi/reactQuery/queries/useRelatedEntitiesQuery.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { queryKeysFactory } from "../queryKeysFactory";
+import { ServerApi } from "../../ServerApi";
+import { ISearchEntitiesResult } from "../../ISearchEntitiesResult";
+
+export const useRelatedEntitiesQuery = (
+  entityId: string,
+  entityType: "Journal" | "Entry",
+) => {
+  const { data: result, isFetching } = useQuery<ISearchEntitiesResult>({
+    queryKey: queryKeysFactory.relatedEntities(entityId, entityType),
+    queryFn: () => ServerApi.getRelatedEntities(entityId, entityType),
+  });
+
+  return { data: result, isFetching };
+};

--- a/app/src/serverApi/reactQuery/queryKeysFactory.ts
+++ b/app/src/serverApi/reactQuery/queryKeysFactory.ts
@@ -76,6 +76,10 @@ export const queryKeysFactory = {
     return [journals, "entries", searchText ?? "", journalTypes?.join() ?? ""];
   },
 
+  relatedEntities(entityId: string, entityType: "Journal" | "Entry") {
+    return ["search", "related", entityType, entityId];
+  },
+
   entities(
     searchText = "",
     scheduledOnly = false,


### PR DESCRIPTION
Closes #2940

## What

Adds a "Show related items" action (hub icon) to journals and to scrap/log-book entries. Clicking it expands the usual action panel showing up to 10 related journals and entries, rendered like the go-to page rows; clicking an item navigates to the journal resp. the entry (via `?selected-item=`).

## How relatedness works

The design goal is **navigation**: surface items you can *not* already reach from the current page. Therefore the source item's own journal and all of its entries are excluded - and relatedness is purely cross-journal text matching:

1. The source item's title (journal name / scrap title / log-book notes) is tokenized: lowercased, stop words (en/de) and words shorter than 3 chars dropped, max 10 words.
2. A single match-any query fetches candidates: journals of all types, but only entries of type `Scraps` and `LogBook` - other entry types have no page of their own, so they are no navigation targets.
3. Candidates are ranked in memory: a word matching in title/name counts 3, in notes/description 1; ties are broken by `EditedOn` descending.

MongoDB `$text`/Atlas Search is not available on the Cosmos DB Mongo API, hence the regex-based candidate query + in-memory ranking.

## Changes

**Backend**

- `GetFreeTextFilters` supports a new `matchAnyWord` mode: per-word filters are OR-ed instead of AND-ed and match whole words. The word-boundary pattern lives in a shared `WholeWordRegex` helper using explicit Unicode classes instead of `\b` (mongo's PCRE2 treats `\b` as ASCII-only, which silently broke matching for words with leading/trailing umlauts); the in-memory scoring uses the same helper so DB and ranking semantics cannot drift apart. Regular search is unchanged (default `false`), exposed as optional parameter on `GetAllJournals`/`SearchEntries`.
- New `GetRelatedEntitiesQuery`/`GetRelatedEntitiesQueryExecutor` (permission-gated like `GetEntryQueryExecutor`, reuses the `SearchEntitiesResult` shape, cached via the regular query cache).
- New endpoint `GET api/search/related?entityId=&entityType=`.

**Frontend**

- `ActionFactory.showRelatedItems` (hub icon), attached as last action to journals (`getCommonJournalActions`) and to saved scrap/log-book entries in view mode (`ScrapBody`).
- New `"related"` action key expands `RelatedItemsAction` via `EntrySubRoutes`/`JournalSubRoutes`; log-book entries (no title) show a notes excerpt.
- The go-to page's row components (`GoToItemRow`, `JournalGoToItemRow`, `ScrapEntryGoToItemRow`) moved to `common/itemRows` and are shared between the go-to page and the related-items panel.
- `useRelatedEntitiesQuery` + `ServerApi.getRelatedEntities`.

## Tests

- 7 executor tests: cross-journal matching, own-journal exclusion, ranking, stop words, non-navigable entry types, missing source, missing id.
- 2 repository tests pinning the match-any semantics (OR + whole-word); existing tests pin that regular search is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
