### PR TITLE
Sort scrap journal entries by edited date instead of entry date

### DIFF
--- a/api/Engraved.Core.Tests/Source/Application/DispatcherShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/DispatcherShould.cs
@@ -250,7 +250,8 @@ public class FakeUserRestrictedRepository(Lazy<IUser> currentUser) : IUserRestri
     DateTime? fromDate,
     DateTime? toDate,
     IDictionary<string, string[]>? attributeValues,
-    string? searchText
+    string? searchText,
+    SortEntriesBy sortOrder
   )
   {
     throw new NotImplementedException();

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Entries/GetAllJournal/GetAllJournalEntriesQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Entries/GetAllJournal/GetAllJournalEntriesQueryExecutorShould.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Threading.Tasks;
+using Engraved.Core.Application.Persistence;
+using Engraved.Core.Domain.Entries;
+using Engraved.Core.Domain.Journals;
+using Engraved.TestUtils;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Engraved.Core.Application.Queries.Entries.GetAllJournal;
+
+public class GetAllJournalEntriesQueryExecutorShould
+{
+  private TestMongoRepository _repo = null!;
+
+  [SetUp]
+  public async Task SetUp()
+  {
+    _repo = await Util.CreateMongoRepository();
+  }
+
+  [Test]
+  public async Task Sort_ScrapsJournal_By_EditedOn_Descending()
+  {
+    UpsertResult scrapsJournal = await _repo.UpsertJournal(new ScrapsJournal { Name = "My Scrap" });
+
+    string olderButRecentlyEditedId = await AddScrap(
+      scrapsJournal.EntityId,
+      dateTime: DateTime.Now.AddDays(-10),
+      editedOn: DateTime.Now
+    );
+    string newerButEditedLongAgoId = await AddScrap(
+      scrapsJournal.EntityId,
+      dateTime: DateTime.Now,
+      editedOn: DateTime.Now.AddDays(-10)
+    );
+
+    IEntry[] entries = await new GetAllJournalEntriesQueryExecutor(_repo, _repo).Execute(
+      new GetAllJournalEntriesQuery { JournalId = scrapsJournal.EntityId }
+    );
+
+    entries.Length.Should().Be(2);
+    entries[0].Id.Should().Be(olderButRecentlyEditedId);
+    entries[1].Id.Should().Be(newerButEditedLongAgoId);
+  }
+
+  [Test]
+  public async Task Sort_NonScrapsJournal_By_DateTime_Descending()
+  {
+    UpsertResult counterJournal = await _repo.UpsertJournal(new CounterJournal { Name = "My Counter" });
+
+    string olderButRecentlyEditedId = await AddCounterEntry(
+      counterJournal.EntityId,
+      dateTime: DateTime.Now.AddDays(-10),
+      editedOn: DateTime.Now
+    );
+    string newerButEditedLongAgoId = await AddCounterEntry(
+      counterJournal.EntityId,
+      dateTime: DateTime.Now,
+      editedOn: DateTime.Now.AddDays(-10)
+    );
+
+    IEntry[] entries = await new GetAllJournalEntriesQueryExecutor(_repo, _repo).Execute(
+      new GetAllJournalEntriesQuery { JournalId = counterJournal.EntityId }
+    );
+
+    entries.Length.Should().Be(2);
+    entries[0].Id.Should().Be(newerButEditedLongAgoId);
+    entries[1].Id.Should().Be(olderButRecentlyEditedId);
+  }
+
+  private async Task<string> AddScrap(string journalId, DateTime dateTime, DateTime editedOn)
+  {
+    var entry = new ScrapsEntry
+    {
+      ParentId = journalId,
+      ScrapType = ScrapType.Markdown,
+      Title = "Scrap",
+      DateTime = dateTime,
+      EditedOn = editedOn
+    };
+
+    UpsertResult result = await _repo.UpsertEntry(entry);
+
+    return result.EntityId;
+  }
+
+  private async Task<string> AddCounterEntry(string journalId, DateTime dateTime, DateTime editedOn)
+  {
+    var entry = new CounterEntry
+    {
+      ParentId = journalId,
+      DateTime = dateTime,
+      EditedOn = editedOn
+    };
+
+    UpsertResult result = await _repo.UpsertEntry(entry);
+
+    return result.EntityId;
+  }
+}

--- a/api/Engraved.Core/Source/Application/Persistence/IEntryRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IEntryRepository.cs
@@ -11,7 +11,7 @@ public interface IEntryRepository
     DateTime? toDate = null,
     IDictionary<string, string[]>? attributeValues = null,
     string? searchText = null,
-    SortEntriesBy sortOrder = SortEntriesBy.ByDateTime
+    SortEntriesBy sortOrder = SortEntriesBy.DateTime
   );
 
   Task<IEntry[]> SearchEntries(

--- a/api/Engraved.Core/Source/Application/Persistence/IEntryRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IEntryRepository.cs
@@ -10,7 +10,8 @@ public interface IEntryRepository
     DateTime? fromDate = null,
     DateTime? toDate = null,
     IDictionary<string, string[]>? attributeValues = null,
-    string? searchText = null
+    string? searchText = null,
+    SortEntriesBy sortOrder = SortEntriesBy.ByDateTime
   );
 
   Task<IEntry[]> SearchEntries(

--- a/api/Engraved.Core/Source/Application/Persistence/SortEntriesBy.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/SortEntriesBy.cs
@@ -2,6 +2,6 @@ namespace Engraved.Core.Application.Persistence;
 
 public enum SortEntriesBy
 {
-  ByDateTime,
-  ByEditedOn
+  DateTime,
+  EditedOn
 }

--- a/api/Engraved.Core/Source/Application/Persistence/SortEntriesBy.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/SortEntriesBy.cs
@@ -1,0 +1,7 @@
+namespace Engraved.Core.Application.Persistence;
+
+public enum SortEntriesBy
+{
+  ByDateTime,
+  ByEditedOn
+}

--- a/api/Engraved.Core/Source/Application/Queries/Entries/GetAllJournal/GetAllJournalEntriesQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Entries/GetAllJournal/GetAllJournalEntriesQueryExecutor.cs
@@ -36,8 +36,8 @@ public class GetAllJournalEntriesQueryExecutor(
     // should surface first. Other journal types show a value/measurement history, where the
     // entry's own DateTime (not when it was last edited) is what matters for ordering.
     SortEntriesBy sortOrder = journal.Type == JournalType.Scraps
-      ? SortEntriesBy.ByEditedOn
-      : SortEntriesBy.ByDateTime;
+      ? SortEntriesBy.EditedOn
+      : SortEntriesBy.DateTime;
 
     return await entryRepository.GetEntriesForJournal(
       query.JournalId,

--- a/api/Engraved.Core/Source/Application/Queries/Entries/GetAllJournal/GetAllJournalEntriesQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Entries/GetAllJournal/GetAllJournalEntriesQueryExecutor.cs
@@ -32,12 +32,20 @@ public class GetAllJournalEntriesQueryExecutor(
       );
     }
 
+    // Scraps are notes that get revisited and edited over time, so the most recently edited one
+    // should surface first. Other journal types show a value/measurement history, where the
+    // entry's own DateTime (not when it was last edited) is what matters for ordering.
+    SortEntriesBy sortOrder = journal.Type == JournalType.Scraps
+      ? SortEntriesBy.ByEditedOn
+      : SortEntriesBy.ByDateTime;
+
     return await entryRepository.GetEntriesForJournal(
       query.JournalId,
       query.FromDate,
       query.ToDate,
       query.AttributeValues,
-      query.SearchText
+      query.SearchText,
+      sortOrder
     );
   }
 }

