### PR TITLE
Lift journal-deletion cascade and permission editing out of the repositories into the executors

### DIFF
--- a/api/Engraved.Api.Tests/Source/StartupSmokeShould.cs
+++ b/api/Engraved.Api.Tests/Source/StartupSmokeShould.cs
@@ -7,6 +7,8 @@ using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
+using Engraved.Core.Application.Commands;
+using Engraved.Core.Application.Commands.Journals.EditPermissions;
 using Engraved.Core.Application.Persistence;
 using Engraved.Persistence.Mongo;
 using Engraved.TestUtils;
@@ -86,6 +88,10 @@ public class StartupSmokeShould
 
     // maintenance is inherently unrestricted, so it resolves to the raw UnrestrictedMongoRepository
     services.GetRequiredService<IMaintenanceRepository>().Should().BeOfType<UnrestrictedMongoRepository>();
+
+    // the edit-permissions executor is the only one with a non-repository dependency
+    // (PermissionsEnsurer); resolve it so a broken registration fails here and not at runtime
+    services.GetRequiredService<ICommandExecutor<EditJournalPermissionsCommand>>();
   }
 
   [Test]

--- a/api/Engraved.Api/Source/Bootstrap/PersistenceRegistration.cs
+++ b/api/Engraved.Api/Source/Bootstrap/PersistenceRegistration.cs
@@ -1,8 +1,10 @@
 using Engraved.Api.Settings;
 using Engraved.Core.Application;
+using Engraved.Core.Application.Permissions;
 using Engraved.Core.Application.Persistence;
 using Engraved.Core.Domain.Users;
 using Engraved.Persistence.Mongo;
+using Engraved.Persistence.Mongo.Repositories;
 
 namespace Engraved.Api.Bootstrap;
 
@@ -44,6 +46,17 @@ public static class PersistenceRegistration
     services.AddTransient<IUserRepository>(provider => provider.GetRequiredService<IUserRestrictedRepository>());
     services.AddTransient<IJournalRepository>(provider => provider.GetRequiredService<IUserRestrictedRepository>());
     services.AddTransient<IEntryRepository>(provider => provider.GetRequiredService<IUserRestrictedRepository>());
+
+    // PermissionsEnsurer deliberately works on the plain (unguarded) user repository: granting a
+    // permission may create the receiving user's record, which the ownership guard on the
+    // user-restricted UpsertUser would (rightly) reject. Write access to the journal itself is
+    // enforced by its consumer (EditJournalPermissionsCommandExecutor).
+    services.AddTransient<PermissionsEnsurer>(provider =>
+      {
+        var userRepository = new MongoUserRepository(provider.GetRequiredService<MongoDatabaseClient>());
+        return new PermissionsEnsurer(userRepository, userRepository.UpsertUser);
+      }
+    );
   }
 
   private static void RegisterUnrestrictedRepository(IServiceCollection services)

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Journals/Delete/DeleteJournalCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Journals/Delete/DeleteJournalCommandExecutorShould.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Permissions;
 using Engraved.TestUtils;
@@ -33,7 +34,7 @@ public class DeleteJournalCommandExecutorShould
     );
 
     // when
-    CommandResult result = await new DeleteJournalCommandExecutor(_repo).Execute(
+    CommandResult result = await new DeleteJournalCommandExecutor(_repo, _repo).Execute(
       new DeleteJournalCommand { JournalId = JournalId }
     );
 
@@ -45,10 +46,27 @@ public class DeleteJournalCommandExecutorShould
   }
 
   [Test]
