### PR TITLE
Debounce scrap checklist save in non-edit mode

### DIFF
--- a/app/src/components/details/scraps/list/ScrapList.tsx
+++ b/app/src/components/details/scraps/list/ScrapList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { styled, Typography, useTheme } from "@mui/material";
 import { ScrapListItem } from "./ScrapListItem";
 import { ListItemCollection } from "./ListItemCollection";
@@ -26,6 +26,10 @@ import SyncAltOutlined from "@mui/icons-material/SyncAltOutlined";
 import { IAction } from "../../../common/actions/IAction";
 import { ScrapType } from "../../../../serverApi/IScrapEntry";
 import { ActionIconButtonGroup } from "../../../common/actions/ActionIconButtonGroup";
+
+// Checking multiple items in quick succession should not fire a save request
+// per click - debounce so only the last change within this window is saved.
+const SAVE_DEBOUNCE_MS = 2000;
 
 export const ScrapList: React.FC<{ editModeActions?: IAction[] }> = ({
   editModeActions,
@@ -59,6 +63,10 @@ export const ScrapList: React.FC<{ editModeActions?: IAction[] }> = ({
       listItemCollection.giveFocus(listItemCollection.items.length - 1, "end");
     }
   }, [isEditMode, listItemCollection]);
+
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout>>(0);
+
+  useEffect(() => () => clearTimeout(saveTimeoutRef.current), []);
 
   const sensors = useSensors(useSensor(TouchSensor), useSensor(PointerSensor));
 
@@ -123,7 +131,10 @@ export const ScrapList: React.FC<{ editModeActions?: IAction[] }> = ({
                       listItemCollection.updateItem(index, updatedItem);
 
                       if (!isEditMode) {
-                        upsertScrap(getItemsAsJson(listItemCollection.items));
+                        clearTimeout(saveTimeoutRef.current);
+                        saveTimeoutRef.current = setTimeout(() => {
+                          upsertScrap(getItemsAsJson(listItemCollection.items));
+                        }, SAVE_DEBOUNCE_MS);
                       }
                     }}
                   />

--- a/tests/src/poms/scrapListComponent.ts
+++ b/tests/src/poms/scrapListComponent.ts
@@ -45,6 +45,13 @@ export class ScrapListComponent {
     return this.expectSaved(isUpdate);
   }
 
+  // Checking an item in non-edit mode debounces the save - wait for it to
+  // complete before relying on the change being persisted (e.g. before a
+  // reload).
+  async waitForDebouncedSave(isUpdate?: boolean) {
+    return this.expectSaved(isUpdate);
+  }
+
   private async expectSaved(isUpdate?: boolean) {
     const appBar = this.page.getByTestId("app-alert-bar");
     await expect(appBar).toContainText(

--- a/tests/tests/scrapList.spec.ts
+++ b/tests/tests/scrapList.spec.ts
@@ -39,11 +39,15 @@ test("add scrap journal, add list entry and add/delete/modify", async ({
 
   await scrapList.dblClickToEdit();
 
-  await (await scrapList.getListItemByText(secondItemText))
+  await (
+    await scrapList.getListItemByText(secondItemText)
+  )
     .getByLabel("Delete")
     .click();
 
-  await (await scrapList.getListItemByText(firstItemText))
+  await (
+    await scrapList.getListItemByText(firstItemText)
+  )
     .getByRole("checkbox")
     .check();
 
@@ -63,13 +67,17 @@ test("add scrap journal, add list entries and mark as checked in non-edit mode",
   await scrapList.addListItem(secondItemText);
   await scrapList.clickSave();
 
-  await (await scrapList.getListItemByText(firstItemText))
+  await (
+    await scrapList.getListItemByText(firstItemText)
+  )
     .getByRole("checkbox")
     .check();
 
   await expect(
     (await scrapList.getListItemByText(firstItemText)).getByRole("checkbox"),
   ).toBeChecked();
+
+  await scrapList.waitForDebouncedSave(true);
 
   await page.reload();
 
@@ -185,7 +193,9 @@ test("deleting all checked items keeps one empty line, which is not persisted", 
 
   // check the only item and delete all checked items - the list must not end up
   // empty, a single blank line has to remain so there is something to type into.
-  await (await scrapList.getListItemByText(firstItemText))
+  await (
+    await scrapList.getListItemByText(firstItemText)
+  )
     .getByRole("checkbox")
     .check();
 
@@ -414,7 +424,9 @@ async function testThatEveryUpdateLeadsToNewInitialState(
     (await scrapList.getListItemByText(firstItemText)).getByRole("checkbox"),
   ).toBeChecked();
 
-  await (await scrapList.getListItemByText(firstItemText))
+  await (
+    await scrapList.getListItemByText(firstItemText)
+  )
     .getByRole("checkbox")
     .uncheck();
 
@@ -422,9 +434,13 @@ async function testThatEveryUpdateLeadsToNewInitialState(
     (await scrapList.getListItemByText(firstItemText)).getByRole("checkbox"),
   ).not.toBeChecked();
 
-  await (await scrapList.getListItemByText(firstItemText))
+  await (
+    await scrapList.getListItemByText(firstItemText)
+  )
     .getByRole("checkbox")
     .check();
+
+  await scrapList.waitForDebouncedSave(true);
 
   await page.reload();
 


### PR DESCRIPTION
## Summary
- Checking multiple items in a scrap checklist while viewing it (non-edit mode) fired an immediate save request per click, which could cause several requests in a few seconds
- Debounces the save (2s) so only the last change within the window is persisted
- Edit mode behavior is unchanged (no save on checkbox toggle there)

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Manually verify: open a checklist scrap in view mode, check several items quickly, confirm only one save request fires after the pause
- [ ] Manually verify: open a checklist scrap in edit mode, toggle items, confirm behavior is unchanged from before

🤖 Generated with [Claude Code](https://claude.com/claude-code)