--- a/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_GetEntriesForJournal_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_GetEntriesForJournal_Should.cs
@@ -243,7 +243,7 @@ public class MongoRepositoryBase_GetEntriesForJournal_Should
 
     IEntry[] entries = await _repository.GetEntriesForJournal(
       scrapsJournal.EntityId,
-      sortOrder: SortEntriesBy.ByEditedOn
+      sortOrder: SortEntriesBy.EditedOn
     );
 
     entries.Length.Should().Be(2);

--- a/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_GetEntriesForJournal_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/MongoRepositoryBase_GetEntriesForJournal_Should.cs
@@ -202,6 +202,71 @@ public class MongoRepositoryBase_GetEntriesForJournal_Should
     entries.Length.Should().Be(1);
   }
 
+  [Test]
+  public async Task Sort_By_DateTime_Descending_When_No_SortOrder_Is_Specified()
+  {
+    UpsertResult scrapsJournal = await _repository.UpsertJournal(new ScrapsJournal { Name = "My Scrap" });
+
+    string olderButRecentlyEditedId = await AddScrap(
+      scrapsJournal.EntityId,
+      dateTime: DateTime.Now.AddDays(-10),
+      editedOn: DateTime.Now
+    );
+    string newerButEditedLongAgoId = await AddScrap(
+      scrapsJournal.EntityId,
+      dateTime: DateTime.Now,
+      editedOn: DateTime.Now.AddDays(-10)
+    );
+
+    IEntry[] entries = await _repository.GetEntriesForJournal(scrapsJournal.EntityId);
+
+    entries.Length.Should().Be(2);
+    entries[0].Id.Should().Be(newerButEditedLongAgoId);
+    entries[1].Id.Should().Be(olderButRecentlyEditedId);
+  }
+
+  [Test]
+  public async Task Sort_By_EditedOn_Descending_When_SortOrder_ByEditedOn_Is_Specified()
+  {
+    UpsertResult scrapsJournal = await _repository.UpsertJournal(new ScrapsJournal { Name = "My Scrap" });
+
+    string olderButRecentlyEditedId = await AddScrap(
+      scrapsJournal.EntityId,
+      dateTime: DateTime.Now.AddDays(-10),
+      editedOn: DateTime.Now
+    );
+    string newerButEditedLongAgoId = await AddScrap(
+      scrapsJournal.EntityId,
+      dateTime: DateTime.Now,
+      editedOn: DateTime.Now.AddDays(-10)
+    );
+
+    IEntry[] entries = await _repository.GetEntriesForJournal(
+      scrapsJournal.EntityId,
+      sortOrder: SortEntriesBy.ByEditedOn
+    );
+
+    entries.Length.Should().Be(2);
+    entries[0].Id.Should().Be(olderButRecentlyEditedId);
+    entries[1].Id.Should().Be(newerButEditedLongAgoId);
+  }
+
+  private async Task<string> AddScrap(string journalId, DateTime dateTime, DateTime editedOn)
+  {
+    var entry = new ScrapsEntry
+    {
+      ParentId = journalId,
+      ScrapType = ScrapType.Markdown,
+      Title = "Scrap",
+      DateTime = dateTime,
+      EditedOn = editedOn
+    };
+
+    UpsertResult result = await _repository.UpsertEntry(entry);
+
+    return result.EntityId;
+  }
+
   private async Task<string> AddEntry(DateTime? date, Dictionary<string, string[]>? attributeValues = null)
   {
     var entry = new CounterEntry

--- a/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
+++ b/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
@@ -169,7 +169,7 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
     DateTime? toDate = null,
     IDictionary<string, string[]>? attributeValues = null,
     string? searchText = null,
-    SortEntriesBy sortOrder = SortEntriesBy.ByDateTime
+    SortEntriesBy sortOrder = SortEntriesBy.DateTime
   )
   {
     IJournal? journal = await GetJournal(journalId);
@@ -214,7 +214,7 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
       );
     }
 