+  public async Task DeleteJournal_And_ItsEntries()
+  {
+    // the "a journal's entries die with it" cascade is owned by this executor (the repository
+    // deletes only the journal document itself)
+    await _repo.UpsertJournal(new CounterJournal { Id = JournalId });
+    await _repo.UpsertEntry(new CounterEntry { ParentId = JournalId });
+    await _repo.UpsertEntry(new CounterEntry { ParentId = JournalId });
+
+    await new DeleteJournalCommandExecutor(_repo, _repo).Execute(
+      new DeleteJournalCommand { JournalId = JournalId }
+    );
+
+    (await _repo.GetJournal(JournalId)).Should().BeNull();
+    (await _repo.SearchEntries(null, journalIds: [JournalId])).Should().BeEmpty();
+  }
+
+  [Test]
   public async Task ReturnEmptyResult_When_JournalDoesNotExist()
   {
     // when
-    CommandResult result = await new DeleteJournalCommandExecutor(_repo).Execute(
+    CommandResult result = await new DeleteJournalCommandExecutor(_repo, _repo).Execute(
       new DeleteJournalCommand { JournalId = "60703c3b0000000000000999" }
     );
 

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Journals/EditPermissions/EditJournalPermissionsCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Journals/EditPermissions/EditJournalPermissionsCommandExecutorShould.cs
@@ -1,6 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Engraved.Core.Application.Permissions;
+using Engraved.Core.Application.Persistence;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Permissions;
 using Engraved.Core.Domain.Users;
@@ -12,21 +14,35 @@ namespace Engraved.Core.Application.Commands.Journals.EditPermissions;
 
 public class EditJournalPermissionsCommandExecutorShould
 {
-  private TestMongoRepository _repo = null!;
-
-  private const string OwnerId = "60703c3b00000000000000f1";
+  private const string CurrentUserName = "me@foo.ch";
+  private const string CurrentUserId = "60703c3b00000000000000f1";
+  private const string OtherUserName = "other@foo.ch";
   private const string JournalId = "60703c3b00000000000000f3";
+
+  private TestMongoRepository _repo = null!;
+  private TestUserRestrictedMongoRepository _userScopedRepo = null!;
+  private PermissionsEnsurer _permissionsEnsurer = null!;
+  private string _otherUserId = null!;
 
   [SetUp]
   public async Task SetUp()
   {
     _repo = await Util.CreateMongoRepository();
+
+    await _repo.UpsertUser(new User { Id = CurrentUserId, Name = CurrentUserName });
+    _otherUserId = (await _repo.UpsertUser(new User { Name = OtherUserName })).EntityId;
+
+    _userScopedRepo = await Util.CreateUserRestrictedMongoRepository(CurrentUserName, CurrentUserId, true);
+
+    // the ensurer works on the plain (unguarded) repository, mirroring the DI registration in
+    // PersistenceRegistration: it may create records for users receiving a permission
+    _permissionsEnsurer = new PermissionsEnsurer(_repo, _repo.UpsertUser);
   }
 
   [Test]
   public async Task Throw_When_JournalIdIsEmpty()
   {
-    Func<Task> act = () => new EditJournalPermissionsCommandExecutor(_repo).Execute(
+    Func<Task> act = () => CreateExecutor().Execute(
       new EditJournalPermissionsCommand { JournalId = "" }
     );
 
@@ -36,36 +52,34 @@ public class EditJournalPermissionsCommandExecutorShould
   [Test]
   public async Task AddPermission_And_ReturnUnionOfBeforeAndAfterUsers()
   {
-    // given: a journal owned by an existing user and a second user to grant access to
-    const string newId = "60703c3b00000000000000f2";
-
-    await _repo.UpsertUser(new User { Id = OwnerId, Name = "owner@foo.ch" });
-    await _repo.UpsertUser(new User { Id = newId, Name = "new@foo.ch" });
-
+    // given: a journal the current user may write, and a second user to grant access to
     await _repo.UpsertJournal(
       new CounterJournal
       {
         Id = JournalId,
-        Permissions = new UserPermissions { { OwnerId, new PermissionDefinition { Kind = PermissionKind.Write } } }
+        Permissions = new UserPermissions
+        {
+          { CurrentUserId, new PermissionDefinition { Kind = PermissionKind.Write } }
+        }
       }
     );
 
     // when
-    CommandResult result = await new EditJournalPermissionsCommandExecutor(_repo).Execute(
+    CommandResult result = await CreateExecutor().Execute(
       new EditJournalPermissionsCommand
       {
         JournalId = JournalId,
-        Permissions = new Dictionary<string, PermissionKind> { { "new@foo.ch", PermissionKind.Read } }
+        Permissions = new Dictionary<string, PermissionKind> { { OtherUserName, PermissionKind.Read } }
       }
     );
 
     // then
     IJournal journal = (await _repo.GetJournal(JournalId))!;
-    journal.Permissions.Should().ContainKey(OwnerId);
-    journal.Permissions.Should().ContainKey(newId);
+    journal.Permissions.Should().ContainKey(CurrentUserId);
+    journal.Permissions.Should().ContainKey(_otherUserId);
 
     result.EntityId.Should().Be(JournalId);
-    result.AffectedUserIds.Should().BeEquivalentTo(OwnerId, newId);
+    result.AffectedUserIds.Should().BeEquivalentTo(CurrentUserId, _otherUserId);
   }
 
   [Test]
@@ -76,18 +90,106 @@ public class EditJournalPermissionsCommandExecutorShould
       new CounterJournal
       {
         Id = JournalId,
-        Permissions = new UserPermissions { { OwnerId, new PermissionDefinition { Kind = PermissionKind.Write } } }
+        Permissions = new UserPermissions
+        {
+          { CurrentUserId, new PermissionDefinition { Kind = PermissionKind.Write } }
+        }
       }
     );
 
     // when
-    CommandResult result = await new EditJournalPermissionsCommandExecutor(_repo).Execute(
+    CommandResult result = await CreateExecutor().Execute(
       new EditJournalPermissionsCommand { JournalId = JournalId }
     );
 
     // then
     IJournal journal = (await _repo.GetJournal(JournalId))!;
-    journal.Permissions.Should().ContainKey(OwnerId);
-    result.AffectedUserIds.Should().BeEquivalentTo(OwnerId);
+    journal.Permissions.Should().ContainKey(CurrentUserId);
+    result.AffectedUserIds.Should().BeEquivalentTo(CurrentUserId);
+  }
+
+  [Test]
+  public async Task Throw_WithNoPermissionsAtAll()
+  {
+    // Modifying permissions is a write: without it, a user could grant themselves (or others)
+    // access to a journal they can merely see - or not even that. Pinned because this guard was
+    // once lost in a refactoring without any test noticing.
+    await CreateJournalOwnedByOtherUser();
+
+    Assert.ThrowsAsync<NotAllowedOperationException>(
+      async () => { await ModifyPermissionsAsCurrentUser(); }
+    );
+
+    await AssertNoUserRecordWasCreatedForNewcomer();
+  }
+
+  [Test]
+  public async Task Throw_WithOnlyReadPermissions()
+  {
+    await CreateJournalOwnedByOtherUser();
+    await GrantCurrentUserPermission(PermissionKind.Read);
+
+    Assert.ThrowsAsync<NotAllowedOperationException>(
+      async () => { await ModifyPermissionsAsCurrentUser(); }
+    );
+
+    await AssertNoUserRecordWasCreatedForNewcomer();
+  }
+
+  [Test]
+  public async Task ModifyPermissions_WithWritePermissions()
+  {
+    await CreateJournalOwnedByOtherUser();
+    await GrantCurrentUserPermission(PermissionKind.Write);
+
+    await ModifyPermissionsAsCurrentUser();
+
+    IJournal journal = (await _repo.GetJournal(JournalId))!;
+    var newcomerId = (await _repo.GetUser("newcomer@foo.ch"))!.Id;
+    journal.Permissions.Should().ContainKey(newcomerId!);
+  }
+
+  private EditJournalPermissionsCommandExecutor CreateExecutor()
+  {
+    return new EditJournalPermissionsCommandExecutor(_userScopedRepo, _permissionsEnsurer);
+  }
+
+  private async Task CreateJournalOwnedByOtherUser()
+  {
+    await _repo.UpsertJournal(
+      new CounterJournal
+      {
+        Id = JournalId,
+        UserId = _otherUserId
+      }
+    );
+  }
+
+  private async Task ModifyPermissionsAsCurrentUser()
+  {
+    await CreateExecutor().Execute(
+      new EditJournalPermissionsCommand
+      {
+        JournalId = JournalId,
+        Permissions = new Dictionary<string, PermissionKind> { { "newcomer@foo.ch", PermissionKind.Read } }
+      }
+    );
+  }
+
+  private async Task GrantCurrentUserPermission(PermissionKind kind)
+  {
+    IJournal journal = (await _repo.GetJournal(JournalId))!;
+    await _permissionsEnsurer.EnsurePermissions(
+      journal,
+      new Dictionary<string, PermissionKind> { { CurrentUserName, kind } }
+    );
+    await _repo.UpsertJournal(journal);
+  }
+
+  // pins that write access is checked BEFORE PermissionsEnsurer runs: a rejected caller must not
+  // cause user records to be created as a side effect
+  private async Task AssertNoUserRecordWasCreatedForNewcomer()
+  {
+    (await _repo.GetUser("newcomer@foo.ch")).Should().BeNull();
   }
 }

--- a/api/Engraved.Core.Tests/Source/Application/DispatcherShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/DispatcherShould.cs
@@ -240,11 +240,6 @@ public class FakeUserRestrictedRepository(Lazy<IUser> currentUser) : IUserRestri
     throw new NotImplementedException();
   }
 
-  public Task ModifyJournalPermissions(string journalId, Dictionary<string, PermissionKind> permissions)
-  {
-    throw new NotImplementedException();
-  }
-
   public Task<IEntry[]> GetEntriesForJournal(
     string journalId,
     DateTime? fromDate,
@@ -277,6 +272,11 @@ public class FakeUserRestrictedRepository(Lazy<IUser> currentUser) : IUserRestri
   }
 
   public Task DeleteEntry(string entryId)
+  {
+    throw new NotImplementedException();
+  }
+
+  public Task DeleteEntriesForJournal(string journalId)
   {
     throw new NotImplementedException();
   }

--- a/api/Engraved.Core/Source/Application/Commands/Journals/Delete/DeleteJournalCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Journals/Delete/DeleteJournalCommandExecutor.cs
@@ -1,21 +1,24 @@
-﻿using Engraved.Core.Application.Persistence;
+using Engraved.Core.Application.Persistence;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Notifications;
 
 namespace Engraved.Core.Application.Commands.Journals.Delete;
 
-public class DeleteJournalCommandExecutor(IJournalRepository repository)
+public class DeleteJournalCommandExecutor(IJournalRepository journalRepository, IEntryRepository entryRepository)
   : ICommandExecutor<DeleteJournalCommand>
 {
   public async Task<CommandResult> Execute(DeleteJournalCommand command)
   {
-    IJournal? journal = await repository.GetJournal(command.JournalId);
+    IJournal? journal = await journalRepository.GetJournal(command.JournalId);
     if (journal == null)
     {
       return new CommandResult();
     }
 
-    await repository.DeleteJournal(command.JournalId);
+    // a journal's entries die with it - this cascade is a use-case rule and therefore lives here,
+    // not in the repository
+    await entryRepository.DeleteEntriesForJournal(command.JournalId);
+    await journalRepository.DeleteJournal(command.JournalId);
 
     return new CommandResult(command.JournalId, journal.Permissions.GetUserIdsWithAccess());
   }

--- a/api/Engraved.Core/Source/Application/Commands/Journals/EditPermissions/EditJournalPermissionsCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Journals/EditPermissions/EditJournalPermissionsCommandExecutor.cs
@@ -1,13 +1,15 @@
-﻿using Engraved.Core.Application.Persistence;
+using Engraved.Core.Application.Permissions;
+using Engraved.Core.Application.Persistence;
 using Engraved.Core.Domain.Journals;
+using Engraved.Core.Domain.Permissions;
 
 namespace Engraved.Core.Application.Commands.Journals.EditPermissions;
 
-public class EditJournalPermissionsCommandExecutor(IJournalRepository repository)
-  : ICommandExecutor<EditJournalPermissionsCommand>
+public class EditJournalPermissionsCommandExecutor(
+  IUserRestrictedRepository repository,
+  PermissionsEnsurer permissionsEnsurer
+) : ICommandExecutor<EditJournalPermissionsCommand>
 {
-  private readonly IJournalRepository _repository = repository;
-
   public async Task<CommandResult> Execute(EditJournalPermissionsCommand command)
   {
     if (string.IsNullOrEmpty(command.JournalId))
@@ -15,18 +17,29 @@ public class EditJournalPermissionsCommandExecutor(IJournalRepository repository
       throw new InvalidCommandException(command, $"{nameof(EditJournalPermissionsCommand.JournalId)} is required");
     }
 
-    IJournal journalBefore = (await _repository.GetJournal(command.JournalId))!;
+    IJournal? journal = await repository.GetJournal(command.JournalId);
+
+    // Modifying permissions requires write access. The UpsertJournal write guard below would also
+    // reject, but checking up front keeps PermissionsEnsurer from creating user records on behalf
+    // of a caller that is not allowed to grant anything.
+    if (!JournalAccessPolicy.HasAccess(journal, repository.CurrentUser.Value.Id, PermissionKind.Write))
+    {
+      throw new NotAllowedOperationException("Journal doesn't exist or you do not have permissions.");
+    }
+
+    string[] userIdsBefore = journal!.Permissions.GetUserIdsWithAccess();
 
     if (command.Permissions?.Count > 0)
     {
-      await _repository.ModifyJournalPermissions(command.JournalId, command.Permissions);
+      // EnsurePermissions creates records for users that receive a permission for the first time
+      // and mutates journal.Permissions in place; the upsert persists the modified journal.
+      await permissionsEnsurer.EnsurePermissions(journal, command.Permissions);
+      await repository.UpsertJournal(journal);
     }
 
-    IJournal journalAfter = (await _repository.GetJournal(command.JournalId))!;
-
     // users are affected that have permissions before or after
-    var userIdsWithAccess = journalBefore.Permissions.GetUserIdsWithAccess()
-      .Union(journalAfter.Permissions.GetUserIdsWithAccess())
+    var userIdsWithAccess = userIdsBefore
+      .Union(journal.Permissions.GetUserIdsWithAccess())
       .Distinct()
       .ToArray();
 

--- a/api/Engraved.Core/Source/Application/Persistence/IEntryRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IEntryRepository.cs
@@ -29,5 +29,9 @@ public interface IEntryRepository
 
   Task DeleteEntry(string entryId);
 
+  // deletes all entries of the given journal in one operation; used by the journal-deletion use case
+  // (DeleteJournalCommandExecutor), which owns the "a journal's entries die with it" rule
+  Task DeleteEntriesForJournal(string journalId);
+
   Task<IEntry?> GetEntry(string entryId);
 }

--- a/api/Engraved.Core/Source/Application/Persistence/IJournalRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/IJournalRepository.cs
@@ -1,5 +1,4 @@
 using Engraved.Core.Domain.Journals;
-using Engraved.Core.Domain.Permissions;
 
 namespace Engraved.Core.Application.Persistence;
 
@@ -20,6 +19,4 @@ public interface IJournalRepository
   Task<UpsertResult> UpsertJournal(IJournal journal);
 
   Task DeleteJournal(string journalId);
-
-  Task ModifyJournalPermissions(string journalId, Dictionary<string, PermissionKind> permissions);
 }

--- a/api/Engraved.Persistence.Mongo.Tests/Source/UserRestrictedMongoRepositoryShould.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/UserRestrictedMongoRepositoryShould.cs
@@ -284,8 +284,11 @@ public class UserRestrictedMongoRepositoryShould
   }
 
   [Test]
-  public async Task DeleteJournal_AndItsEntries()
+  public async Task DeleteJournal_DeletesOnlyTheJournalDocument()
   {
+    // deleting a journal's entries is a use-case rule owned by DeleteJournalCommandExecutor (via
+    // DeleteEntriesForJournal), NOT by the repository. Pinned so the cascade cannot silently creep
+    // back into the persistence layer.
     UpsertResult journal = await _repository.UpsertJournal(
       new CounterJournal
       {
@@ -306,8 +309,22 @@ public class UserRestrictedMongoRepositoryShould
 
     await _repository.DeleteJournal(journal.EntityId);
 
-    (await _repository.GetAllJournals()).Length.Should().Be(0);
     (await _repository.Journals.CountDocumentsAsync(FilterDefinition<JournalDocument>.Empty)).Should().Be(0);
-    (await _repository.Entries.CountDocumentsAsync(FilterDefinition<EntryDocument>.Empty)).Should().Be(0);
+    (await _repository.Entries.CountDocumentsAsync(FilterDefinition<EntryDocument>.Empty)).Should().Be(1);
+  }
+
+  [Test]
+  public async Task DeleteEntriesForJournal_DeletesAllEntriesOfThatJournal()
+  {
+    UpsertResult journal = await _repository.UpsertJournal(new CounterJournal { UserId = _currentUserId });
+    UpsertResult otherJournal = await _repository.UpsertJournal(new CounterJournal { UserId = _currentUserId });
+
+    await _repository.UpsertEntry(new CounterEntry { ParentId = journal.EntityId, UserId = _currentUserId });
+    await _repository.UpsertEntry(new CounterEntry { ParentId = journal.EntityId, UserId = _currentUserId });
+    await _repository.UpsertEntry(new CounterEntry { ParentId = otherJournal.EntityId, UserId = _currentUserId });
+
+    await _repository.DeleteEntriesForJournal(journal.EntityId);
+
+    (await _repository.Entries.CountDocumentsAsync(FilterDefinition<EntryDocument>.Empty)).Should().Be(1);
   }
 }

--- a/api/Engraved.Persistence.Mongo.Tests/Source/UserRestrictedMongoRepository_Permissions_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/UserRestrictedMongoRepository_Permissions_Should.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Engraved.Core.Application.Permissions;
 using Engraved.Core.Application.Persistence;
 using Engraved.Core.Domain.Entries;
 using Engraved.Core.Domain.Journals;
@@ -54,10 +55,7 @@ public class UserRestrictedMongoRepository_Permissions_Should
       }
     );
 
-    await _repository.ModifyJournalPermissions(
-      otherJournal.EntityId,
-      new Dictionary<string, PermissionKind> { { OtherUserName + "_another_one", PermissionKind.Write } }
-    );
+    await GivePermissions(otherJournal.EntityId, OtherUserName + "_another_one", PermissionKind.Write);
 
     IJournal[] allJournals = await _userRestrictedRepository.GetAllJournals();
 
@@ -114,10 +112,7 @@ public class UserRestrictedMongoRepository_Permissions_Should
       }
     );
 
