### PR TITLE
Split the monolithic Mongo repository into per-aggregate repositories with injected read scopes

### DIFF
--- a/api/Engraved.Persistence.Mongo/Source/FreeTextFilters.cs
+++ b/api/Engraved.Persistence.Mongo/Source/FreeTextFilters.cs
@@ -1,0 +1,55 @@
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+using Engraved.Core.Application.Search;
+using Engraved.Persistence.Mongo.DocumentTypes;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Engraved.Persistence.Mongo;
+
+public static class FreeTextFilters
+{
+  // matchAnyWord = false: every word must match somewhere (one AND-ed filter per word,
+  // substring semantics) - this is the regular search behavior.
+  // matchAnyWord = true: a single filter matching documents that contain ANY of the words,
+  // as whole words (via WholeWordRegex) - used to collect candidates for "related items",
+  // where requiring all words would be far too strict and substring matches are mostly noise.
+  public static List<FilterDefinition<T>> Build<T>(
+    string? searchText,
+    bool matchAnyWord,
+    params Expression<Func<T, object>>[] fieldNameExpressions
+  ) where T : IDocument
+  {
+    if (string.IsNullOrEmpty(searchText))
+    {
+      return [];
+    }
+
+    List<FilterDefinition<T>> perWordFilters = searchText.Split(" ")
+      .Select(segment =>
+        {
+          // Escape the user input so it is matched literally. Passing it to the
+          // regex engine unescaped allowed malformed patterns (exceptions) and
+          // catastrophic-backtracking patterns (ReDoS) to be injected via search.
+          var pattern = matchAnyWord
+            ? WholeWordRegex.BuildPattern(segment)
+            : Regex.Escape(segment);
+
+          return Builders<T>.Filter.Or(
+            fieldNameExpressions.Select(exp => Builders<T>.Filter.Regex(
+                exp,
+                new BsonRegularExpression(
+                  new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Multiline)
+                )
+              )
+            )
+          );
+        }
+      )
+      .ToList();
+
+    return matchAnyWord
+      ? [Builders<T>.Filter.Or(perWordFilters)]
+      : perWordFilters;
+  }
+}

--- a/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
+++ b/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
@@ -1,38 +1,41 @@
-using System.Linq.Expressions;
-using System.Text.RegularExpressions;
-using Engraved.Core.Application.Permissions;
 using Engraved.Core.Application.Persistence;
-using Engraved.Core.Application.Search;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Permissions;
 using Engraved.Core.Domain.Users;
-using Engraved.Persistence.Mongo.DocumentTypes;
 using Engraved.Persistence.Mongo.DocumentTypes.Entries;
 using Engraved.Persistence.Mongo.DocumentTypes.Journals;
 using Engraved.Persistence.Mongo.DocumentTypes.Users;
 using Engraved.Persistence.Mongo.Repositories;
 using Engraved.Persistence.Mongo.Scoping;
-using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace Engraved.Persistence.Mongo;
 
-// Shared MongoDB data access for the journal/entry roles. The read scope (what the caller may see)
-// is injected via IReadScope rather than baked in by inheritance:
-//  - UnrestrictedMongoRepository:  UnrestrictedReadScope plus the maintenance operations
-//  - UserRestrictedMongoRepository: UserReadScope plus the write guards
-// The user role is delegated to MongoUserRepository - the first aggregate extracted into its own
-// class; journals and entries are next.
-public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClient, IReadScope readScope)
-  : IUserRepository, IJournalRepository, IEntryRepository
+// Delegating facade over the per-aggregate repositories (MongoUserRepository,
+// MongoJournalRepository, MongoEntryRepository), which do the actual data access shaped by the
+// injected IReadScope. Only composition and the write-guard override points (the virtual methods
+// UserRestrictedMongoRepository hooks into) live here; the plan is to dissolve this class entirely
+// once the guards become decorators.
+public abstract class MongoRepositoryBase : IUserRepository, IJournalRepository, IEntryRepository
 {
-  private readonly MongoUserRepository _userRepository = new(mongoDatabaseClient);
+  private readonly MongoDatabaseClient _mongoDatabaseClient;
+  private readonly MongoUserRepository _userRepository;
+  private readonly MongoJournalRepository _journalRepository;
+  private readonly MongoEntryRepository _entryRepository;
+
+  protected MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClient, IReadScope readScope)
+  {
+    _mongoDatabaseClient = mongoDatabaseClient;
+    _userRepository = new MongoUserRepository(mongoDatabaseClient);
+    _journalRepository = new MongoJournalRepository(mongoDatabaseClient, readScope);
+    _entryRepository = new MongoEntryRepository(mongoDatabaseClient, _journalRepository);
+  }
 
   // protected so they can be accessed from derived repositories (and the test repositories)
-  protected IMongoCollection<EntryDocument> EntriesCollection => mongoDatabaseClient.EntriesCollection;
-  protected IMongoCollection<JournalDocument> JournalsCollection => mongoDatabaseClient.JournalsCollection;
-  protected IMongoCollection<UserDocument> UsersCollection => mongoDatabaseClient.UsersCollection;
+  protected IMongoCollection<EntryDocument> EntriesCollection => _mongoDatabaseClient.EntriesCollection;
+  protected IMongoCollection<JournalDocument> JournalsCollection => _mongoDatabaseClient.JournalsCollection;
+  protected IMongoCollection<UserDocument> UsersCollection => _mongoDatabaseClient.UsersCollection;
 
   public Task<IUser?> GetUser(string? nameOrId)
   {
@@ -54,7 +57,7 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
     return _userRepository.GetAllUsers();
   }
 
