### PR TITLE
Support an optional title on log book entries

### DIFF
--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertLogBookEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertLogBookEntryCommandExecutorShould.cs
@@ -47,6 +47,40 @@ public class UpsertLogBookEntryCommandExecutorShould
   }
 
   [Test]
+  public async Task StoreOptionalTitle()
+  {
+    var command = new UpsertLogBookEntryCommand
+    {
+      JournalId = JournalId,
+      Notes = "some notes",
+      Title = "some title",
+      DateTime = _fakeDateService.UtcNow
+    };
+
+    await new UpsertLogBookEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
+
+    IEntry entry = (await _testRepository.GetEntriesForJournal(JournalId)).Single();
+    ((LogBookEntry)entry).Title.Should().Be("some title");
+  }
+
+  [Test]
+  public async Task CreateNew_WithoutTitle()
+  {
+    var command = new UpsertLogBookEntryCommand
+    {
+      JournalId = JournalId,
+      Notes = "some notes",
+      Title = null,
+      DateTime = _fakeDateService.UtcNow
+    };
+
+    await new UpsertLogBookEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
+
+    IEntry entry = (await _testRepository.GetEntriesForJournal(JournalId)).Single();
+    ((LogBookEntry)entry).Title.Should().BeNull();
+  }
+
+  [Test]
   public void Throw_WhenNotesIsNull()
   {
     var command = new UpsertLogBookEntryCommand

--- a/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/LogBook/UpsertLogBookEntryCommand.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/LogBook/UpsertLogBookEntryCommand.cs
@@ -4,6 +4,8 @@ namespace Engraved.Core.Application.Commands.Entries.Upsert.LogBook;
 
 public class UpsertLogBookEntryCommand : BaseUpsertScrapLikeEntryCommand
 {
+  public string? Title { get; set; }
+
   public override JournalType GetSupportedJournalType()
   {
     return JournalType.LogBook;

--- a/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/LogBook/UpsertLogBookEntryCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/LogBook/UpsertLogBookEntryCommandExecutor.cs
@@ -58,5 +58,6 @@ public class UpsertLogBookEntryCommandExecutor(
     // LogBook entries are date-only: strip the time component so that at most one entry can exist
     // per day, regardless of the time the client happens to send.
     entry.DateTime = DateTime.SpecifyKind(command.DateTime!.Value.Date, DateTimeKind.Utc);
+    entry.Title = command.Title;
   }
 }

--- a/api/Engraved.Core/Source/Domain/Entries/LogBookEntry.cs
+++ b/api/Engraved.Core/Source/Domain/Entries/LogBookEntry.cs
@@ -2,6 +2,8 @@
 
 public class LogBookEntry : BaseEntry
 {
+  public string? Title { get; set; }
+
   public override double GetValue()
   {
     throw new NotImplementedException();

--- a/api/Engraved.Persistence.Mongo.Tests/Source/DocumentTypes/EntryDocumentMapperShould.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/DocumentTypes/EntryDocumentMapperShould.cs
@@ -191,7 +191,8 @@ public class EntryDocumentMapperShould
       Notes = "n0t3",
       ParentId = Key,
       DateTime = DateTime.UtcNow,
-      JournalAttributeValues = new Dictionary<string, string[]> { { "wh@t3v3r", ["bla"] } }
+      JournalAttributeValues = new Dictionary<string, string[]> { { "wh@t3v3r", ["bla"] } },
+      Title = "log book title"
     };
 
     EntryDocument document = EntryDocumentMapper.ToDocument(entry);
@@ -201,6 +202,7 @@ public class EntryDocumentMapperShould
 
     var logBookDocument = document as LogBookEntryDocument;
     logBookDocument.Should().NotBeNull();
+    logBookDocument!.Title.Should().Be(entry.Title);
   }
 
   [Test]
@@ -212,7 +214,8 @@ public class EntryDocumentMapperShould
       Notes = "n0t3",
       ParentId = Key,
       DateTime = DateTime.UtcNow,
-      JournalAttributeValues = new Dictionary<string, string[]> { { "wh@t3v3r", ["bla"] } }
+      JournalAttributeValues = new Dictionary<string, string[]> { { "wh@t3v3r", ["bla"] } },
+      Title = "log book title"
     };
 
     IEntry entry = EntryDocumentMapper.FromDocument(document);
@@ -220,6 +223,7 @@ public class EntryDocumentMapperShould
     AssertEqual(document, entry);
     var logBookEntry = entry as LogBookEntry;
     logBookEntry.Should().NotBeNull();
+    logBookEntry!.Title.Should().Be(document.Title);
   }
 
   private static void AssertEqual(IEntry expected, EntryDocument actual)