-    await _repository.ModifyJournalPermissions(
-      otherJournal.EntityId,
-      new Dictionary<string, PermissionKind> { { OtherUserName + "_another_one", PermissionKind.Write } }
-    );
+    await GivePermissions(otherJournal.EntityId, OtherUserName + "_another_one", PermissionKind.Write);
 
     await _repository.UpsertEntry(
       new CounterEntry
@@ -333,41 +328,9 @@ public class UserRestrictedMongoRepository_Permissions_Should
     (await _repository.GetEntry(entryId)).Should().BeNull();
   }
 
-  [Test]
-  public async Task ModifyJournalPermissions_NotPossible_WithNoPermissionsAtAll()
-  {
-    // Modifying permissions is a write: without it, a user could grant themselves (or others)
-    // access to a journal they can merely see - or not even that. Pinned because this guard was
-    // once lost in a refactoring without any test noticing.
-    string journalId = await CreateJournalForOtherUser();
-
-    Assert.ThrowsAsync<NotAllowedOperationException>(
-      async () => { await ModifyPermissionsAsMe(journalId); }
-    );
-  }
-
-  [Test]
-  public async Task ModifyJournalPermissions_NotPossible_WithOnlyReadPermissions()
-  {
-    string journalId = await CreateJournalForOtherUser();
-    await GiveMePermissions(journalId, PermissionKind.Read);
-
-    Assert.ThrowsAsync<NotAllowedOperationException>(
-      async () => { await ModifyPermissionsAsMe(journalId); }
-    );
-  }
-
-  [Test]
-  public async Task ModifyJournalPermissions_Possible_WithWritePermissions()
-  {
-    string journalId = await CreateJournalForOtherUser();
-    await GiveMePermissions(journalId, PermissionKind.Write);
-
-    await ModifyPermissionsAsMe(journalId);
-
-    IJournal journal = (await _repository.GetJournal(journalId))!;
-    journal.Permissions.Should().ContainKey(_otherUserId);
-  }
+  // Modifying journal permissions is no longer a repository operation: the use case (including its
+  // write-permission check) lives in EditJournalPermissionsCommandExecutor and is pinned by
+  // EditJournalPermissionsCommandExecutorShould.
 
   [Test]
   public async Task GetEntry_IsUnscoped_ReturnsEntry_EvenWithoutJournalPermission()
