### PR TITLE
Improve rolling average: fill time gaps and use shrinking edge window

### DIFF
--- a/app/src/components/details/chart/dataSets/createDataSets.ts
+++ b/app/src/components/details/chart/dataSets/createDataSets.ts
@@ -6,6 +6,7 @@ import { IDataSet } from "./IDataSet";
 import { IJournalAttributes } from "../../../../serverApi/IJournalAttributes";
 import { IChartUiProps } from "../IChartProps";
 import { movingAverage } from "./movingAverage";
+import { fillGaps } from "./fillGaps";
 
 export function createDataSets(
   entries: IEntry[],
@@ -36,8 +37,11 @@ function entriesToDataSet(
 ): IDataSet {
   let data = transform(entries, journal, groupByTime);
 
-  if (chartUiProps?.rollingAverage && chartUiProps.rollingAverage > 0) {
-    data = movingAverage(data, chartUiProps.rollingAverage);
+  if (chartUiProps?.rollingAverage && chartUiProps.rollingAverage > 1) {
+    data = movingAverage(
+      fillGaps(data, journal.type, groupByTime),
+      chartUiProps.rollingAverage,
+    );
   }
 
   // todo: we use indexer here to get (only) the first item. what if there's more?

--- a/app/src/components/details/chart/dataSets/fillGaps.test.ts
+++ b/app/src/components/details/chart/dataSets/fillGaps.test.ts
@@ -1,0 +1,81 @@
+import { fillGaps } from "./fillGaps";
+import { ITransformedEntry } from "../transformation/ITransformedEntry";
+import { GroupByTime } from "../consolidation/GroupByTime";
+import { JournalType } from "../../../../serverApi/JournalType";
+
+describe("fillGaps", () => {
+  it("should insert zero values for missing days", () => {
+    const results = fillGaps(
+      [getEntry(new Date(2026, 0, 1), 3), getEntry(new Date(2026, 0, 4), 6)],
+      JournalType.Counter,
+      GroupByTime.Day,
+    );
+
+    expect(results.length).toBe(4);
+    expect(results.map((r) => r.y)).toEqual([3, 0, 0, 6]);
+    expect(results[1].x).toEqual(new Date(2026, 0, 2));
+    expect(results[2].x).toEqual(new Date(2026, 0, 3));
+    expect(results[1].entries).toEqual([]);
+  });
+
+  it("should insert zero values for missing months across year boundary", () => {
+    const results = fillGaps(
+      [getEntry(new Date(2025, 10, 1), 3), getEntry(new Date(2026, 1, 1), 6)],
+      JournalType.Timer,
+      GroupByTime.Month,
+    );
+
+    expect(results.length).toBe(4);
+    expect(results.map((r) => r.y)).toEqual([3, 0, 0, 6]);
+    expect(results[1].x).toEqual(new Date(2025, 11, 1));
+    expect(results[2].x).toEqual(new Date(2026, 0, 1));
+  });
+
+  it("should not insert anything for consecutive days", () => {
+    const results = fillGaps(
+      [getEntry(new Date(2026, 0, 1), 3), getEntry(new Date(2026, 0, 2), 6)],
+      JournalType.Counter,
+      GroupByTime.Day,
+    );
+
+    expect(results.length).toBe(2);
+    expect(results.map((r) => r.y)).toEqual([3, 6]);
+  });
+
+  it("should sort entries chronologically", () => {
+    const results = fillGaps(
+      [getEntry(new Date(2026, 0, 3), 6), getEntry(new Date(2026, 0, 1), 3)],
+      JournalType.Counter,
+      GroupByTime.Day,
+    );
+
+    expect(results.length).toBe(3);
+    expect(results.map((r) => r.y)).toEqual([3, 0, 6]);
+  });
+
+  it("should not fill gaps for gauge journals", () => {
+    const entries = [
+      getEntry(new Date(2026, 0, 1), 3),
+      getEntry(new Date(2026, 0, 4), 6),
+    ];
+
+    const results = fillGaps(entries, JournalType.Gauge, GroupByTime.Day);
+
+    expect(results).toBe(entries);
+  });
+
+  it("should not fill gaps without time grouping", () => {
+    const entries = [
+      getEntry(new Date(2026, 0, 1), 3),
+      getEntry(new Date(2026, 0, 4), 6),
+    ];
+
+    const results = fillGaps(entries, JournalType.Counter, GroupByTime.None);
+
+    expect(results).toBe(entries);
+  });
+});
+
+function getEntry(x: Date, y: number): ITransformedEntry {
+  return { x, y, entries: [] };
+}

--- a/app/src/components/details/chart/dataSets/fillGaps.ts
+++ b/app/src/components/details/chart/dataSets/fillGaps.ts
@@ -1,0 +1,49 @@
+import { addDays, addMonths, isBefore } from "date-fns";
+import { ITransformedEntry } from "../transformation/ITransformedEntry";
+import { GroupByTime } from "../consolidation/GroupByTime";
+import { JournalType } from "../../../../serverApi/JournalType";
+
+// a missing group is only semantically zero for journals where the
+// value is an amount per period (counts, tracked minutes). for gauges
+// a gap means "no measurement", so inserting zeros would distort the chart.
+const zeroFillableJournalTypes = [JournalType.Counter, JournalType.Timer];
+
+export function fillGaps(
+  entries: ITransformedEntry[],
+  journalType: JournalType,
+  groupByTime: GroupByTime,
+): ITransformedEntry[] {
+  if (
+    groupByTime === GroupByTime.None ||
+    !zeroFillableJournalTypes.includes(journalType) ||
+    entries.length < 2
+  ) {
+    return entries;
+  }
+
+  const sorted = [...entries].sort(
+    (a, b) => new Date(a.x).getTime() - new Date(b.x).getTime(),
+  );
+
+  const filled: ITransformedEntry[] = [sorted[0]];
+
+  for (let i = 1; i < sorted.length; i++) {
+    const nextDate = new Date(sorted[i].x);
+    let gapDate = addPeriod(new Date(filled[filled.length - 1].x), groupByTime);
+
+    while (isBefore(gapDate, nextDate)) {
+      filled.push({ x: gapDate, y: 0, entries: [] });
+      gapDate = addPeriod(gapDate, groupByTime);
+    }
+
+    filled.push(sorted[i]);
+  }
+
+  return filled;
+}
+
+function addPeriod(date: Date, groupByTime: GroupByTime): Date {
+  return groupByTime === GroupByTime.Day
+    ? addDays(date, 1)
+    : addMonths(date, 1);
+}

--- a/app/src/components/details/chart/dataSets/movingAverage.test.ts
+++ b/app/src/components/details/chart/dataSets/movingAverage.test.ts
@@ -8,21 +8,29 @@ describe("movingAverage", () => {
     );
   });
 
-  it("should return original values if fewer than groupSize", () => {
-    const results = movingAverage([getEntry(1), getEntry(2)], 3);
+  it("should return original values for groupSize 1", () => {
+    const results = movingAverage([getEntry(1), getEntry(2)], 1);
 
     expect(results.length).toBe(2);
     expect(results[0].y).toBe(1);
     expect(results[1].y).toBe(2);
   });
 
+  it("should shrink window if fewer entries than groupSize", () => {
+    const results = movingAverage([getEntry(1), getEntry(2)], 3);
+
+    expect(results.length).toBe(2);
+    expect(results[0].y).toBe((1 + 2) / 2);
+    expect(results[1].y).toBe((1 + 2) / 2);
+  });
+
   it("should calculate average with 3 entries and groupSize 3", () => {
     const results = movingAverage([getEntry(11), getEntry(20), getEntry(9)], 3);
 
     expect(results.length).toBe(3);
-    expect(results[0].y).toBe((11 + 11 + 20) / 3);
+    expect(results[0].y).toBe((11 + 20) / 2);
     expect(results[1].y).toBe((11 + 20 + 9) / 3);
-    expect(results[2].y).toBe((20 + 9 + 9) / 3);
+    expect(results[2].y).toBe((20 + 9) / 2);
   });
 
   it("should calculate average with 4 entries and groupSize 3", () => {
@@ -32,10 +40,10 @@ describe("movingAverage", () => {
     );
 
     expect(results.length).toBe(4);
-    expect(results[0].y).toBe((10 + 10 + 20) / 3);
+    expect(results[0].y).toBe((10 + 20) / 2);
     expect(results[1].y).toBe((10 + 20 + 10) / 3);
     expect(results[2].y).toBe((20 + 10 + 20) / 3);
-    expect(results[3].y).toBe((10 + 20 + 20) / 3);
+    expect(results[3].y).toBe((10 + 20) / 2);
   });
 
   it("should calculate average with 5 entries and groupSize 5", () => {
@@ -45,11 +53,11 @@ describe("movingAverage", () => {
     );
 
     expect(results.length).toBe(5);
-    expect(results[0].y).toBe((10 + 10 + 10 + 20 + 10) / 5);
-    expect(results[1].y).toBe((10 + 10 + 20 + 10 + 20) / 5);
+    expect(results[0].y).toBe((10 + 20 + 10) / 3);
+    expect(results[1].y).toBe((10 + 20 + 10 + 20) / 4);
     expect(results[2].y).toBe((10 + 20 + 10 + 20 + 10) / 5);
-    expect(results[3].y).toBe((20 + 10 + 20 + 10 + 10) / 5);
-    expect(results[4].y).toBe((10 + 20 + 10 + 10 + 10) / 5);
+    expect(results[3].y).toBe((20 + 10 + 20 + 10) / 4);
+    expect(results[4].y).toBe((10 + 20 + 10) / 3);
   });
 });
 

--- a/app/src/components/details/chart/dataSets/movingAverage.ts
+++ b/app/src/components/details/chart/dataSets/movingAverage.ts
@@ -8,34 +8,23 @@ export function movingAverage(
     throw new Error("Group size must be an odd number.");
   }
 
-  if (entries.length < groupSize) {
+  if (groupSize <= 1) {
     return entries;
   }
 
-  return entries.map((e, i) => {
-    return { ...e, y: getAverage(entries, i, groupSize) };
-  });
-}
+  const halfWindow = (groupSize - 1) / 2;
 
-function getAverage(
-  entries: ITransformedEntry[],
-  index: number,
-  groupSize: number,
-): number {
-  let sum = 0;
-  const startIndex = index - Math.floor(groupSize / 2);
+  return entries.map((entry, index) => {
+    // towards the edges the window shrinks to the points that actually
+    // exist, so no value is ever counted more than once
+    const startIndex = Math.max(0, index - halfWindow);
+    const endIndex = Math.min(entries.length - 1, index + halfWindow);
 
-  for (let i = 0; i < groupSize; i++) {
-    const currentIndex = startIndex + i;
-
-    if (currentIndex < 0) {
-      sum += entries[0].y;
-    } else if (currentIndex >= entries.length) {
-      sum += entries[entries.length - 1].y;
-    } else {
-      sum += entries[startIndex + i].y;
+    let sum = 0;
+    for (let i = startIndex; i <= endIndex; i++) {
+      sum += entries[i].y;
     }
-  }
 
-  return sum / groupSize;
+    return { ...entry, y: sum / (endIndex - startIndex + 1) };
+  });
 }


### PR DESCRIPTION
The chart's rolling average was index-based and used replicate padding at the edges. This PR fixes both weaknesses:

- **Time-gap filling** (`fillGaps.ts`, new): missing days/months are inserted as zero-value points before smoothing for counter and timer journals, where a gap semantically means 0. Previously gaps were invisibly skipped, so a "7-point average" could blend values months apart and was biased upward. Gauge journals are excluded (a gap means "no measurement", not 0), as is ungrouped data.
- **Shrinking edge window** (`movingAverage.ts`): edges now average only the points that actually exist instead of repeating the first/last value, which counted endpoints multiple times and pinned the line toward them.
- The no-op smoothing pass when the slider is at 0 is skipped.

Tests updated/added for both.

Note: smoothed lines for counter/timer journals now dip toward zero across empty periods — the honest picture, but sparse journals will look different than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)