--- a/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/EntryDocumentMapper.cs
+++ b/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/EntryDocumentMapper.cs
@@ -39,7 +39,10 @@ public static class EntryDocumentMapper
 
       LogBookEntry le => MapToDocument(
         le,
-        new LogBookEntryDocument()
+        new LogBookEntryDocument
+        {
+          Title = le.Title
+        }
       ),
 
       _ => throw new ArgumentOutOfRangeException(nameof(entry), entry, null)
@@ -85,7 +88,10 @@ public static class EntryDocumentMapper
 
       LogBookEntryDocument lbed => MapFromDocument(
         lbed,
-        new LogBookEntry()
+        new LogBookEntry
+        {
+          Title = lbed.Title
+        }
       ),
 
       TimerEntryDocument ted => MapFromDocument(

--- a/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/LogBookEntryDocument.cs
+++ b/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/LogBookEntryDocument.cs
@@ -1,3 +1,6 @@
 ﻿namespace Engraved.Persistence.Mongo.DocumentTypes.Entries;
 
-public class LogBookEntryDocument : EntryDocument { }
+public class LogBookEntryDocument : EntryDocument
+{
+  public string? Title { get; set; }
+}

--- a/app/src/components/common/itemRows/ScrapEntryGoToItemRow.tsx
+++ b/app/src/components/common/itemRows/ScrapEntryGoToItemRow.tsx
@@ -37,7 +37,7 @@ export const ScrapEntryGoToItemRow: React.FC<{
   );
 };
 