@@ -468,19 +431,23 @@ public class UserRestrictedMongoRepository_Permissions_Should
     newNotesValues.Should().Be(entry.Notes);
   }
 
-  private async Task ModifyPermissionsAsMe(string journalId)
-  {
-    await _userRestrictedRepository.ModifyJournalPermissions(
-      journalId,
-      new Dictionary<string, PermissionKind> { { OtherUserName, PermissionKind.Read } }
-    );
-  }
-
   private async Task GiveMePermissions(string journalId, PermissionKind kind)
   {
-    await _repository.ModifyJournalPermissions(
-      journalId,
-      new Dictionary<string, PermissionKind> { { CurrentUserName, kind } }
+    await GivePermissions(journalId, CurrentUserName, kind);
+  }
+
+  // grants directly through the unrestricted repository (the same steps
+  // EditJournalPermissionsCommandExecutor performs for the client-facing use case)
+  private async Task GivePermissions(string journalId, string userName, PermissionKind kind)
+  {
+    IJournal journal = (await _repository.GetJournal(journalId))!;
+
+    var permissionsEnsurer = new PermissionsEnsurer(_repository, _repository.UpsertUser);
+    await permissionsEnsurer.EnsurePermissions(
+      journal,
+      new Dictionary<string, PermissionKind> { { userName, kind } }
     );
+
+    await _repository.UpsertJournal(journal);
   }
 }