-  public async Task<IJournal[]> GetAllJournals(
+  public Task<IJournal[]> GetAllJournals(
     string? searchText = null,
     ScheduleMode? scheduleMode = null,
     JournalType[]? journalTypes = null,
@@ -64,86 +67,45 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
     bool matchAnyWord = false
   )
   {
-    var filters = new List<FilterDefinition<JournalDocument>>();
-
-    filters.Add(readScope.GetFilter<JournalDocument>(PermissionKind.Read));
-
-    if (journalTypes is { Length: > 0 })
-    {
-      filters.Add(
-        Builders<JournalDocument>.Filter.Or(
-          journalTypes.Select(t => Builders<JournalDocument>.Filter.Where(GetIsJournalTypeExpression(t)))
-        )
-      );
-    }
-
-    if (journalIds is { Length: > 0 })
-    {
-      var objectIds = journalIds
-        .Select(i => ObjectId.TryParse(i, out var id) ? (ObjectId?) id : null)
-        .Where(id => id.HasValue)
-        .Select(id => id!.Value)
-        .ToList();
-
-      if (objectIds.Any())
-      {
-        filters.Add(Builders<JournalDocument>.Filter.In(d => d.Id, objectIds));
-      }
-      else
-      {
-        // if IDs were provided but none were valid ObjectIds, we should return nothing
-        filters.Add(Builders<JournalDocument>.Filter.Where(d => false));
-      }
-    }
-
-    if (scheduleMode == ScheduleMode.AnySchedule)
-    {
-      filters.Add(
-        Builders<JournalDocument>.Filter.Exists(d => d.Schedules)
-      );
-    }
-    if (scheduleMode == ScheduleMode.CurrentUserOnly)
-    {
-      if (string.IsNullOrEmpty(currentUserId))
-      {
-        throw new ArgumentException("Current user id is required", nameof(currentUserId));
-      }
-
-      // "scheduled" means a schedule with a pending occurrence: a fired schedule keeps its sub-document
-      // (with NextOccurrence nulled out), so we must check NextOccurrence rather than mere existence.
-      filters.Add(Builders<JournalDocument>.Filter.And(
-        Builders<JournalDocument>.Filter.Exists($"Schedules.{currentUserId}"),
-        Builders<JournalDocument>.Filter.Ne($"Schedules.{currentUserId}.NextOccurrence", BsonNull.Value)
-      ));
-    }
-
-    if (!string.IsNullOrEmpty(searchText))
-    {
-      filters.AddRange(
-        GetFreeTextFilters<JournalDocument>(
-          searchText,
-          matchAnyWord,
-          d => d.Name!,
-          d => d.Description!
-        )
-      );
-    }
-
-    var journals = await JournalsCollection
-      .Find(filters.Count > 0 ? Builders<JournalDocument>.Filter.And(filters) : Builders<JournalDocument>.Filter.Empty)
-      .Sort(Builders<JournalDocument>.Sort.Descending(d => d.EditedOn).Descending(d => d.Id))
-      .Limit(limit)
-      .ToListAsync();
-
-    return journals.Select(j => JournalDocumentMapper.FromDocument(j)!).ToArray();
+    return _journalRepository.GetAllJournals(
+      searchText,
+      scheduleMode,
+      journalTypes,
+      journalIds,
+      limit,
+      currentUserId,
+      matchAnyWord
+    );
   }
 
-  public async Task<IJournal?> GetJournal(string journalId)
+  public Task<IJournal?> GetJournal(string journalId)
   {
-    return await GetJournal(journalId, PermissionKind.Read);
+    return _journalRepository.GetJournal(journalId);
   }
 
-  public async Task<IEntry[]> GetEntriesForJournal(
+  public virtual Task<UpsertResult> UpsertJournal(IJournal journal)
+  {
+    return _journalRepository.UpsertJournal(journal);
+  }
+
+  public virtual Task DeleteJournal(string journalId)
+  {
+    return _journalRepository.DeleteJournal(journalId);
+  }
+
+  public Task ModifyJournalPermissions(string journalId, Dictionary<string, PermissionKind> permissions)
+  {
+    return _journalRepository.ModifyJournalPermissions(journalId, permissions);
+  }
+
+  // Explicitly unscoped read: loads the journal regardless of the caller's read permissions, so the
+  // write guards can apply the permission rule in memory.
+  protected Task<IJournal?> GetJournalUnscoped(string journalId)
+  {
+    return _journalRepository.GetJournalUnscoped(journalId);
+  }
+
+  public Task<IEntry[]> GetEntriesForJournal(
     string journalId,
     DateTime? fromDate = null,
     DateTime? toDate = null,
@@ -152,68 +114,10 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
     SortEntriesBy sortOrder = SortEntriesBy.DateTime
   )
   {
-    IJournal? journal = await GetJournal(journalId);
-    if (journal == null)
-    {
-      return [];
-    }
-
-    var filters = new List<FilterDefinition<EntryDocument>>
-    {
-      Builders<EntryDocument>.Filter.Where(d => d.ParentId == journalId)
-    };
-
-    if (!string.IsNullOrEmpty(searchText))
-    {
-      filters.AddRange(
-        GetFreeTextFilters<EntryDocument>(
-          searchText,
-          false,
-          d => d.Notes!,
-          d => ((ScrapsEntryDocument) d).Title!
-        )
-      );
-    }
-
-    if (fromDate.HasValue)
-    {
-      filters.Add(Builders<EntryDocument>.Filter.Where(d => d.DateTime >= fromDate.Value));
-    }
-
-    if (toDate.HasValue)
-    {
-      filters.Add(Builders<EntryDocument>.Filter.Where(d => d.DateTime < toDate.Value.AddDays(1)));
-    }
-
-    if (attributeValues != null)
-    {
-      filters.AddRange(
-        attributeValues.Select(attributeValue =>
-          Builders<EntryDocument>.Filter.In($"JournalAttributeValues.{attributeValue.Key}", attributeValue.Value)
-        )
-      );
-    }
-
-    SortDefinition<EntryDocument> sort = sortOrder == SortEntriesBy.EditedOn
-      ? Builders<EntryDocument>.Sort.Descending(d => d.EditedOn)
-      : Builders<EntryDocument>.Sort.Descending(d => d.DateTime);
-
-    var entries = await EntriesCollection
-      .Find(Builders<EntryDocument>.Filter.And(filters))
-      .Sort(sort)
-      .ToListAsync();
-
-    return entries
-      .Select(EntryDocumentMapper.FromDocument)
-      .ToArray();
+    return _entryRepository.GetEntriesForJournal(journalId, fromDate, toDate, attributeValues, searchText, sortOrder);
   }
 
-  // Unscoped primitive: this method does NOT enforce journal read-permission. It trusts the
-  // journalIds supplied by the caller. The only scoped caller, SearchEntriesQueryExecutor, first
-  // resolves the current user's accessible journals (via the scoped GetAllJournals) and passes
-  // those ids in, so read access is enforced there. Pinned by
-  // UserRestrictedMongoRepository_Permissions_Should.SearchEntries_IsUnscoped_TrustsCallerProvidedJournalIds.
-  public async Task<IEntry[]> SearchEntries(
+  public Task<IEntry[]> SearchEntries(
     string? searchText,
     ScheduleMode? scheduleMode = null,
     JournalType[]? journalTypes = null,
@@ -224,354 +128,31 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
     bool matchAnyWord = false
   )
   {
-    var filters = new List<FilterDefinition<EntryDocument>>();
-
-    if (!string.IsNullOrEmpty(searchText))
-    {
-      filters.AddRange(
-        GetFreeTextFilters<EntryDocument>(
-          searchText,
-          matchAnyWord,
-          onlyConsiderTitle
-            ? [d => ((ScrapsEntryDocument) d).Title!]
-            : [d => ((ScrapsEntryDocument) d).Title!, d => d.Notes!]
-        )
-      );
-    }
-
-    if (journalIds is { Length: > 0 })
-    {
-      filters.Add(Builders<EntryDocument>.Filter.In(d => d.ParentId, journalIds));
-    }
-
-    if (journalTypes is { Length: > 0 })
-    {
-      filters.Add(
-        Builders<EntryDocument>.Filter.Or(
-          journalTypes.Select(t => Builders<EntryDocument>.Filter.Where(GetIsEntryTypeExpression(t)))
-        )
-      );
-    }
-
-    if (scheduleMode == ScheduleMode.AnySchedule)
-    {
-      filters.Add(
-        Builders<EntryDocument>.Filter.Exists(d => d.Schedules)
-      );
-    }
-    else if (scheduleMode == ScheduleMode.CurrentUserOnly)
-    {
-      if (string.IsNullOrEmpty(currentUserId))
-      {
-        throw new ArgumentException("Current user id is required", nameof(currentUserId));
-      }
-
-      filters.Add(GetHasScheduleForCurrentUserFilter(currentUserId));
-    }
-
-    // Ordering is done at the DB level (see defaultSort below, and the CurrentUserFirst branch in
-    // LoadDocuments). We deliberately do NOT re-order scheduled entries to the front here: the entries
-    // tab (ScheduleMode.None) must stay sorted purely by edited date, and the scheduled tab
-    // (CurrentUserOnly) already contains only scheduled entries.
-    return await LoadData(
-      limit,
+    return _entryRepository.SearchEntries(
+      searchText,
       scheduleMode,
-      currentUserId,
-      filters,
-      Builders<EntryDocument>.Sort.Descending(d => d.EditedOn).Descending(d => d.Id)
-    );
-  }
-
-  private async Task<IEntry[]> LoadData(
-    int? limit,
-    ScheduleMode? scheduleMode,
-    string? currentUserId,
-    List<FilterDefinition<EntryDocument>> filters,
-    SortDefinition<EntryDocument> defaultSort
-  )
-  {
-    List<EntryDocument> documents = await LoadDocuments(
+      journalTypes,
+      journalIds,
       limit,
-      scheduleMode,
       currentUserId,
-      filters,
-      defaultSort
-    );
-
-    return documents
-      .Select(EntryDocumentMapper.FromDocument)
-      .ToArray();
-  }
-
-  private async Task<List<EntryDocument>> LoadDocuments(
-    int? limit,
-    ScheduleMode? scheduleMode,
-    string? currentUserId,
-    List<FilterDefinition<EntryDocument>> filters,
-    SortDefinition<EntryDocument> defaultSort
-  )
-  {
-    if (scheduleMode != ScheduleMode.CurrentUserFirst)
-    {
-      return await EntriesCollection
-        .Find(
-          filters.Count > 0
-            ? Builders<EntryDocument>.Filter.And(filters)
-            : Builders<EntryDocument>.Filter.Empty
-        )
-        .Sort(defaultSort)
-        .Limit(limit)
-        .ToListAsync();
-    }
-
-    if (string.IsNullOrEmpty(currentUserId))
-    {
-      throw new ArgumentException(
-        $"\"{nameof(currentUserId)}\" must be specified when using {ScheduleMode.CurrentUserFirst}."
-      );
-    }
-
-    var entries = await EntriesCollection
-      .Find(
-        Builders<EntryDocument>.Filter.And(
-          filters.Union([GetHasScheduleForCurrentUserFilter(currentUserId)])
-        )
-      )
-      .Sort(Builders<EntryDocument>.Sort.Ascending(d => d.Schedules[currentUserId].NextOccurrence))
-      .Limit(limit)
-      .ToListAsync();
-
-    var foundIds = entries.Select(e => e.Id).ToArray();
-
-    entries.AddRange(
-      await EntriesCollection
-        .Find(
-          Builders<EntryDocument>.Filter.And(
-            filters.Concat([Builders<EntryDocument>.Filter.Nin(d => d.Id, foundIds)])
-          )
-        )
-        .Sort(defaultSort)
-        .Limit(limit - entries.Count)
-        .ToListAsync()
-    );
-
-    return entries;
-  }
-
-  public virtual async Task<UpsertResult> UpsertJournal(IJournal journal)
-  {
-    JournalDocument document = JournalDocumentMapper.ToDocument(journal);
-
-    ReplaceOneResult? replaceOneResult = await JournalsCollection.ReplaceOneAsync(
-      MongoUtil.GetDocumentByIdFilter<JournalDocument>(journal.Id),
-      document,
-      new ReplaceOptions { IsUpsert = true }
-    );
-
-    return MongoUtil.CreateUpsertResult(journal.Id, replaceOneResult);
-  }
-
-  public virtual async Task DeleteJournal(string journalId)
-  {
-    IJournal? journal = await GetJournal(journalId);
-    if (journal == null)
-    {
-      return;
-    }
-
-    await EntriesCollection.DeleteManyAsync(
-      Builders<EntryDocument>.Filter.Where(d => d.ParentId == journalId)
-    );
-
-    await JournalsCollection.DeleteOneAsync(
-      MongoUtil.GetDocumentByIdFilter<JournalDocument>(journalId)
+      onlyConsiderTitle,
+      matchAnyWord
     );
   }
 
-  public async Task ModifyJournalPermissions(string journalId, Dictionary<string, PermissionKind> permissions)
-  {
-    IJournal? journal = await GetJournal(journalId);
-    if (journal == null)
-    {
-      // should we throw here?
-      return;
-    }
-
-    // deliberately uses the plain user repository: granting a permission may create the receiving
-    // user's record, which the ownership guard on the public UpsertUser would (rightly) reject
-    var permissionsEnsurer = new PermissionsEnsurer(_userRepository, _userRepository.UpsertUser);
-    await permissionsEnsurer.EnsurePermissions(journal, permissions);
-
-    await UpsertJournal(journal);
-  }
-
-  public virtual async Task<UpsertResult> UpsertEntry<TEntry>(TEntry entry)
+  public virtual Task<UpsertResult> UpsertEntry<TEntry>(TEntry entry)
     where TEntry : IEntry
   {
-    EntryDocument document = EntryDocumentMapper.ToDocument(entry);
-
-    ReplaceOneResult? replaceOneResult = await EntriesCollection.ReplaceOneAsync(
-      MongoUtil.GetDocumentByIdFilter<EntryDocument>(entry.Id),
-      document,
-      new ReplaceOptions { IsUpsert = true }
-    );
-
-    return MongoUtil.CreateUpsertResult(entry.Id, replaceOneResult);
+    return _entryRepository.UpsertEntry(entry);
   }
 
-  public virtual async Task DeleteEntry(string entryId)
+  public virtual Task DeleteEntry(string entryId)
   {
-    await EntriesCollection.DeleteOneAsync(MongoUtil.GetDocumentByIdFilter<EntryDocument>(entryId));
+    return _entryRepository.DeleteEntry(entryId);
   }
 
-  // Unscoped primitive: GetEntry does NOT enforce read-permission on the parent journal (note it is
-  // not overridden in UserRestrictedMongoRepository). The client-facing single-entry read enforces
-  // access in GetEntryQueryExecutor; command executors use it as a load-for-modify primitive and
-  // rely on the subsequent UpsertEntry/DeleteEntry write checks. Pinned by
-  // UserRestrictedMongoRepository_Permissions_Should.GetEntry_IsUnscoped_ReturnsEntry_EvenWithoutJournalPermission.
-  public async Task<IEntry?> GetEntry(string entryId)
+  public Task<IEntry?> GetEntry(string entryId)
   {
-    if (string.IsNullOrEmpty(entryId))
-    {
-      throw new ArgumentNullException(nameof(entryId), "Id must be specified.");
-    }
-
-    EntryDocument? document = await EntriesCollection
-      .Find(MongoUtil.GetDocumentByIdFilter<EntryDocument>(entryId))
-      .FirstOrDefaultAsync();
-
-    return document == null
-      ? null
-      : EntryDocumentMapper.FromDocument(document);
-  }
-
-  // there must be a better solution than this, but it works for the moment... i believe
-  // Builders<JournalDocument>.Filter.Where(t => t.Type == journalType) does not work because
-  // JournalDocument.Type is an ABSTRACT property.
-  private static Expression<Func<JournalDocument, bool>> GetIsJournalTypeExpression(JournalType journalType)
-  {
-    return journalType switch
-    {
-      JournalType.Counter => d => d.GetType() == typeof(CounterJournalDocument),
-      JournalType.Gauge => d => d.GetType() == typeof(GaugeJournalDocument),
-      JournalType.Timer => d => d.GetType() == typeof(TimerJournalDocument),
-      JournalType.Scraps => d => d.GetType() == typeof(ScrapsJournalDocument),
-      JournalType.LogBook => d => d.GetType() == typeof(LogBookJournalDocument),
-      _ => throw new ArgumentOutOfRangeException(
-        nameof(journalType),
-        journalType,
-        $"{nameof(GetIsJournalTypeExpression)} not defined for {journalType}."
-      )
-    };
-  }
-
-  private static Expression<Func<EntryDocument, bool>> GetIsEntryTypeExpression(JournalType journalType)
-  {
-    switch (journalType)
-    {
-      case JournalType.Counter:
-        return d => d.GetType() == typeof(CounterEntryDocument);
-      case JournalType.Gauge:
-        return d => d.GetType() == typeof(GaugeEntryDocument);
-      case JournalType.Timer:
-        return d => d.GetType() == typeof(TimerEntryDocument);
-      case JournalType.Scraps:
-        return d => d.GetType() == typeof(ScrapsEntryDocument);
-      case JournalType.LogBook:
-        return d => d.GetType() == typeof(LogBookEntryDocument);
-      default:
-        throw new ArgumentOutOfRangeException(
-          nameof(journalType),
-          journalType,
-          $"{nameof(GetIsEntryTypeExpression)} not defined for {journalType}."
-        );
-    }
-  }
-
-  // Explicitly unscoped read: loads the journal regardless of the caller's read permissions, so the
-  // caller can apply the permission rule in memory (the write guards) or read the owner of a journal
-  // it is about to update.
-  protected Task<IJournal?> GetJournalUnscoped(string journalId)
-  {
-    return GetJournal(journalId, PermissionKind.None, UnrestrictedReadScope.Instance);
-  }
-
-  private Task<IJournal?> GetJournal(string journalId, PermissionKind permissionKind)
-  {
-    return GetJournal(journalId, permissionKind, readScope);
-  }
-
-  private async Task<IJournal?> GetJournal(string journalId, PermissionKind permissionKind, IReadScope scope)
-  {
-    if (string.IsNullOrEmpty(journalId))
-    {
-      throw new ArgumentNullException(nameof(journalId), "Id must be specified.");
-    }
-
-    JournalDocument? document = await JournalsCollection
-      .Find(
-        Builders<JournalDocument>.Filter.And(
-          MongoUtil.GetDocumentByIdFilter<JournalDocument>(journalId),
-          scope.GetFilter<JournalDocument>(permissionKind)
-        )
-      )
-      .FirstOrDefaultAsync();
-
-    return JournalDocumentMapper.FromDocument(document);
-  }
-
-  private static FilterDefinition<EntryDocument> GetHasScheduleForCurrentUserFilter(string currentUserId)
-  {
-    // "scheduled" means the user has a schedule with a pending occurrence. A schedule sub-document is
-    // kept around after it has fired (with NextOccurrence set to null), so checking mere existence of
-    // the sub-document would wrongly surface already-fired schedules as "scheduled".
-    return Builders<EntryDocument>.Filter.And(
-      Builders<EntryDocument>.Filter.Exists($"Schedules.{currentUserId}"),
-      Builders<EntryDocument>.Filter.Ne($"Schedules.{currentUserId}.NextOccurrence", BsonNull.Value)
-    );
-  }
-
-  // matchAnyWord = false: every word must match somewhere (one AND-ed filter per word,
-  // substring semantics) - this is the regular search behavior.
-  // matchAnyWord = true: a single filter matching documents that contain ANY of the words,
-  // as whole words (via WholeWordRegex) - used to collect candidates for "related items",
-  // where requiring all words would be far too strict and substring matches are mostly noise.
-  private static List<FilterDefinition<T>> GetFreeTextFilters<T>(
-    string? searchText,
-    bool matchAnyWord,
-    params Expression<Func<T, object>>[] fieldNameExpressions
-  ) where T : IDocument
-  {
-    if (string.IsNullOrEmpty(searchText))
-    {
-      return [];
-    }
-
-    List<FilterDefinition<T>> perWordFilters = searchText.Split(" ")
-      .Select(segment =>
-        {
-          // Escape the user input so it is matched literally. Passing it to the
-          // regex engine unescaped allowed malformed patterns (exceptions) and
-          // catastrophic-backtracking patterns (ReDoS) to be injected via search.
-          var pattern = matchAnyWord
-            ? WholeWordRegex.BuildPattern(segment)
-            : Regex.Escape(segment);
-
-          return Builders<T>.Filter.Or(
-            fieldNameExpressions.Select(exp => Builders<T>.Filter.Regex(
-                exp,
-                new BsonRegularExpression(
-                  new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Multiline)
-                )
-              )
-            )
-          );
-        }
-      )
-      .ToList();
-
-    return matchAnyWord
-      ? [Builders<T>.Filter.Or(perWordFilters)]
-      : perWordFilters;
+    return _entryRepository.GetEntry(entryId);
   }
 }

--- a/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
+++ b/api/Engraved.Persistence.Mongo/Source/MongoRepositoryBase.cs
@@ -11,67 +11,47 @@ using Engraved.Persistence.Mongo.DocumentTypes;
 using Engraved.Persistence.Mongo.DocumentTypes.Entries;
 using Engraved.Persistence.Mongo.DocumentTypes.Journals;
 using Engraved.Persistence.Mongo.DocumentTypes.Users;
+using Engraved.Persistence.Mongo.Repositories;
+using Engraved.Persistence.Mongo.Scoping;
 using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace Engraved.Persistence.Mongo;
 
-// Shared MongoDB data access for the user/journal/entry roles. Concrete repositories derive from
-// this and supply the read-shaping filter via GetAllJournalDocumentsFilter:
-//  - UnrestrictedMongoRepository:  no filter (full access) plus the maintenance operations
-//  - UserRestrictedMongoRepository: the per-user permission filter plus the write guards
-public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClient)
+// Shared MongoDB data access for the journal/entry roles. The read scope (what the caller may see)
+// is injected via IReadScope rather than baked in by inheritance:
+//  - UnrestrictedMongoRepository:  UnrestrictedReadScope plus the maintenance operations
+//  - UserRestrictedMongoRepository: UserReadScope plus the write guards
+// The user role is delegated to MongoUserRepository - the first aggregate extracted into its own
+// class; journals and entries are next.
+public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClient, IReadScope readScope)
   : IUserRepository, IJournalRepository, IEntryRepository
 {
+  private readonly MongoUserRepository _userRepository = new(mongoDatabaseClient);
+
   // protected so they can be accessed from derived repositories (and the test repositories)
   protected IMongoCollection<EntryDocument> EntriesCollection => mongoDatabaseClient.EntriesCollection;
   protected IMongoCollection<JournalDocument> JournalsCollection => mongoDatabaseClient.JournalsCollection;
   protected IMongoCollection<UserDocument> UsersCollection => mongoDatabaseClient.UsersCollection;
 
-  public virtual async Task<IUser?> GetUser(string? nameOrId)
+  public Task<IUser?> GetUser(string? nameOrId)
   {
-    if (string.IsNullOrEmpty(nameOrId))
-    {
-      throw new ArgumentNullException(nameof(nameOrId), "Username or ID must be specified.");
-    }
-
-    var filterDefinition = ObjectId.TryParse(nameOrId, out ObjectId id)
-      ? Builders<UserDocument>.Filter.Where(d => d.Id == id)
-      : Builders<UserDocument>.Filter.Where(d => d.Name == nameOrId);
-
-    UserDocument? document = await UsersCollection
-      .Find(filterDefinition)
-      .FirstOrDefaultAsync();
-
-    return UserDocumentMapper.FromDocument(document);
+    return _userRepository.GetUser(nameOrId);
   }
 
-  public virtual async Task<UpsertResult> UpsertUser(IUser user)
+  public virtual Task<UpsertResult> UpsertUser(IUser user)
   {
-    return await UpsertUserInternal(user);
+    return _userRepository.UpsertUser(user);
   }
 
-  public async Task<IUser[]> GetUsers(params string[] userIds)
+  public Task<IUser[]> GetUsers(params string[] userIds)
   {
-    if (userIds.Length == 0)
-    {
-      return [];
-    }
-
-    var users = await UsersCollection
-      .Find(Builders<UserDocument>.Filter.Or(userIds.Distinct().Select(MongoUtil.GetDocumentByIdFilter<UserDocument>)))
-      .ToListAsync();
-
-    return users.Select(u => UserDocumentMapper.FromDocument(u)!).ToArray();
+    return _userRepository.GetUsers(userIds);
   }
 
-  public async Task<IUser[]> GetAllUsers()
+  public Task<IUser[]> GetAllUsers()
   {
-    var users = await UsersCollection
-      .Find(MongoUtil.GetAllDocumentsFilter<UserDocument>())
-      .ToListAsync();
-
-    return users.Select(u => UserDocumentMapper.FromDocument(u)!).ToArray();
+    return _userRepository.GetAllUsers();
   }
 
   public async Task<IJournal[]> GetAllJournals(
@@ -86,7 +66,7 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
   {
     var filters = new List<FilterDefinition<JournalDocument>>();
 
-    filters.Add(GetAllJournalDocumentsFilter<JournalDocument>(PermissionKind.Read));
+    filters.Add(readScope.GetFilter<JournalDocument>(PermissionKind.Read));
 
     if (journalTypes is { Length: > 0 })
     {
@@ -388,7 +368,7 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
       new ReplaceOptions { IsUpsert = true }
     );
 
-    return CreateUpsertResult(journal.Id, replaceOneResult);
+    return MongoUtil.CreateUpsertResult(journal.Id, replaceOneResult);
   }
 
   public virtual async Task DeleteJournal(string journalId)
@@ -417,7 +397,9 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
       return;
     }
 
-    var permissionsEnsurer = new PermissionsEnsurer(this, UpsertUserInternal);
+    // deliberately uses the plain user repository: granting a permission may create the receiving
+    // user's record, which the ownership guard on the public UpsertUser would (rightly) reject
+    var permissionsEnsurer = new PermissionsEnsurer(_userRepository, _userRepository.UpsertUser);
     await permissionsEnsurer.EnsurePermissions(journal, permissions);
 
     await UpsertJournal(journal);
@@ -434,7 +416,7 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
       new ReplaceOptions { IsUpsert = true }
     );
 