-    SortDefinition<EntryDocument> sort = sortOrder == SortEntriesBy.ByEditedOn
+    SortDefinition<EntryDocument> sort = sortOrder == SortEntriesBy.EditedOn
       ? Builders<EntryDocument>.Sort.Descending(d => d.EditedOn)
       : Builders<EntryDocument>.Sort.Descending(d => d.DateTime);
 

--- a/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
+++ b/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
@@ -168,7 +168,8 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
     DateTime? fromDate = null,
     DateTime? toDate = null,
     IDictionary<string, string[]>? attributeValues = null,
-    string? searchText = null
+    string? searchText = null,
+    SortEntriesBy sortOrder = SortEntriesBy.ByDateTime
   )
   {
     IJournal? journal = await GetJournal(journalId);
@@ -213,9 +214,13 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
       );
     }
 
+    SortDefinition<EntryDocument> sort = sortOrder == SortEntriesBy.ByEditedOn
+      ? Builders<EntryDocument>.Sort.Descending(d => d.EditedOn)
+      : Builders<EntryDocument>.Sort.Descending(d => d.DateTime);
+
     var entries = await EntriesCollection
       .Find(Builders<EntryDocument>.Filter.And(filters))
-      .Sort(Builders<EntryDocument>.Sort.Descending(d => d.DateTime))
+      .Sort(sort)
       .ToListAsync();
 
     return entries


### PR DESCRIPTION
## Summary
- Scraps are notes that get revisited and edited over time, so opening a scrap journal now sorts entries by `EditedOn` descending instead of `DateTime` descending.
- Other journal types (Counter, Gauge, Timer, LogBook) are unaffected — they still sort by the entry's own `DateTime`, since that's what matters for a value/measurement history.
- The sort-order decision is made in `GetAllJournalEntriesQueryExecutor` (Engraved.Core), based on `journal.Type`, and passed down to the repository via a new `SortEntriesBy` enum on `IEntryRepository.GetEntriesForJournal`. The Mongo repository itself stays agnostic of journal types — it just applies whichever sort it's given (defaulting to the old `ByDateTime` behavior for every other caller).

## Test plan
- [x] `dotnet build` succeeds for the whole solution
- [x] `dotnet test` passes across `Engraved.Core.Tests`, `Engraved.Persistence.Mongo.Tests`, and `Engraved.Api.Tests` (245 tests)
- [x] Added `GetAllJournalEntriesQueryExecutorShould` covering: Scraps journal sorts by `EditedOn` desc; Counter journal sorts by `DateTime` desc
- [x] Added repository-level tests covering the default (`ByDateTime`) and explicit `ByEditedOn` sort orders

🤖 Generated with [Claude Code](https://claude.com/claude-code)