--- a/api/Engraved.Persistence.Mongo/Source/Repositories/MongoEntryRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Repositories/MongoEntryRepository.cs
@@ -177,6 +177,13 @@ public class MongoEntryRepository(MongoDatabaseClient mongoDatabaseClient, Mongo
     await EntriesCollection.DeleteOneAsync(MongoUtil.GetDocumentByIdFilter<EntryDocument>(entryId));
   }
 
+  public async Task DeleteEntriesForJournal(string journalId)
+  {
+    await EntriesCollection.DeleteManyAsync(
+      Builders<EntryDocument>.Filter.Where(d => d.ParentId == journalId)
+    );
+  }
+
   // Unscoped primitive: GetEntry does NOT enforce read-permission on the parent journal. The
   // client-facing single-entry read enforces access in GetEntryQueryExecutor; command executors use
   // it as a load-for-modify primitive and rely on the subsequent UpsertEntry/DeleteEntry write

--- a/api/Engraved.Persistence.Mongo/Source/Repositories/MongoJournalRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Repositories/MongoJournalRepository.cs
@@ -1,9 +1,7 @@
 using System.Linq.Expressions;
-using Engraved.Core.Application.Permissions;
 using Engraved.Core.Application.Persistence;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Permissions;
-using Engraved.Persistence.Mongo.DocumentTypes.Entries;
 using Engraved.Persistence.Mongo.DocumentTypes.Journals;
 using Engraved.Persistence.Mongo.Scoping;
 using MongoDB.Bson;