-    return CreateUpsertResult(entry.Id, replaceOneResult);
+    return MongoUtil.CreateUpsertResult(entry.Id, replaceOneResult);
   }
 
   public virtual async Task DeleteEntry(string entryId)
@@ -506,26 +488,20 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
     }
   }
 
-  private async Task<UpsertResult> UpsertUserInternal(IUser user)
+  // Explicitly unscoped read: loads the journal regardless of the caller's read permissions, so the
+  // caller can apply the permission rule in memory (the write guards) or read the owner of a journal
+  // it is about to update.
+  protected Task<IJournal?> GetJournalUnscoped(string journalId)
   {
-    UserDocument document = UserDocumentMapper.ToDocument(user);
-
-    IUser? existingUser = await GetUser(user.Name);
-    if (existingUser != null && string.IsNullOrEmpty(user.Id))
-    {
-      throw new ArgumentException("ID must be specified for existing users.");
-    }
-
-    ReplaceOneResult? replaceOneResult = await UsersCollection.ReplaceOneAsync(
-      Builders<UserDocument>.Filter.Where(d => d.Name == user.Name),
-      document,
-      new ReplaceOptions { IsUpsert = true }
-    );
-
-    return CreateUpsertResult(user.Id, replaceOneResult);
+    return GetJournal(journalId, PermissionKind.None, UnrestrictedReadScope.Instance);
   }
 