-// log book entries have no title, so we show the beginning of their notes instead
+// log book entries may have no title, in which case we show the beginning of their notes instead
 function getNotesExcerpt(notes: string | undefined): string | undefined {
   if (!notes) {
     return undefined;

--- a/app/src/components/details/scraps/LogBookInner.tsx
+++ b/app/src/components/details/scraps/LogBookInner.tsx
@@ -63,21 +63,21 @@ export const LogBookInner: React.FC = () => {
     >
       {isEditMode ? (
         <>
-          <SimpleDateSelector
-            setDate={setDate}
-            date={date}
-            shouldDisableDate={(d) => usedDays.has(getDayKey(d))}
-          />
           <TitleEditorHost>
             <RichTextEditor
               initialValue={title}
-              placeholder="Title (optional)"
+              placeholder="Title"
               isTitle={true}
               setValue={setTitle}
               onFocus={() => setHasTitleFocus(true)}
               onBlur={() => setHasTitleFocus(false)}
             />
           </TitleEditorHost>
+          <SimpleDateSelector
+            setDate={setDate}
+            date={date}
+            shouldDisableDate={(d) => usedDays.has(getDayKey(d))}
+          />
         </>
       ) : (
         <TitleRow
@@ -108,7 +108,7 @@ export const LogBookInner: React.FC = () => {
 
 // Mirrors the title styling of ParseableDate, which the (scrap) title editor uses elsewhere.
 const TitleEditorHost = styled("div")`
-  margin-top: ${(p) => p.theme.spacing(1)};
+  margin-bottom: ${(p) => p.theme.spacing(1)};
 
   .ngrvd-text-editor {
     font-size: 1.8rem;

--- a/app/src/components/details/scraps/LogBookInner.tsx
+++ b/app/src/components/details/scraps/LogBookInner.tsx
@@ -1,8 +1,10 @@
 import React from "react";
+import { styled } from "@mui/material";
 import { useScrapContext } from "./ScrapContext";
 import { ScrapMarkdown } from "./markdown/ScrapMarkdown";
 import { ReadonlyTitle } from "../../overview/ReadonlyTitle";
 import { Markdown } from "./markdown/Markdown";
+import { RichTextEditor } from "../../common/RichTextEditor";
 import { SimpleDateSelector } from "../../common/DateSelector";
 import { format } from "date-fns";
 import { getDayKey, utcToDateOnly } from "../../../util/utils";
@@ -20,6 +22,9 @@ export const LogBookInner: React.FC = () => {
     scrapToRender,
     hasFocus,
     notes,
+    title,
+    setTitle,
+    setHasTitleFocus,
   } = useScrapContext();
 
   // Fetch the journal's entries directly (rather than via JournalContext) so day-deduplication
@@ -57,11 +62,23 @@ export const LogBookInner: React.FC = () => {
       data-scrap-type={scrapToRender.scrapType}
     >
       {isEditMode ? (
-        <SimpleDateSelector
-          setDate={setDate}
-          date={date}
-          shouldDisableDate={(d) => usedDays.has(getDayKey(d))}
-        />
+        <>
+          <SimpleDateSelector
+            setDate={setDate}
+            date={date}
+            shouldDisableDate={(d) => usedDays.has(getDayKey(d))}
+          />
+          <TitleEditorHost>
+            <RichTextEditor
+              initialValue={title}
+              placeholder="Title (optional)"
+              isTitle={true}
+              setValue={setTitle}
+              onFocus={() => setHasTitleFocus(true)}
+              onBlur={() => setHasTitleFocus(false)}
+            />
+          </TitleEditorHost>
+        </>
       ) : (
         <TitleRow
           hasFocus={hasFocus}
@@ -74,7 +91,10 @@ export const LogBookInner: React.FC = () => {
             title={
               <Markdown
                 useBasic={true}
-                value={format(date, "EEEE, do MMMM yy")}
+                value={
+                  format(date, "EEEE, do MMMM yy") +
+                  (title?.trim() ? ` - ${title.trim()}` : "")
+                }
               />
             }
           />
@@ -85,3 +105,14 @@ export const LogBookInner: React.FC = () => {
     </div>
   );
 };
+
+// Mirrors the title styling of ParseableDate, which the (scrap) title editor uses elsewhere.
+const TitleEditorHost = styled("div")`
+  margin-top: ${(p) => p.theme.spacing(1)};
+
+  .ngrvd-text-editor {
+    font-size: 1.8rem;
+    color: ${(p) => p.theme.palette.primary.main};
+    font-weight: lighter;
+  }
+`;


### PR DESCRIPTION
## What

Log book entries can now have an optional **title**, displayed after the date in view mode, e.g. **"Wednesday, 15th July 26 - My super title"**. In edit mode a new "Title (optional)" input appears below the date selector; clearing it removes the title again.

## How

The frontend already sent a \`title\` in the upsert payload (log books reuse the scrap editing flow and context) — the backend simply dropped it. So most of the change is plumbing the property through the backend:

- \`LogBookEntry\`, \`UpsertLogBookEntryCommand\`, \`UpsertLogBookEntryCommandExecutor\`: new nullable \`Title\`, persisted on upsert
- \`LogBookEntryDocument\` + \`EntryDocumentMapper\`: stored in Mongo and mapped in both directions
- \`LogBookInner.tsx\`: title editor in edit mode (styled like the scrap title editor), \`date - title\` rendering in view mode
- \`ScrapEntryGoToItemRow.tsx\`: comment update only — search results already prefer \`title\` over the notes excerpt, so titled log book entries show their title there automatically

The title is optional: notes remain the only required content (unchanged validation), and existing entries without the field deserialize to \`null\` and render exactly as before.

## Testing

- New/extended unit tests: title round-trip in \`EntryDocumentMapperShould\`, storing/omitting the title in \`UpsertLogBookEntryCommandExecutorShould\`
- Verified end-to-end against a local build (e2e mode): created a log book, added an entry with title → renders \`Wednesday, 15th July 26 - My super title\` and survives reload; cleared the title → plain date, no dangling separator; title-only entry without notes is still rejected by validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)