@@ -16,10 +14,7 @@ namespace Engraved.Persistence.Mongo.Repositories;
 public class MongoJournalRepository(MongoDatabaseClient mongoDatabaseClient, IReadScope readScope)
   : IJournalRepository
 {
-  private readonly MongoUserRepository _userRepository = new(mongoDatabaseClient);
-
   private IMongoCollection<JournalDocument> JournalsCollection => mongoDatabaseClient.JournalsCollection;
-  private IMongoCollection<EntryDocument> EntriesCollection => mongoDatabaseClient.EntriesCollection;
 
   public async Task<IJournal[]> GetAllJournals(
     string? searchText = null,
@@ -131,6 +126,8 @@ public class MongoJournalRepository(MongoDatabaseClient mongoDatabaseClient, IRe
     return MongoUtil.CreateUpsertResult(journal.Id, replaceOneResult);
   }
 
+  // deletes only the journal document itself - deleting its entries is a use-case rule owned by
+  // DeleteJournalCommandExecutor (via IEntryRepository.DeleteEntriesForJournal)
   public async Task DeleteJournal(string journalId)
   {
     IJournal? journal = await GetJournal(journalId);
@@ -139,32 +136,9 @@ public class MongoJournalRepository(MongoDatabaseClient mongoDatabaseClient, IRe
       return;
     }
 
-    // cascading use-case logic (a journal's entries die with it) - candidate to move up into
-    // DeleteJournalCommandExecutor in a follow-up
-    await EntriesCollection.DeleteManyAsync(
-      Builders<EntryDocument>.Filter.Where(d => d.ParentId == journalId)
-    );
-
     await JournalsCollection.DeleteOneAsync(
       MongoUtil.GetDocumentByIdFilter<JournalDocument>(journalId)
     );
-  }
-
-  public async Task ModifyJournalPermissions(string journalId, Dictionary<string, PermissionKind> permissions)
-  {
-    IJournal? journal = await GetJournal(journalId);
-    if (journal == null)
-    {
-      // should we throw here?
-      return;
-    }
-
-    // deliberately uses the plain user repository: granting a permission may create the receiving
-    // user's record, which the ownership guard on the public UpsertUser would (rightly) reject
-    var permissionsEnsurer = new PermissionsEnsurer(_userRepository, _userRepository.UpsertUser);
-    await permissionsEnsurer.EnsurePermissions(journal, permissions);
-
-    await UpsertJournal(journal);
   }
 
   private async Task<IJournal?> GetJournal(string journalId, PermissionKind permissionKind, IReadScope scope)

--- a/api/Engraved.Persistence.Mongo/Source/Repositories/UserRestrictedEntryRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Repositories/UserRestrictedEntryRepository.cs
@@ -70,4 +70,10 @@ public class UserRestrictedEntryRepository(MongoEntryRepository entryRepository,
     await writeGuard.EnsureUserHasWritePermission(entry.ParentId);
     await entryRepository.DeleteEntry(entryId);
   }
+
+  public async Task DeleteEntriesForJournal(string journalId)
+  {
+    await writeGuard.EnsureUserHasWritePermission(journalId);
+    await entryRepository.DeleteEntriesForJournal(journalId);
+  }
 }

--- a/api/Engraved.Persistence.Mongo/Source/Repositories/UserRestrictedJournalRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Repositories/UserRestrictedJournalRepository.cs
@@ -1,6 +1,5 @@
 using Engraved.Core.Application.Persistence;
 using Engraved.Core.Domain.Journals;
-using Engraved.Core.Domain.Permissions;
 
 namespace Engraved.Persistence.Mongo.Repositories;
 
@@ -61,11 +60,5 @@ public class UserRestrictedJournalRepository(MongoJournalRepository journalRepos
   {
     await writeGuard.EnsureUserHasWritePermission(journalId);
     await journalRepository.DeleteJournal(journalId);
-  }
-
-  public async Task ModifyJournalPermissions(string journalId, Dictionary<string, PermissionKind> permissions)
-  {
-    await writeGuard.EnsureUserHasWritePermission(journalId);
-    await journalRepository.ModifyJournalPermissions(journalId, permissions);
   }
 }

--- a/api/Engraved.Persistence.Mongo/Source/UnrestrictedMongoRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/UnrestrictedMongoRepository.cs
@@ -89,11 +89,6 @@ public class UnrestrictedMongoRepository : IUnrestrictedRepository
     return _journalRepository.DeleteJournal(journalId);
   }
 