-  protected async Task<IJournal?> GetJournal(string journalId, PermissionKind permissionKind)
+  private Task<IJournal?> GetJournal(string journalId, PermissionKind permissionKind)
+  {
+    return GetJournal(journalId, permissionKind, readScope);
+  }
+
+  private async Task<IJournal?> GetJournal(string journalId, PermissionKind permissionKind, IReadScope scope)
   {
     if (string.IsNullOrEmpty(journalId))
     {
@@ -533,37 +509,15 @@ public abstract class MongoRepositoryBase(MongoDatabaseClient mongoDatabaseClien
     }
 
     JournalDocument? document = await JournalsCollection
-      .Find(GetJournalDocumentByIdFilter<JournalDocument>(journalId, permissionKind))
+      .Find(
+        Builders<JournalDocument>.Filter.And(
+          MongoUtil.GetDocumentByIdFilter<JournalDocument>(journalId),
+          scope.GetFilter<JournalDocument>(permissionKind)
+        )
+      )
       .FirstOrDefaultAsync();
 
     return JournalDocumentMapper.FromDocument(document);
-  }
-
-  private FilterDefinition<TDocument> GetJournalDocumentByIdFilter<TDocument>(string journalId, PermissionKind kind)
-    where TDocument : IDocument
-  {
-    return Builders<TDocument>.Filter.And(
-      MongoUtil.GetDocumentByIdFilter<TDocument>(journalId),
-      GetAllJournalDocumentsFilter<TDocument>(kind)
-    );
-  }
-
-  // Read-shaping hook: derived repositories restrict journal/entry queries to what the caller may
-  // read. UnrestrictedMongoRepository returns "everything"; UserRestrictedMongoRepository returns
-  // the per-user permission filter.
-  protected abstract FilterDefinition<TDocument> GetAllJournalDocumentsFilter<TDocument>(PermissionKind kind)
-    where TDocument : IDocument;
-
-  private static UpsertResult CreateUpsertResult(string? entityId, ReplaceOneResult replaceOneResult)
-  {
-    var id = (string.IsNullOrEmpty(entityId)
-      ? replaceOneResult.UpsertedId.ToString()
-      : entityId)!;
-
-    return new UpsertResult
-    {
-      EntityId = id
-    };
   }
 
   private static FilterDefinition<EntryDocument> GetHasScheduleForCurrentUserFilter(string currentUserId)

--- a/api/Engraved.Persistence.Mongo/Source/MongoUtil.cs
+++ b/api/Engraved.Persistence.Mongo/Source/MongoUtil.cs
@@ -1,4 +1,5 @@
-﻿using Engraved.Persistence.Mongo.DocumentTypes;
+﻿using Engraved.Core.Application.Persistence;
+using Engraved.Persistence.Mongo.DocumentTypes;
 using MongoDB.Bson;
 using MongoDB.Driver;
 
@@ -6,6 +7,18 @@ namespace Engraved.Persistence.Mongo;
 
 public static class MongoUtil
 {
+  public static UpsertResult CreateUpsertResult(string? entityId, ReplaceOneResult replaceOneResult)
+  {
+    var id = (string.IsNullOrEmpty(entityId)
+      ? replaceOneResult.UpsertedId.ToString()
+      : entityId)!;
+
+    return new UpsertResult
+    {
+      EntityId = id
+    };
+  }
+
   public static FilterDefinition<TDocument> GetAllDocumentsFilter<TDocument>()
     where TDocument : IDocument
   {

--- a/api/Engraved.Persistence.Mongo/Source/Repositories/MongoEntryRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Repositories/MongoEntryRepository.cs
@@ -1,0 +1,310 @@
+using System.Linq.Expressions;
+using Engraved.Core.Application.Persistence;
+using Engraved.Core.Domain.Entries;
+using Engraved.Core.Domain.Journals;
+using Engraved.Persistence.Mongo.DocumentTypes.Entries;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Engraved.Persistence.Mongo.Repositories;
+
+// Entry data access. Note that this repository takes no IReadScope: entry read-scoping is derived
+// entirely from journal permissions, so GetEntriesForJournal delegates the permission decision to
+// the (scoped) journal repository, while SearchEntries and GetEntry are unscoped primitives whose
+// callers enforce access themselves (see the comments on those methods).
+public class MongoEntryRepository(MongoDatabaseClient mongoDatabaseClient, MongoJournalRepository journalRepository)
+  : IEntryRepository
+{
+  private IMongoCollection<EntryDocument> EntriesCollection => mongoDatabaseClient.EntriesCollection;
+
+  public async Task<IEntry[]> GetEntriesForJournal(
+    string journalId,
+    DateTime? fromDate = null,
+    DateTime? toDate = null,
+    IDictionary<string, string[]>? attributeValues = null,
+    string? searchText = null,
+    SortEntriesBy sortOrder = SortEntriesBy.DateTime
+  )
+  {
+    // permission gate: the scoped journal repository returns null when the caller may not read the
+    // journal, in which case its entries are hidden too
+    IJournal? journal = await journalRepository.GetJournal(journalId);
+    if (journal == null)
+    {
+      return [];
+    }
+
+    var filters = new List<FilterDefinition<EntryDocument>>
+    {
+      Builders<EntryDocument>.Filter.Where(d => d.ParentId == journalId)
+    };
+
+    if (!string.IsNullOrEmpty(searchText))
+    {
+      filters.AddRange(
+        FreeTextFilters.Build<EntryDocument>(
+          searchText,
+          false,
+          d => d.Notes!,
+          d => ((ScrapsEntryDocument) d).Title!
+        )
+      );
+    }
+
+    if (fromDate.HasValue)
+    {
+      filters.Add(Builders<EntryDocument>.Filter.Where(d => d.DateTime >= fromDate.Value));
+    }
+
+    if (toDate.HasValue)
+    {
+      filters.Add(Builders<EntryDocument>.Filter.Where(d => d.DateTime < toDate.Value.AddDays(1)));
+    }
+
+    if (attributeValues != null)
+    {
+      filters.AddRange(
+        attributeValues.Select(attributeValue =>
+          Builders<EntryDocument>.Filter.In($"JournalAttributeValues.{attributeValue.Key}", attributeValue.Value)
+        )
+      );
+    }
+
+    SortDefinition<EntryDocument> sort = sortOrder == SortEntriesBy.EditedOn
+      ? Builders<EntryDocument>.Sort.Descending(d => d.EditedOn)
+      : Builders<EntryDocument>.Sort.Descending(d => d.DateTime);
+
+    var entries = await EntriesCollection
+      .Find(Builders<EntryDocument>.Filter.And(filters))
+      .Sort(sort)
+      .ToListAsync();
+
+    return entries
+      .Select(EntryDocumentMapper.FromDocument)
+      .ToArray();
+  }
+
+  // Unscoped primitive: this method does NOT enforce journal read-permission. It trusts the
+  // journalIds supplied by the caller. The only scoped caller, SearchEntriesQueryExecutor, first
+  // resolves the current user's accessible journals (via the scoped GetAllJournals) and passes
+  // those ids in, so read access is enforced there. Pinned by
+  // UserRestrictedMongoRepository_Permissions_Should.SearchEntries_IsUnscoped_TrustsCallerProvidedJournalIds.
+  public async Task<IEntry[]> SearchEntries(
+    string? searchText,
+    ScheduleMode? scheduleMode = null,
+    JournalType[]? journalTypes = null,
+    string[]? journalIds = null,
+    int? limit = null,
+    string? currentUserId = null,
+    bool onlyConsiderTitle = false,
+    bool matchAnyWord = false
+  )
+  {
+    var filters = new List<FilterDefinition<EntryDocument>>();
+
+    if (!string.IsNullOrEmpty(searchText))
+    {
+      filters.AddRange(
+        FreeTextFilters.Build<EntryDocument>(
+          searchText,
+          matchAnyWord,
+          onlyConsiderTitle
+            ? [d => ((ScrapsEntryDocument) d).Title!]
+            : [d => ((ScrapsEntryDocument) d).Title!, d => d.Notes!]
+        )
+      );
+    }
+
+    if (journalIds is { Length: > 0 })
+    {
+      filters.Add(Builders<EntryDocument>.Filter.In(d => d.ParentId, journalIds));
+    }
+
+    if (journalTypes is { Length: > 0 })
+    {
+      filters.Add(
+        Builders<EntryDocument>.Filter.Or(
+          journalTypes.Select(t => Builders<EntryDocument>.Filter.Where(GetIsEntryTypeExpression(t)))
+        )
+      );
+    }
+
+    if (scheduleMode == ScheduleMode.AnySchedule)
+    {
+      filters.Add(
+        Builders<EntryDocument>.Filter.Exists(d => d.Schedules)
+      );
+    }
+    else if (scheduleMode == ScheduleMode.CurrentUserOnly)
+    {
+      if (string.IsNullOrEmpty(currentUserId))
+      {
+        throw new ArgumentException("Current user id is required", nameof(currentUserId));
+      }
+
+      filters.Add(GetHasScheduleForCurrentUserFilter(currentUserId));
+    }
+
+    // Ordering is done at the DB level (see defaultSort below, and the CurrentUserFirst branch in
+    // LoadDocuments). We deliberately do NOT re-order scheduled entries to the front here: the entries
+    // tab (ScheduleMode.None) must stay sorted purely by edited date, and the scheduled tab
+    // (CurrentUserOnly) already contains only scheduled entries.
+    return await LoadData(
+      limit,
+      scheduleMode,
+      currentUserId,
+      filters,
+      Builders<EntryDocument>.Sort.Descending(d => d.EditedOn).Descending(d => d.Id)
+    );
+  }
+
+  public async Task<UpsertResult> UpsertEntry<TEntry>(TEntry entry)
+    where TEntry : IEntry
+  {
+    EntryDocument document = EntryDocumentMapper.ToDocument(entry);
+
+    ReplaceOneResult? replaceOneResult = await EntriesCollection.ReplaceOneAsync(
+      MongoUtil.GetDocumentByIdFilter<EntryDocument>(entry.Id),
+      document,
+      new ReplaceOptions { IsUpsert = true }
+    );
+
+    return MongoUtil.CreateUpsertResult(entry.Id, replaceOneResult);
+  }
+
+  public async Task DeleteEntry(string entryId)
+  {
+    await EntriesCollection.DeleteOneAsync(MongoUtil.GetDocumentByIdFilter<EntryDocument>(entryId));
+  }
+
+  // Unscoped primitive: GetEntry does NOT enforce read-permission on the parent journal. The
+  // client-facing single-entry read enforces access in GetEntryQueryExecutor; command executors use
+  // it as a load-for-modify primitive and rely on the subsequent UpsertEntry/DeleteEntry write
+  // checks. Pinned by
+  // UserRestrictedMongoRepository_Permissions_Should.GetEntry_IsUnscoped_ReturnsEntry_EvenWithoutJournalPermission.
+  public async Task<IEntry?> GetEntry(string entryId)
+  {
+    if (string.IsNullOrEmpty(entryId))
+    {
+      throw new ArgumentNullException(nameof(entryId), "Id must be specified.");
+    }
+
+    EntryDocument? document = await EntriesCollection
+      .Find(MongoUtil.GetDocumentByIdFilter<EntryDocument>(entryId))
+      .FirstOrDefaultAsync();
+
+    return document == null
+      ? null
+      : EntryDocumentMapper.FromDocument(document);
+  }
+
+  private async Task<IEntry[]> LoadData(
+    int? limit,
+    ScheduleMode? scheduleMode,
+    string? currentUserId,
+    List<FilterDefinition<EntryDocument>> filters,
+    SortDefinition<EntryDocument> defaultSort
+  )
+  {
+    List<EntryDocument> documents = await LoadDocuments(
+      limit,
+      scheduleMode,
+      currentUserId,
+      filters,
+      defaultSort
+    );
+
+    return documents
+      .Select(EntryDocumentMapper.FromDocument)
+      .ToArray();
+  }
+
+  private async Task<List<EntryDocument>> LoadDocuments(
+    int? limit,
+    ScheduleMode? scheduleMode,
+    string? currentUserId,
+    List<FilterDefinition<EntryDocument>> filters,
+    SortDefinition<EntryDocument> defaultSort
+  )
+  {
+    if (scheduleMode != ScheduleMode.CurrentUserFirst)
+    {
+      return await EntriesCollection
+        .Find(
+          filters.Count > 0
+            ? Builders<EntryDocument>.Filter.And(filters)
+            : Builders<EntryDocument>.Filter.Empty
+        )
+        .Sort(defaultSort)
+        .Limit(limit)
+        .ToListAsync();
+    }
+
+    if (string.IsNullOrEmpty(currentUserId))
+    {
+      throw new ArgumentException(
+        $"\"{nameof(currentUserId)}\" must be specified when using {ScheduleMode.CurrentUserFirst}."
+      );
+    }
+
+    var entries = await EntriesCollection
+      .Find(
+        Builders<EntryDocument>.Filter.And(
+          filters.Union([GetHasScheduleForCurrentUserFilter(currentUserId)])
+        )
+      )
+      .Sort(Builders<EntryDocument>.Sort.Ascending(d => d.Schedules[currentUserId].NextOccurrence))
+      .Limit(limit)
+      .ToListAsync();
+
+    var foundIds = entries.Select(e => e.Id).ToArray();
+
+    entries.AddRange(
+      await EntriesCollection
+        .Find(
+          Builders<EntryDocument>.Filter.And(
+            filters.Concat([Builders<EntryDocument>.Filter.Nin(d => d.Id, foundIds)])
+          )
+        )
+        .Sort(defaultSort)
+        .Limit(limit - entries.Count)
+        .ToListAsync()
+    );
+
+    return entries;
+  }
+
+  private static FilterDefinition<EntryDocument> GetHasScheduleForCurrentUserFilter(string currentUserId)
+  {
+    // "scheduled" means the user has a schedule with a pending occurrence. A schedule sub-document is
+    // kept around after it has fired (with NextOccurrence set to null), so checking mere existence of
+    // the sub-document would wrongly surface already-fired schedules as "scheduled".
+    return Builders<EntryDocument>.Filter.And(
+      Builders<EntryDocument>.Filter.Exists($"Schedules.{currentUserId}"),
+      Builders<EntryDocument>.Filter.Ne($"Schedules.{currentUserId}.NextOccurrence", BsonNull.Value)
+    );
+  }
+
+  private static Expression<Func<EntryDocument, bool>> GetIsEntryTypeExpression(JournalType journalType)
+  {
+    switch (journalType)
+    {
+      case JournalType.Counter:
+        return d => d.GetType() == typeof(CounterEntryDocument);
+      case JournalType.Gauge:
+        return d => d.GetType() == typeof(GaugeEntryDocument);
+      case JournalType.Timer:
+        return d => d.GetType() == typeof(TimerEntryDocument);
+      case JournalType.Scraps:
+        return d => d.GetType() == typeof(ScrapsEntryDocument);
+      case JournalType.LogBook:
+        return d => d.GetType() == typeof(LogBookEntryDocument);
+      default:
+        throw new ArgumentOutOfRangeException(
+          nameof(journalType),
+          journalType,
+          $"{nameof(GetIsEntryTypeExpression)} not defined for {journalType}."
+        );
+    }
+  }
+}

--- a/api/Engraved.Persistence.Mongo/Source/Repositories/MongoJournalRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Repositories/MongoJournalRepository.cs
@@ -1,0 +1,208 @@
+using System.Linq.Expressions;
+using Engraved.Core.Application.Permissions;
+using Engraved.Core.Application.Persistence;
+using Engraved.Core.Domain.Journals;
+using Engraved.Core.Domain.Permissions;
+using Engraved.Persistence.Mongo.DocumentTypes.Entries;
+using Engraved.Persistence.Mongo.DocumentTypes.Journals;
+using Engraved.Persistence.Mongo.Scoping;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Engraved.Persistence.Mongo.Repositories;
+
+// Journal data access. Reads are shaped by the injected IReadScope; the write guards live on top of
+// this (see UserRestrictedMongoRepository).
+public class MongoJournalRepository(MongoDatabaseClient mongoDatabaseClient, IReadScope readScope)
+  : IJournalRepository
+{
+  private readonly MongoUserRepository _userRepository = new(mongoDatabaseClient);
+
+  private IMongoCollection<JournalDocument> JournalsCollection => mongoDatabaseClient.JournalsCollection;
+  private IMongoCollection<EntryDocument> EntriesCollection => mongoDatabaseClient.EntriesCollection;
+
+  public async Task<IJournal[]> GetAllJournals(
+    string? searchText = null,
+    ScheduleMode? scheduleMode = null,
+    JournalType[]? journalTypes = null,
+    string[]? journalIds = null,
+    int? limit = null,
+    string? currentUserId = null,
+    bool matchAnyWord = false
+  )
+  {
+    var filters = new List<FilterDefinition<JournalDocument>>();
+
+    filters.Add(readScope.GetFilter<JournalDocument>(PermissionKind.Read));
+
+    if (journalTypes is { Length: > 0 })
+    {
+      filters.Add(
+        Builders<JournalDocument>.Filter.Or(
+          journalTypes.Select(t => Builders<JournalDocument>.Filter.Where(GetIsJournalTypeExpression(t)))
+        )
+      );
+    }
+
+    if (journalIds is { Length: > 0 })
+    {
+      var objectIds = journalIds
+        .Select(i => ObjectId.TryParse(i, out var id) ? (ObjectId?) id : null)
+        .Where(id => id.HasValue)
+        .Select(id => id!.Value)
+        .ToList();
+
+      if (objectIds.Any())
+      {
+        filters.Add(Builders<JournalDocument>.Filter.In(d => d.Id, objectIds));
+      }
+      else
+      {
+        // if IDs were provided but none were valid ObjectIds, we should return nothing
+        filters.Add(Builders<JournalDocument>.Filter.Where(d => false));
+      }
+    }
+
+    if (scheduleMode == ScheduleMode.AnySchedule)
+    {
+      filters.Add(
+        Builders<JournalDocument>.Filter.Exists(d => d.Schedules)
+      );
+    }
+    if (scheduleMode == ScheduleMode.CurrentUserOnly)
+    {
+      if (string.IsNullOrEmpty(currentUserId))
+      {
+        throw new ArgumentException("Current user id is required", nameof(currentUserId));
+      }
+
+      // "scheduled" means a schedule with a pending occurrence: a fired schedule keeps its sub-document
+      // (with NextOccurrence nulled out), so we must check NextOccurrence rather than mere existence.
+      filters.Add(Builders<JournalDocument>.Filter.And(
+        Builders<JournalDocument>.Filter.Exists($"Schedules.{currentUserId}"),
+        Builders<JournalDocument>.Filter.Ne($"Schedules.{currentUserId}.NextOccurrence", BsonNull.Value)
+      ));
+    }
+
+    if (!string.IsNullOrEmpty(searchText))
+    {
+      filters.AddRange(
+        FreeTextFilters.Build<JournalDocument>(
+          searchText,
+          matchAnyWord,
+          d => d.Name!,
+          d => d.Description!
+        )
+      );
+    }
+
+    var journals = await JournalsCollection
+      .Find(filters.Count > 0 ? Builders<JournalDocument>.Filter.And(filters) : Builders<JournalDocument>.Filter.Empty)
+      .Sort(Builders<JournalDocument>.Sort.Descending(d => d.EditedOn).Descending(d => d.Id))
+      .Limit(limit)
+      .ToListAsync();
+
+    return journals.Select(j => JournalDocumentMapper.FromDocument(j)!).ToArray();
+  }
+
+  public async Task<IJournal?> GetJournal(string journalId)
+  {
+    return await GetJournal(journalId, PermissionKind.Read, readScope);
+  }
+
+  // Explicitly unscoped read: loads the journal regardless of the caller's read permissions, so the
+  // caller can apply the permission rule in memory (the write guards) or read the owner of a journal
+  // it is about to update. Deliberately not part of IJournalRepository.
+  public Task<IJournal?> GetJournalUnscoped(string journalId)
+  {
+    return GetJournal(journalId, PermissionKind.None, UnrestrictedReadScope.Instance);
+  }
+
+  public async Task<UpsertResult> UpsertJournal(IJournal journal)
+  {
+    JournalDocument document = JournalDocumentMapper.ToDocument(journal);
+
+    ReplaceOneResult? replaceOneResult = await JournalsCollection.ReplaceOneAsync(
+      MongoUtil.GetDocumentByIdFilter<JournalDocument>(journal.Id),
+      document,
+      new ReplaceOptions { IsUpsert = true }
+    );
+
+    return MongoUtil.CreateUpsertResult(journal.Id, replaceOneResult);
+  }
+
+  public async Task DeleteJournal(string journalId)
+  {
+    IJournal? journal = await GetJournal(journalId);
+    if (journal == null)
+    {
+      return;
+    }
+
+    // cascading use-case logic (a journal's entries die with it) - candidate to move up into
+    // DeleteJournalCommandExecutor in a follow-up
+    await EntriesCollection.DeleteManyAsync(
+      Builders<EntryDocument>.Filter.Where(d => d.ParentId == journalId)
+    );
+
+    await JournalsCollection.DeleteOneAsync(
+      MongoUtil.GetDocumentByIdFilter<JournalDocument>(journalId)
+    );
+  }
+
+  public async Task ModifyJournalPermissions(string journalId, Dictionary<string, PermissionKind> permissions)
+  {
+    IJournal? journal = await GetJournal(journalId);
+    if (journal == null)
+    {
+      // should we throw here?
+      return;
+    }
+
+    // deliberately uses the plain user repository: granting a permission may create the receiving
+    // user's record, which the ownership guard on the public UpsertUser would (rightly) reject
+    var permissionsEnsurer = new PermissionsEnsurer(_userRepository, _userRepository.UpsertUser);
+    await permissionsEnsurer.EnsurePermissions(journal, permissions);
+
+    await UpsertJournal(journal);
+  }
+
+  private async Task<IJournal?> GetJournal(string journalId, PermissionKind permissionKind, IReadScope scope)
+  {
+    if (string.IsNullOrEmpty(journalId))
+    {
+      throw new ArgumentNullException(nameof(journalId), "Id must be specified.");
+    }
+
+    JournalDocument? document = await JournalsCollection
+      .Find(
+        Builders<JournalDocument>.Filter.And(
+          MongoUtil.GetDocumentByIdFilter<JournalDocument>(journalId),
+          scope.GetFilter<JournalDocument>(permissionKind)
+        )
+      )
+      .FirstOrDefaultAsync();
+
+    return JournalDocumentMapper.FromDocument(document);
+  }
+
+  // there must be a better solution than this, but it works for the moment... i believe
+  // Builders<JournalDocument>.Filter.Where(t => t.Type == journalType) does not work because
+  // JournalDocument.Type is an ABSTRACT property.
+  private static Expression<Func<JournalDocument, bool>> GetIsJournalTypeExpression(JournalType journalType)
+  {
+    return journalType switch
+    {
+      JournalType.Counter => d => d.GetType() == typeof(CounterJournalDocument),
+      JournalType.Gauge => d => d.GetType() == typeof(GaugeJournalDocument),
+      JournalType.Timer => d => d.GetType() == typeof(TimerJournalDocument),
+      JournalType.Scraps => d => d.GetType() == typeof(ScrapsJournalDocument),
+      JournalType.LogBook => d => d.GetType() == typeof(LogBookJournalDocument),
+      _ => throw new ArgumentOutOfRangeException(
+        nameof(journalType),
+        journalType,
+        $"{nameof(GetIsJournalTypeExpression)} not defined for {journalType}."
+      )
+    };
+  }
+}

--- a/api/Engraved.Persistence.Mongo/Source/Repositories/MongoUserRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Repositories/MongoUserRepository.cs
@@ -1,0 +1,75 @@
+using Engraved.Core.Application.Persistence;
+using Engraved.Core.Domain.Users;
+using Engraved.Persistence.Mongo.DocumentTypes.Users;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Engraved.Persistence.Mongo.Repositories;
+
+// Plain user data access with no guards. Callers that must enforce ownership do so on top of this
+// (see UserRestrictedMongoRepository.UpsertUser); internal consumers like PermissionsEnsurer use it
+// directly because they legitimately operate on other users' records.
+public class MongoUserRepository(MongoDatabaseClient mongoDatabaseClient) : IUserRepository
+{
+  private IMongoCollection<UserDocument> UsersCollection => mongoDatabaseClient.UsersCollection;
+
+  public async Task<IUser?> GetUser(string? nameOrId)
+  {
+    if (string.IsNullOrEmpty(nameOrId))
+    {
+      throw new ArgumentNullException(nameof(nameOrId), "Username or ID must be specified.");
+    }
+
+    var filterDefinition = ObjectId.TryParse(nameOrId, out ObjectId id)
+      ? Builders<UserDocument>.Filter.Where(d => d.Id == id)
+      : Builders<UserDocument>.Filter.Where(d => d.Name == nameOrId);
+
+    UserDocument? document = await UsersCollection
+      .Find(filterDefinition)
+      .FirstOrDefaultAsync();
+
+    return UserDocumentMapper.FromDocument(document);
+  }
+
+  public async Task<UpsertResult> UpsertUser(IUser user)
+  {
+    UserDocument document = UserDocumentMapper.ToDocument(user);
+
+    IUser? existingUser = await GetUser(user.Name);
+    if (existingUser != null && string.IsNullOrEmpty(user.Id))
+    {
+      throw new ArgumentException("ID must be specified for existing users.");
+    }
+
+    ReplaceOneResult? replaceOneResult = await UsersCollection.ReplaceOneAsync(
+      Builders<UserDocument>.Filter.Where(d => d.Name == user.Name),
+      document,
+      new ReplaceOptions { IsUpsert = true }
+    );
+
+    return MongoUtil.CreateUpsertResult(user.Id, replaceOneResult);
+  }
+
+  public async Task<IUser[]> GetUsers(params string[] userIds)
+  {
+    if (userIds.Length == 0)
+    {
+      return [];
+    }
+
+    var users = await UsersCollection
+      .Find(Builders<UserDocument>.Filter.Or(userIds.Distinct().Select(MongoUtil.GetDocumentByIdFilter<UserDocument>)))
+      .ToListAsync();
+
+    return users.Select(u => UserDocumentMapper.FromDocument(u)!).ToArray();
+  }
+
+  public async Task<IUser[]> GetAllUsers()
+  {
+    var users = await UsersCollection
+      .Find(MongoUtil.GetAllDocumentsFilter<UserDocument>())
+      .ToListAsync();
+
+    return users.Select(u => UserDocumentMapper.FromDocument(u)!).ToArray();
+  }
+}

--- a/api/Engraved.Persistence.Mongo/Source/Scoping/IReadScope.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Scoping/IReadScope.cs
@@ -1,0 +1,16 @@
+using Engraved.Core.Domain.Permissions;
+using Engraved.Persistence.Mongo.DocumentTypes;
+using MongoDB.Driver;
+
+namespace Engraved.Persistence.Mongo.Scoping;
+
+// Read-scoping strategy: shapes journal/entry reads to what the caller may see. Injected into the
+// repositories instead of being baked in via inheritance, so the effective scope of a repository is
+// visible at construction time:
+//  - UnrestrictedReadScope: everything is visible (system jobs, login, health)
+//  - UserReadScope: only what the current user owns or has been granted permission on
+public interface IReadScope
+{
+  FilterDefinition<TDocument> GetFilter<TDocument>(PermissionKind kind)
+    where TDocument : IDocument;
+}

--- a/api/Engraved.Persistence.Mongo/Source/Scoping/UnrestrictedReadScope.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Scoping/UnrestrictedReadScope.cs
@@ -1,0 +1,17 @@
+using Engraved.Core.Domain.Permissions;
+using Engraved.Persistence.Mongo.DocumentTypes;
+using MongoDB.Driver;
+
+namespace Engraved.Persistence.Mongo.Scoping;
+
+// No scoping: every document is visible regardless of the requested permission kind.
+public class UnrestrictedReadScope : IReadScope
+{
+  public static readonly UnrestrictedReadScope Instance = new();
+
+  public FilterDefinition<TDocument> GetFilter<TDocument>(PermissionKind kind)
+    where TDocument : IDocument
+  {
+    return MongoUtil.GetAllDocumentsFilter<TDocument>();
+  }
+}

--- a/api/Engraved.Persistence.Mongo/Source/Scoping/UserReadScope.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Scoping/UserReadScope.cs
@@ -1,0 +1,24 @@
+using Engraved.Core.Application.Persistence;
+using Engraved.Core.Domain.Permissions;
+using Engraved.Core.Domain.Users;
+using Engraved.Persistence.Mongo.DocumentTypes;
+using MongoDB.Driver;
+
+namespace Engraved.Persistence.Mongo.Scoping;
+
+// Restricts reads to what the current user owns or has been granted permission on. The actual rule
+// lives in JournalAccessFilter (the query form of JournalAccessPolicy).
+public class UserReadScope(Lazy<IUser> currentUser) : IReadScope
+{
+  public FilterDefinition<TDocument> GetFilter<TDocument>(PermissionKind kind)
+    where TDocument : IDocument
+  {
+    var userId = currentUser.Value.Id;
+    if (string.IsNullOrEmpty(userId))
+    {
+      throw new NotAllowedOperationException("Current user is not available.");
+    }
+
+    return JournalAccessFilter.ForUser<TDocument>(userId, kind);
+  }
+}

--- a/api/Engraved.Persistence.Mongo/Source/UnrestrictedMongoRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/UnrestrictedMongoRepository.cs
@@ -1,25 +1,18 @@
 using Engraved.Core.Application.Persistence;
-using Engraved.Core.Domain.Permissions;
-using Engraved.Persistence.Mongo.DocumentTypes;
 using Engraved.Persistence.Mongo.DocumentTypes.Entries;
 using Engraved.Persistence.Mongo.DocumentTypes.Journals;
 using Engraved.Persistence.Mongo.DocumentTypes.Users;
+using Engraved.Persistence.Mongo.Scoping;
 using MongoDB.Driver;
 
 namespace Engraved.Persistence.Mongo;
 
-// Full persistence access with no permission/user scoping, plus the inherently-unrestricted
-// maintenance operations (keep-alive, global counts).
+// Full persistence access with no permission/user scoping (UnrestrictedReadScope), plus the
+// inherently-unrestricted maintenance operations (keep-alive, global counts).
 public class UnrestrictedMongoRepository(MongoDatabaseClient mongoDatabaseClient)
-  : MongoRepositoryBase(mongoDatabaseClient), IUnrestrictedRepository
+  : MongoRepositoryBase(mongoDatabaseClient, UnrestrictedReadScope.Instance), IUnrestrictedRepository
 {
   private const string RandomDocId = "63f949da880b5bf2518be721";
-
-  // no scoping: every journal/entry is visible regardless of the requested permission kind.
-  protected override FilterDefinition<TDocument> GetAllJournalDocumentsFilter<TDocument>(PermissionKind kind)
-  {
-    return MongoUtil.GetAllDocumentsFilter<TDocument>();
-  }
 
   public async Task WakeMeUp()
   {

--- a/api/Engraved.Persistence.Mongo/Source/UserRestrictedMongoRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/UserRestrictedMongoRepository.cs
@@ -5,27 +5,28 @@ using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Permissions;
 using Engraved.Core.Domain.Users;
-using MongoDB.Driver;
+using Engraved.Persistence.Mongo.Repositories;
+using Engraved.Persistence.Mongo.Scoping;
 
 namespace Engraved.Persistence.Mongo;
 
-// Permission/owner-filtered access for the current user. Adds the read-shaping filter and the write
-// guards on top of the shared MongoRepositoryBase, and exposes the CurrentUser the scoping is based
-// on. Both mechanisms enforce one shared rule (JournalAccessPolicy / JournalAccessFilter).
+// Permission/owner-filtered access for the current user. Reads are shaped by the injected
+// UserReadScope; writes are guarded here by loading the journal unscoped and applying the same rule
+// in memory. Both mechanisms enforce one shared rule (JournalAccessPolicy / JournalAccessFilter).
 public class UserRestrictedMongoRepository : MongoRepositoryBase, IUserRestrictedRepository
 {
-  private readonly ICurrentUserService _currentUserService;
-
-  private bool _ignorePermissionsForJournalIdFilter;
-
   public UserRestrictedMongoRepository(
     MongoDatabaseClient mongoDatabaseClient,
     ICurrentUserService currentUserService
   )
-    : base(mongoDatabaseClient)
+    : this(mongoDatabaseClient, CreateCurrentUserLazy(mongoDatabaseClient, currentUserService))
   {
-    _currentUserService = currentUserService;
-    CurrentUser = new Lazy<IUser>(LoadUser);
+  }
+
+  private UserRestrictedMongoRepository(MongoDatabaseClient mongoDatabaseClient, Lazy<IUser> currentUser)
+    : base(mongoDatabaseClient, new UserReadScope(currentUser))
+  {
+    CurrentUser = currentUser;
   }
 
   public Lazy<IUser> CurrentUser { get; }
@@ -40,7 +41,7 @@ public class UserRestrictedMongoRepository : MongoRepositoryBase, IUserRestricte
   {
     if (!string.IsNullOrEmpty(journal.Id))
     {
-      IJournal? existingJournal = await LoadJournalIgnoringPermissions(journal.Id);
+      IJournal? existingJournal = await GetJournalUnscoped(journal.Id);
 
       if (existingJournal != null)
       {
@@ -82,28 +83,22 @@ public class UserRestrictedMongoRepository : MongoRepositoryBase, IUserRestricte
     await base.DeleteEntry(entryId);
   }
 
-  // Read-shaping mechanism: restrict journal/entry queries to what the current user may read.
-  // The actual rule lives in JournalAccessFilter (the query form of JournalAccessPolicy).
-  protected override FilterDefinition<TDocument> GetAllJournalDocumentsFilter<TDocument>(PermissionKind kind)
+  private static Lazy<IUser> CreateCurrentUserLazy(
+    MongoDatabaseClient mongoDatabaseClient,
+    ICurrentUserService currentUserService
+  )
   {
-    if (_ignorePermissionsForJournalIdFilter)
-    {
-      return MongoUtil.GetAllDocumentsFilter<TDocument>();
-    }
+    var userRepository = new MongoUserRepository(mongoDatabaseClient);
 
-    var userId = CurrentUser.Value.Id;
-    EnsureUserIsSet(userId);
+    return new Lazy<IUser>(() =>
+      {
+        IUser user = currentUserService.LoadUser().Result;
+        EnsureUserIsSet(user.Name);
 
-    return JournalAccessFilter.ForUser<TDocument>(userId, kind);
-  }
-
-  private IUser LoadUser()
-  {
-    IUser result = _currentUserService.LoadUser().Result;
-    EnsureUserIsSet(result.Name);
-
-    IUser? dbUser = base.GetUser(result.Id ?? result.Name).Result;
-    return dbUser ?? result;
+        IUser? dbUser = userRepository.GetUser(user.Id ?? user.Name).Result;
+        return dbUser ?? user;
+      }
+    );
   }
 
   private void EnsureUserId(IUserOwned entity)
@@ -117,12 +112,12 @@ public class UserRestrictedMongoRepository : MongoRepositoryBase, IUserRestricte
   }
 
   // Write-guard mechanism: load the journal without scoping, then apply the same rule in memory via
-  // JournalAccessPolicy. Reads (above) and writes (here) therefore enforce one shared rule.
+  // JournalAccessPolicy. Reads (UserReadScope) and writes (here) therefore enforce one shared rule.
   private async Task EnsureUserHasPermission(string? journalId, PermissionKind kind)
   {
     if (!string.IsNullOrEmpty(journalId))
     {
-      IJournal? journal = await LoadJournalIgnoringPermissions(journalId);
+      IJournal? journal = await GetJournalUnscoped(journalId);
       if (JournalAccessPolicy.HasAccess(journal, CurrentUser.Value.Id, kind))
       {
         return;
@@ -130,21 +125,6 @@ public class UserRestrictedMongoRepository : MongoRepositoryBase, IUserRestricte
     }
 
     throw new NotAllowedOperationException("Journal doesn't exist or you do not have permissions.");
-  }
-
-  // Loads a journal bypassing the read-scoping filter, so callers can apply the permission rule
-  // themselves (the write guard) or read the owner of a journal they are about to update.
-  private async Task<IJournal?> LoadJournalIgnoringPermissions(string journalId)
-  {
-    try
-    {
-      _ignorePermissionsForJournalIdFilter = true;
-      return await GetJournal(journalId, PermissionKind.None);
-    }
-    finally
-    {
-      _ignorePermissionsForJournalIdFilter = false;
-    }
   }
 
   private void EnsureEntityBelongsToUser(string? entityUserId)


### PR DESCRIPTION
## Summary

Restructures the persistence layer. The monolithic `MongoRepositoryBase` (623 lines, three aggregates, permission plumbing via inheritance) was hard to reason about; this PR splits it into small, single-purpose classes composed explicitly instead of via inheritance.

**Per-aggregate repositories** (`Source/Repositories/`):

- **`MongoUserRepository`**: plain user data access. The confusing `UpsertUser`/`UpsertUserInternal` virtual pair is gone — `PermissionsEnsurer` openly uses the plain repository (it legitimately writes *other* users'' records when granting permissions), while the ownership guard remains on the public path.
- **`MongoJournalRepository`**: journal data access shaped by the injected read scope, including the explicitly-unscoped `GetJournalUnscoped` primitive used by the write guards.
- **`MongoEntryRepository`**: entry data access. Takes **no** read scope — entry scoping is derived entirely from journal permissions via the (scoped) journal repository; `SearchEntries`/`GetEntry` remain documented unscoped primitives whose callers enforce access (pinned by tests).

**Scoping** (`Source/Scoping/`):

- **`IReadScope`** (`UnrestrictedReadScope` / `UserReadScope`): the read-shaping permission filter is injected at construction time, replacing the abstract `GetAllJournalDocumentsFilter` template method. Each repository''s effective scope is now visible on one line in its constructor.
- **Mutable scoping flag removed**: `_ignorePermissionsForJournalIdFilter` (temporal state on the instance) is replaced by explicit `GetJournalUnscoped()` calls, so permission-bypassing reads are visible at the call site.

**What remains of the old structure**: `MongoRepositoryBase` is now a pure delegating facade holding only the composition and the virtual write-guard hooks; `UserRestrictedMongoRepository` is only the write guards; `UnrestrictedMongoRepository` is only the maintenance operations. `FreeTextFilters` holds the shared free-text regex building.

## Context / decisions

Came out of an architecture discussion about the persistence layer being too big and business logic being spread across executors and repositories. Key decisions:

- Keep permission enforcement at the data layer (fail-closed: injecting `IUserRestrictedRepository` cannot forget a check) but make the mechanism explicit strategy objects instead of subclass overrides.
- Behavior-preserving on purpose: public constructors, interfaces, and DI wiring are unchanged, so all executors and tests are untouched.
- Journals and entries were extracted in one step because they are entangled (entry reads derive permissions from journal access; journal deletion cascades into entries) — extracting them separately would have created throwaway intermediate wiring.
- Planned follow-up PRs: (1) turn the write guards into decorators and dissolve `MongoRepositoryBase` + the inheritance entirely (incl. DI/TestUtils cleanup, moving `CurrentUser` to a provider); (2) lift leaked use-case logic (cascading journal delete, `PermissionsEnsurer` orchestration) up into the executors.

## Trade-offs

- The `Lazy<IUser>` current-user loading forces a slightly baroque constructor chain in `UserRestrictedMongoRepository` (private constructor + static factory). The pre-existing sync-over-async (`.Result`) inside it is deliberately untouched — fixing that is a behavior change that deserves its own PR.
- `MongoUserRepository` is instantiated more than once per composed repository (delegation, journal permissions, current-user loading); it is a stateless view over the shared `MongoDatabaseClient`, so this is harmless and disappears with the cleanup PR.
- The cascading entry delete stays in `MongoJournalRepository` for now (marked as a candidate to move into `DeleteJournalCommandExecutor`) to keep this PR behavior-preserving.

## Verification

`dotnet build` clean, `dotnet test` green after each slice: 245/245 (Api 33, Core 107, Persistence.Mongo 105), including the permission-pinning suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)