-  public Task ModifyJournalPermissions(string journalId, Dictionary<string, PermissionKind> permissions)
-  {
-    return _journalRepository.ModifyJournalPermissions(journalId, permissions);
-  }
-
   public Task<IEntry[]> GetEntriesForJournal(
     string journalId,
     DateTime? fromDate = null,
@@ -138,6 +133,11 @@ public class UnrestrictedMongoRepository : IUnrestrictedRepository
   public Task DeleteEntry(string entryId)
   {
     return _entryRepository.DeleteEntry(entryId);
+  }
+
+  public Task DeleteEntriesForJournal(string journalId)
+  {
+    return _entryRepository.DeleteEntriesForJournal(journalId);
   }
 
   public Task<IEntry?> GetEntry(string entryId)

--- a/api/Engraved.Persistence.Mongo/Source/UserRestrictedMongoRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/UserRestrictedMongoRepository.cs
@@ -95,11 +95,6 @@ public class UserRestrictedMongoRepository : IUserRestrictedRepository
     return _journalRepository.DeleteJournal(journalId);
   }
 
-  public Task ModifyJournalPermissions(string journalId, Dictionary<string, PermissionKind> permissions)
-  {
-    return _journalRepository.ModifyJournalPermissions(journalId, permissions);
-  }
-
   public Task<IEntry[]> GetEntriesForJournal(
     string journalId,
     DateTime? fromDate = null,
@@ -144,6 +139,11 @@ public class UserRestrictedMongoRepository : IUserRestrictedRepository
   public Task DeleteEntry(string entryId)
   {
     return _entryRepository.DeleteEntry(entryId);
+  }
+
+  public Task DeleteEntriesForJournal(string journalId)
+  {
+    return _entryRepository.DeleteEntriesForJournal(journalId);
   }
 
   public Task<IEntry?> GetEntry(string entryId)


### PR DESCRIPTION
## Summary

Follow-up to #2945/#2946 and the final planned step of the persistence restructuring: the last two pieces of use-case logic move out of the repositories into the executors that own those use cases.

**Journal deletion cascade** — the rule that a journal's entries die with it now lives in `DeleteJournalCommandExecutor`, composed from two single-collection primitives:

- `IEntryRepository.DeleteEntriesForJournal(journalId)` (new; write-guarded in `UserRestrictedEntryRepository`, so the permission story is unchanged: no permission / read-only → `NotAllowedOperationException` before anything is deleted)
- `IJournalRepository.DeleteJournal(journalId)` now deletes **only** the journal document

**Permission editing** — `ModifyJournalPermissions` is removed from `IJournalRepository` entirely. `EditJournalPermissionsCommandExecutor` performs the use case itself:

1. explicit `JournalAccessPolicy` write check — deliberately **before** `PermissionsEnsurer` runs, preserving the strict ordering from #2946: a rejected caller cannot cause user records to be created as a side effect (pinned by test)
2. `PermissionsEnsurer.EnsurePermissions` (mutates the journal's permissions, creating records for first-time grantees)
3. the (write-guarded) `UpsertJournal` persists the change

`PermissionsEnsurer` is registered in DI over the **plain** user repository, since granting a permission may legitimately create *another* user's record — the same reasoning previously buried inside `MongoJournalRepository`, now visible in the composition root.

## Test changes

- The three `ModifyJournalPermissions` permission-pinning tests moved from the repository suite to `EditJournalPermissionsCommandExecutorShould`, extended with "no user record leaked on rejection" assertions.
- The repository suites now pin the inverse contract: `DeleteJournal` deletes only the journal document, so the cascade cannot silently creep back into the persistence layer; `DeleteEntriesForJournal` gets its own test.
- `DeleteJournalCommandExecutorShould` gains the cascade test (moved from the repo suite).
- `StartupSmokeShould` now also resolves the edit-permissions executor — the only executor with a non-repository dependency — so a broken `PermissionsEnsurer` registration fails in tests rather than at runtime.

## Behavior notes

- Editing permissions of a nonexistent or inaccessible journal now throws `NotAllowedOperationException` instead of surfacing a `NullReferenceException` from the executor (the old code null-forgave the journal load).
- `MongoJournalRepository` no longer depends on the user repository or the entries collection — each per-aggregate repository now touches exactly one collection.

## Verification

`dotnet build` clean, `dotnet test` green: 250/250 (Api 33, Core 111, Persistence.Mongo 106).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
