### PR TITLE
Local-first Phase 1: offline entry writes with durable outbox

### DIFF
--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertGaugeEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertGaugeEntryCommandExecutorShould.cs
@@ -127,6 +127,83 @@ public class UpsertGaugeEntryCommandExecutorShould
     gaugeEntry.Value.Should().Be(value);
   }
 
+  [Test]
+  public async Task Create_WithClientGeneratedId()
+  {
+    const string journalId = "60703c3b00000000000000a5";
+    await _testRepository.UpsertJournal(new GaugeJournal { Id = journalId });
+
+    const string clientGeneratedId = "66703c3b00000000000000f1";
+
+    var command = new UpsertGaugeEntryCommand
+    {
+      Id = clientGeneratedId,
+      IsNew = true,
+      JournalId = journalId,
+      Value = 42
+    };
+
+    CommandResult commandResult =
+      await new UpsertGaugeEntryCommandExecutor(_testRepository, _testRepository, new FakeDateService()).Execute(
+        command
+      );
+
+    commandResult.Discarded.Should().BeFalse();
+    commandResult.EntityId.Should().Be(clientGeneratedId);
+    (await _testRepository.CountAllEntries()).Should().Be(1);
+    (await _testRepository.GetEntry(clientGeneratedId)).Should().NotBeNull();
+  }
+
+  [Test]
+  public async Task Create_WithClientGeneratedId_IsIdempotentOnReplay()
+  {
+    const string journalId = "60703c3b00000000000000a6";
+    await _testRepository.UpsertJournal(new GaugeJournal { Id = journalId });
+
+    var command = new UpsertGaugeEntryCommand
+    {
+      Id = "66703c3b00000000000000f2",
+      IsNew = true,
+      JournalId = journalId,
+      Value = 42
+    };
+
+    var executor = new UpsertGaugeEntryCommandExecutor(_testRepository, _testRepository, new FakeDateService());
+    await executor.Execute(command);
+    CommandResult replayResult = await executor.Execute(command);
+
+    replayResult.Discarded.Should().BeFalse();
+    replayResult.EntityId.Should().Be(command.Id);
+    (await _testRepository.CountAllEntries()).Should().Be(1);
+  }
+
+  [Test]
+  public async Task Discard_UpdateOfEntryThatNoLongerExists()
+  {
+    const string journalId = "60703c3b00000000000000a7";
+    await _testRepository.UpsertJournal(new GaugeJournal { Id = journalId });
+
+    // not flagged IsNew, i.e. an update - but the entry does not exist (any more)
+    var command = new UpsertGaugeEntryCommand
+    {
+      Id = "66703c3b00000000000000f3",
+      JournalId = journalId,
+      Value = 42
+    };
+
+    CommandResult commandResult =
+      await new UpsertGaugeEntryCommandExecutor(_testRepository, _testRepository, new FakeDateService()).Execute(
+        command
+      );
+
+    commandResult.Discarded.Should().BeTrue();
+    commandResult.EntityId.Should().Be(command.Id);
+    (await _testRepository.CountAllEntries()).Should().Be(0);
+
+    // a discarded command must not touch the journal either
+    (await _testRepository.GetJournal(journalId))!.EditedOn.Should().BeNull();
+  }
+
   private static void AssertJournalAttributeValuesEqual(
     Dictionary<string, string[]> d1,
     Dictionary<string, string[]> d2

--- a/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertTimerEntryCommandExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Commands/Entries/Upsert/UpsertTimerEntryCommandExecutorShould.cs
@@ -141,6 +141,49 @@ public class UpsertTimerEntryCommandExecutorShould
   }
 
   [Test]
+  public async Task Create_WithClientGeneratedIdAndExplicitDates_DoesNotReDecideAgainstActiveEntry()
+  {
+    // an entry is already running ...
+    var activeEntryId = "60703c3b00000000000000e4";
+    await _testRepository.UpsertEntry(
+      new TimerEntry
+      {
+        Id = activeEntryId,
+        ParentId = JournalId,
+        StartDate = _fakeDateService.UtcNow.AddMinutes(-60)
+      }
+    );
+
+    // ... and a start decided by the client (e.g. while offline) arrives with a client-generated
+    // id and an explicit start date
+    DateTime clientStartDate = _fakeDateService.UtcNow.AddMinutes(-5);
+
+    var command = new UpsertTimerEntryCommand
+    {
+      Id = "66703c3b00000000000000e5",
+      IsNew = true,
+      JournalId = JournalId,
+      StartDate = clientStartDate
+    };
+
+    CommandResult result =
+      await new UpsertTimerEntryCommandExecutor(_testRepository, _testRepository, _fakeDateService).Execute(command);
+
+    // the command is applied as sent: the client's start date is kept (not replaced by "now" at
+    // replay time), and the already-active entry is left alone instead of being auto-stopped -
+    // "at most one open timer" is reconciled eventually, not re-decided here
+    result.EntityId.Should().Be(command.Id);
+    (await _testRepository.CountAllEntries()).Should().Be(2);
+
+    var createdEntry = await _testRepository.GetEntry(command.Id) as TimerEntry;
+    createdEntry!.StartDate.Should().BeCloseTo(clientStartDate, TimeSpan.FromMilliseconds(100));
+    createdEntry.EndDate.Should().BeNull();
+
+    var activeEntry = await _testRepository.GetEntry(activeEntryId) as TimerEntry;
+    activeEntry!.EndDate.Should().BeNull();
+  }
+
+  [Test]
   public async Task UpdateExistingEntry_ChangeExistingStartDateWhenNoEndDate()
   {
     var entryId = "60703c3b00000000000000e3";

--- a/api/Engraved.Core/Source/Application/Commands/CommandResult.cs
+++ b/api/Engraved.Core/Source/Application/Commands/CommandResult.cs
@@ -6,6 +6,10 @@ public class CommandResult
 
   public string[] AffectedUserIds { get; } = [];
 
+  // true when the command was accepted but deliberately not applied, because it targeted an
+  // entity that no longer exists (e.g. an offline edit replayed after the entry was deleted).
+  public bool Discarded { get; }
+
   public CommandResult(string entityId, string[] affectedUserIds)
   {
     EntityId = entityId;
@@ -13,4 +17,15 @@ public class CommandResult
   }
 
   public CommandResult() { }
+
+  private CommandResult(string entityId)
+  {
+    EntityId = entityId;
+    Discarded = true;
+  }
+
+  public static CommandResult CreateDiscarded(string entityId)
+  {
+    return new CommandResult(entityId);
+  }
 }

--- a/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/BaseUpsertEntryCommand.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/BaseUpsertEntryCommand.cs
@@ -6,6 +6,11 @@ public abstract class BaseUpsertEntryCommand : ICommand
 {
   public string? Id { get; set; }
 
+  // true when the client created this entry itself (with a client-generated Id), e.g. while
+  // offline. Only such commands may materialize a new entry under an explicit Id; an update whose
+  // entry no longer exists is discarded instead of resurrecting the deleted entry.
+  public bool IsNew { get; set; }
+
   public string JournalId { get; set; } = null!;
 
   public string? Notes { get; set; }

--- a/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/BaseUpsertEntryCommandExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Commands/Entries/Upsert/BaseUpsertEntryCommandExecutor.cs
@@ -24,31 +24,29 @@ public abstract class BaseUpsertEntryCommandExecutor<TCommand, TEntry, TJournal>
     var journal =
       await JournalCommandUtil.LoadAndValidateJournal<TJournal>(JournalRepository, command, command.JournalId);
 
-    await ValidateCommand(command, journal);
-
-    UpsertResult result = await UpsertEntry(command, journal);
-
-    await UpdateJournal(JournalRepository, DateService, journal);
-
-    return new CommandResult(result.EntityId, journal.Permissions.GetUserIdsWithAccess());
-  }
-
-  private async Task ValidateCommand(TCommand command, TJournal journal)
-  {
     EnsureCompatibleJournalType(command, journal);
+
+    TEntry? entry = await GetOrCreateNewEntry(command, journal);
+    if (entry == null)
+    {
+      // the command targets an entry that no longer exists (deleted since the client cached it,
+      // e.g. while the command sat in an offline outbox) -> discard it instead of resurrecting
+      // the deleted entry. Deliberately before the remaining validation: a discarded command must
+      // not fail on rules (like the log book's one-entry-per-day) it no longer participates in.
+      return CommandResult.CreateDiscarded(command.Id!);
+    }
 
     ValidateJournalAttributes(command, journal);
     await PerformTypeSpecificValidation(command);
-  }
-
-  private async Task<UpsertResult> UpsertEntry(TCommand command, TJournal journal)
-  {
-    TEntry entry = await GetOrCreateNewEntry(command, journal);
 
     SetCommonValues(command, entry);
     SetTypeSpecificValues(command, entry);
 
-    return await EntryRepository.UpsertEntry(entry);
+    UpsertResult result = await EntryRepository.UpsertEntry(entry);
+
+    await UpdateJournal(JournalRepository, DateService, journal);
+
+    return new CommandResult(result.EntityId, journal.Permissions.GetUserIdsWithAccess());
   }
 
   private static async Task UpdateJournal(IJournalRepository repository, IDateService dateService, TJournal journal)
@@ -123,21 +121,27 @@ public abstract class BaseUpsertEntryCommandExecutor<TCommand, TEntry, TJournal>
     }
   }
 
-  private async Task<TEntry> GetOrCreateNewEntry(TCommand command, TJournal journal)
-  {
-    return await LoadEntryById(command)
-           ?? await LoadEntryToUpdate(command, journal)
-           ?? new TEntry();
-  }
-
-  private async Task<TEntry?> LoadEntryById(TCommand command)
+  // Returns null when the command must be discarded (see Execute). Commands with an Id either
+  // update the existing entry (which doubles as the idempotent replay of a create) or - only when
+  // flagged IsNew - create it under the client-generated Id. An update whose entry is gone was
+  // deleted in the meantime and must not come back to life via the upsert.
+  private async Task<TEntry?> GetOrCreateNewEntry(TCommand command, TJournal journal)
   {
     if (!string.IsNullOrEmpty(command.Id))
     {
-      return (TEntry)(await EntryRepository.GetEntry(command.Id))!;
+      TEntry? existingEntry = (TEntry?)await EntryRepository.GetEntry(command.Id);
+      if (existingEntry != null)
+      {
+        return existingEntry;
+      }
+
+      return command.IsNew
+        ? new TEntry { Id = command.Id }
+        : null;
     }
 
-    return null;
+    return await LoadEntryToUpdate(command, journal)
+           ?? new TEntry();
   }
 
   protected InvalidCommandException CreateInvalidCommandException(TCommand command, string message)

--- a/app/src/components/details/add/UpsertEntryAction.tsx
+++ b/app/src/components/details/add/UpsertEntryAction.tsx
@@ -34,7 +34,12 @@ import { ScrapsJournalType } from "../../../journalTypes/ScrapsJournalType";
 import { IScrapEntry, ScrapType } from "../../../serverApi/IScrapEntry";
 import { useItemAction } from "../../common/actions/searchParamHooks";
 import { LogBookJournalType } from "../../../journalTypes/LogBookJournalType";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import {
+  onlineManager,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { queryKeysFactory } from "../../../serverApi/reactQuery/queryKeysFactory";
 
 export const UpsertEntryAction: React.FC<{
   journal?: IJournal;
@@ -247,8 +252,20 @@ const UpsertEntryActionInternal: React.FC<{
 
       case JournalType.Timer: {
         const timerCommand = command as IUpsertTimerEntryCommand;
-        timerCommand.startDate = startDate ? new Date(startDate) : undefined;
-        timerCommand.endDate = endDate ? new Date(endDate) : undefined;
+        // the client decides and sends explicit dates instead of leaving them empty and letting
+        // the server fill in "now" at apply time: saving without dates means "start now" for a
+        // new entry and "stop now" for the running one. This keeps the command idempotent when
+        // it is replayed from the offline outbox at a later point in time.
+        timerCommand.startDate = startDate
+          ? new Date(startDate)
+          : entry
+            ? undefined
+            : new Date();
+        timerCommand.endDate = endDate
+          ? new Date(endDate)
+          : entry && !(entry as ITimerEntry).endDate
+            ? new Date()
+            : undefined;
         break;
       }
     }
@@ -270,6 +287,8 @@ const useUpsertEntryData = (
     initialEntryParentId: string | null;
   };
 
+  const queryClient = useQueryClient();
+
   const { data } = useSuspenseQuery({
     queryKey: [
       "upsert-entry-data",
@@ -290,11 +309,37 @@ const useUpsertEntryData = (
         ? params.initialEntry
         : journal.type !== JournalType.Timer
           ? null
-          : await ServerApi.getActiveEntry(journal.id ?? "");
+          : await getActiveEntry(journal);
 
       return { journal, entry };
     },
   });
 
   return data;
+
+  // The active (i.e. running) timer entry decides whether saving means start or stop. While
+  // offline the server cannot be asked, so it is derived from the cached entries instead - the
+  // client deciding over local state is exactly what makes the resulting command replayable.
+  async function getActiveEntry(journal: IJournal): Promise<IEntry | null> {
+    try {
+      return await ServerApi.getActiveEntry(journal.id ?? "");
+    } catch (e) {
+      if (onlineManager.isOnline()) {
+        throw e;
+      }
+
+      const cachedEntryLists = queryClient.getQueriesData<ITimerEntry[]>({
+        queryKey: queryKeysFactory.prefixes.journalEntries(journal.id ?? ""),
+      });
+
+      for (const [, entries] of cachedEntryLists) {
+        const activeEntry = entries?.find((en) => en.startDate && !en.endDate);
+        if (activeEntry) {
+          return activeEntry;
+        }
+      }
+
+      return null;
+    }
+  }
 };

--- a/app/src/serverApi/ICommandResult.ts
+++ b/app/src/serverApi/ICommandResult.ts
@@ -1,3 +1,6 @@
 export interface ICommandResult {
   entityId: string;
+  // true when the command was accepted but deliberately not applied, because it targeted an
+  // entity that no longer exists (e.g. an offline edit replayed after the entry was deleted).
+  discarded?: boolean;
 }

--- a/app/src/serverApi/commands/IUpsertEntryCommand.ts
+++ b/app/src/serverApi/commands/IUpsertEntryCommand.ts
@@ -4,6 +4,10 @@ import { IScheduleDefinition } from "../IScheduleDefinition";
 
 export interface IUpsertEntryCommand {
   id?: string;
+  // true when the client generated the id itself (offline-capable create). Only such commands may
+  // create an entry under an explicit id on the server; an update whose entry no longer exists is
+  // discarded instead (see ICommandResult.discarded).
+  isNew?: boolean;
   journalId: string;
   journalAttributeValues?: IJournalAttributeValues;
   notes?: string;

--- a/app/src/serverApi/reactQuery/ReactQueryProviderWrapper.tsx
+++ b/app/src/serverApi/reactQuery/ReactQueryProviderWrapper.tsx
@@ -1,4 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
+import { registerEntryMutationDefaults } from "./mutations/entryMutationDefaults";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
 import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
 import { del, get, set } from "idb-keyval";
@@ -24,13 +25,23 @@ const queryClient = new QueryClient({
     },
     mutations: {
       throwOnError: true,
+      // Phase 1 (local-first): a mutation fired while offline is paused (networkMode "online" is
+      // the default, made explicit here) and must survive both the wait for reconnection and a
+      // reload in between - so keep it around as long as the persisted cache itself.
+      networkMode: "online",
+      gcTime: oneDay,
     },
   },
 });
 
-// Phase 0 (local-first): persist the React Query cache to IndexedDB so the app
-// shows the last-seen data on reload and while offline. This is read-only
-// caching - offline writes / sync come in later phases.
+// entry writes are offline-capable: their mutationFns are registered as mutation defaults so
+// that mutations restored from the persisted outbox after a reload can still run
+registerEntryMutationDefaults(queryClient);
+
+// Phase 0/1 (local-first): persist the React Query cache to IndexedDB so the app
+// shows the last-seen data on reload and while offline. Since Phase 1 this also
+// persists paused mutations - the offline write outbox - which are replayed via
+// resumePausedMutations once the cache is restored (see onSuccess below).
 const persister = createAsyncStoragePersister({
   key: "engraved-query-cache",
   storage: {
@@ -59,6 +70,14 @@ export const ReactQueryProviderWrapper: React.FC<{
         // user's data restored from IndexedDB, and old-schema caches are still
         // dropped on deploy.
         buster: `${envSettings.version ?? "dev"}:${user?.id ?? "anon"}`,
+      }}
+      onSuccess={() => {
+        // the persisted cache (including the offline outbox) has been restored: replay whatever
+        // is still pending, then refetch so the UI converges on the server's state. While still
+        // offline this is safe: the replay stays paused and the refetches are skipped.
+        queryClient
+          .resumePausedMutations()
+          .then(() => queryClient.invalidateQueries());
       }}
     >
       {children}

--- a/app/src/serverApi/reactQuery/mutations/entryMutationDefaults.ts
+++ b/app/src/serverApi/reactQuery/mutations/entryMutationDefaults.ts
@@ -1,0 +1,152 @@
+import { QueryClient } from "@tanstack/react-query";
+import { ServerApi } from "../../ServerApi";
+import { IUpsertEntryCommand } from "../../commands/IUpsertEntryCommand";
+import { IJournal } from "../../IJournal";
+import { JournalType } from "../../JournalType";
+import { IEntry } from "../../IEntry";
+import { queryKeysFactory } from "../queryKeysFactory";
+
+// Phase 1 (local-first): entry writes are offline-capable. A mutation issued while offline is
+// paused by react-query, persisted to IndexedDB along with the query cache (the "outbox") and
+// replayed on reconnect or after the next app start. For that to work, everything a mutation
+// needs to run must live in its *variables* (serializable, captured at mutate() time) and its
+// mutationFn must be registered here as a mutation *default* - a function defined in a hook
+// closure would be lost on reload.
+
+export interface IUpsertEntryVariables {
+  command: IUpsertEntryCommand;
+  journalType: JournalType;
+  // journal with attribute values added by this entry (precomputed at mutate() time so the
+  // replay does not depend on component state); saved before the entry itself
+  updatedJournal?: IJournal;
+  // true when the mutation was queued while offline; the queue-time feedback (alert, dialog
+  // close) has already happened in that case, so the success handler skips it
+  queuedOffline?: boolean;
+}
+
+export interface IDeleteEntryVariables {
+  journalId: string;
+  entryId: string;
+  queuedOffline?: boolean;
+}
+
+export function registerEntryMutationDefaults(queryClient: QueryClient) {
+  queryClient.setMutationDefaults(
+    queryKeysFactory.prefixes.upsertEntryMutations(),
+    {
+      mutationFn: async (variables: IUpsertEntryVariables) => {
+        const journal = variables.updatedJournal;
+        if (journal) {
+          await ServerApi.editJournal(
+            journal.id ?? "",
+            journal.name,
+            journal.description,
+            journal.notes,
+            journal.attributes,
+            journal.thresholds,
+            journal.customProps,
+          );
+        }
+
+        return await ServerApi.upsertEntry(
+          variables.command,
+          variables.journalType.toLowerCase(),
+        );
+      },
+
+      // applies to mutations resumed from the persisted outbox after a reload; live mutations
+      // use the (overriding) handlers from useUpsertEntryMutation instead
+      onSuccess: () => invalidateAfterEntryWrite(queryClient),
+    },
+  );
+
+  queryClient.setMutationDefaults(
+    queryKeysFactory.prefixes.deleteEntryMutations(),
+    {
+      mutationFn: (variables: IDeleteEntryVariables) =>
+        ServerApi.deleteEntry(variables.entryId),
+
+      onSuccess: () => invalidateAfterEntryWrite(queryClient),
+    },
+  );
+}
+
+export async function invalidateAfterEntryWrite(queryClient: QueryClient) {
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: queryKeysFactory.prefixes.journals(),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: queryKeysFactory.prefixes.entities(),
+    }),
+  ]);
+}
+
+// Applies an upsert command to every cached entry list of its journal, so the write is visible
+// immediately - also (and especially) while offline, when the confirming refetch cannot happen.
+export function applyEntryUpsertToCache(
+  queryClient: QueryClient,
+  command: IUpsertEntryCommand,
+) {
+  queryClient.setQueriesData<IEntry[]>(
+    { queryKey: queryKeysFactory.prefixes.journalEntries(command.journalId) },
+    (entries) => {
+      if (!entries) {
+        return entries;
+      }
+
+      const optimisticEntry = createOptimisticEntry(command);
+
+      const patched = entries.some((e) => e.id === command.id)
+        ? entries.map((e) =>
+            e.id === command.id ? { ...e, ...optimisticEntry } : e,
+          )
+        : [optimisticEntry, ...entries];
+
+      // entry lists are served sorted by dateTime descending - keep that invariant
+      return patched.sort(
+        (a, b) =>
+          new Date(b.dateTime).getTime() - new Date(a.dateTime).getTime(),
+      );
+    },
+  );
+}
+
+export function removeEntryFromCache(
+  queryClient: QueryClient,
+  journalId: string,
+  entryId: string,
+) {
+  queryClient.setQueriesData<IEntry[]>(
+    { queryKey: queryKeysFactory.prefixes.journalEntries(journalId) },
+    (entries) => entries?.filter((e) => e.id !== entryId),
+  );
+}
+
+function createOptimisticEntry(command: IUpsertEntryCommand): IEntry {
+  const nowIso = new Date().toISOString();
+
+  // the type-specific command shapes (value, startDate/endDate, title, scrapType) match the
+  // corresponding entry shapes, so the command fields can be carried over as-is - except for
+  // dates, which are Date objects on commands but ISO strings on entries
+  const carriedOver: Record<string, unknown> = { ...command };
+  delete carriedOver.isNew;
+  delete carriedOver.journalId;
+  delete carriedOver.schedule;
+
+  for (const key of ["startDate", "endDate"]) {
+    if (carriedOver[key] instanceof Date) {
+      carriedOver[key] = (carriedOver[key] as Date).toISOString();
+    }
+  }
+
+  return {
+    ...carriedOver,
+    id: command.id,
+    parentId: command.journalId,
+    dateTime: command.dateTime
+      ? new Date(command.dateTime).toISOString()
+      : nowIso,
+    editedOn: nowIso,
+  } as IEntry;
+}

--- a/app/src/serverApi/reactQuery/mutations/useDeleteEntryMutation.ts
+++ b/app/src/serverApi/reactQuery/mutations/useDeleteEntryMutation.ts
@@ -1,14 +1,23 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { onlineManager, useMutation, useQueryClient } from "@tanstack/react-query";
 import { queryKeysFactory } from "../queryKeysFactory";
-import { ServerApi } from "../../ServerApi";
+import { ICommandResult } from "../../ICommandResult";
+import {
+  IDeleteEntryVariables,
+  removeEntryFromCache,
+} from "./entryMutationDefaults";
 
 export const useDeleteEntryMutation = (journalId: string, entryId: string) => {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  const mutation = useMutation<ICommandResult, Error, IDeleteEntryVariables>({
     mutationKey: queryKeysFactory.deleteEntry(journalId, entryId),
 
-    mutationFn: () => ServerApi.deleteEntry(entryId),
+    // no mutationFn here: it comes from the mutation defaults (entryMutationDefaults), so that
+    // mutations resumed from the persisted offline outbox after a reload run the same code
+
+    onMutate: (variables) => {
+      removeEntryFromCache(queryClient, variables.journalId, variables.entryId);
+    },
 
     onSuccess: async () => {
       await Promise.all([
@@ -24,4 +33,20 @@ export const useDeleteEntryMutation = (journalId: string, entryId: string) => {
       ]);
     },
   });
+
+  return {
+    ...mutation,
+    mutate: () =>
+      mutation.mutate({
+        journalId,
+        entryId,
+        queuedOffline: !onlineManager.isOnline(),
+      }),
+    mutateAsync: () =>
+      mutation.mutateAsync({
+        journalId,
+        entryId,
+        queuedOffline: !onlineManager.isOnline(),
+      }),
+  };
 };

--- a/app/src/serverApi/reactQuery/mutations/useUpsertEntryMutation.tsx
+++ b/app/src/serverApi/reactQuery/mutations/useUpsertEntryMutation.tsx
@@ -1,23 +1,22 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { onlineManager, useMutation, useQueryClient } from "@tanstack/react-query";
 import { queryKeysFactory } from "../queryKeysFactory";
 import { IUpsertEntryCommand } from "../../commands/IUpsertEntryCommand";
-import { ServerApi } from "../../ServerApi";
 import { useAppContext } from "../../../AppContext";
-import { IEntry } from "../../IEntry";
 import { ICommandResult } from "../../ICommandResult";
 import { IJournalAttributeValues } from "../../IJournalAttributeValues";
 import { IJournalAttributes } from "../../IJournalAttributes";
-import { useEditJournalMutation } from "./useEditJournalMutation";
 import { JournalType } from "../../JournalType";
 import { IJournal } from "../../IJournal";
 import { useMatchRoute } from "@tanstack/react-router";
 import { knownQueryParams } from "../../../components/common/actions/searchParamHooks";
 import { StyledLink } from "./StyledLink";
 import { getErrorAlert } from "./getErrorAlert";
-
-interface IUpsertEntryCommandVariables {
-  command: IUpsertEntryCommand;
-}
+import {
+  applyEntryUpsertToCache,
+  invalidateAfterEntryWrite,
+  IUpsertEntryVariables,
+} from "./entryMutationDefaults";
+import { generateClientId } from "../../../util/clientId";
 
 export const useUpsertEntryMutation = (
   journalId: string,
@@ -32,79 +31,75 @@ export const useUpsertEntryMutation = (
 
   const matchRoute = useMatchRoute();
 
-  const editJournalMutation = useEditJournalMutation(journalId);
-
-  return useMutation({
+  const mutation = useMutation<ICommandResult, Error, IUpsertEntryVariables>({
     mutationKey: queryKeysFactory.updateEntries(journalId, entryId ?? ""),
 
     throwOnError: false,
 
-    mutationFn: async (variables: IUpsertEntryCommandVariables) => {
-      const journalWithNewValues = journal
-        ? getJournalWithNewAttributeValues(
-            journal,
-            variables.command.journalAttributeValues ?? {},
-          )
-        : null;
+    // no mutationFn here: it comes from the mutation defaults (entryMutationDefaults), so that
+    // mutations resumed from the persisted offline outbox after a reload run the same code
 
-      if (journalWithNewValues) {
-        await editJournalMutation.mutateAsync({
-          journal: journalWithNewValues,
+    onMutate: (variables) => {
+      applyEntryUpsertToCache(queryClient, variables.command);
+
+      if (variables.queuedOffline) {
+        // the mutation is paused until the app is back online; give the queue-time feedback the
+        // success handler would otherwise give
+        setAppAlert({
+          title: "Saved offline - will be synced when reconnected",
+          type: "info",
+          relatedEntityId: variables.command.id,
         });
-      }
 
-      return await ServerApi.upsertEntry(
-        variables.command,
-        journalType.toLowerCase(),
-      );
+        onSaved?.();
+      }
     },
 
     onSuccess: async (
       result: ICommandResult,
-      variables: IUpsertEntryCommandVariables,
+      variables: IUpsertEntryVariables,
     ) => {
       const journalId = variables.command.journalId;
 
-      // Only offer a "View in journal" link when we're not already on that
-      // journal's details page (or one of its sub-routes).
-      const isOnJournalPage = matchRoute({
-        to: "/journals/details/$journalId",
-        params: { journalId },
-        fuzzy: true,
-      });
+      if (result.discarded) {
+        // the entry was deleted (e.g. on another device) while this change sat in the offline
+        // outbox; the server ignored the change instead of resurrecting the entry
+        setAppAlert({
+          title: "Entry does not exist anymore - change was discarded",
+          type: "info",
+          relatedEntityId: result.entityId,
+        });
+      } else if (!variables.queuedOffline) {
+        // Only offer a "View in journal" link when we're not already on that
+        // journal's details page (or one of its sub-routes).
+        const isOnJournalPage = matchRoute({
+          to: "/journals/details/$journalId",
+          params: { journalId },
+          fuzzy: true,
+        });
 
-      setAppAlert({
-        title: `${entryId ? "Updated" : "Added"} entry`,
-        message: !isOnJournalPage ? (
-          <>
-            <StyledLink
-              to="/journals/details/$journalId"
-              params={{ journalId }}
-              search={{ [knownQueryParams.selectedItemId]: result.entityId }}
-            >
-              View
-            </StyledLink>{" "}
-            in journal
-          </>
-        ) : null,
-        type: "success",
-        relatedEntityId: result.entityId,
-      });
+        setAppAlert({
+          title: `${entryId ? "Updated" : "Added"} entry`,
+          message: !isOnJournalPage ? (
+            <>
+              <StyledLink
+                to="/journals/details/$journalId"
+                params={{ journalId }}
+                search={{ [knownQueryParams.selectedItemId]: result.entityId }}
+              >
+                View
+              </StyledLink>{" "}
+              in journal
+            </>
+          ) : null,
+          type: "success",
+          relatedEntityId: result.entityId,
+        });
 
-      onSaved?.();
-
-      if (entryId) {
-        updateExistingEntryInCache(variables.command);
+        onSaved?.();
       }
 
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: queryKeysFactory.prefixes.journals(),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: queryKeysFactory.prefixes.entities(),
-        }),
-      ]);
+      await invalidateAfterEntryWrite(queryClient);
     },
 
     onError: (error) => {
@@ -112,35 +107,34 @@ export const useUpsertEntryMutation = (
     },
   });
 
-  function updateExistingEntryInCache(command: IUpsertEntryCommand) {
-    queryClient.setQueryData(
-      queryKeysFactory.journalEntries(journalId),
-      (entries: IEntry[]) => {
-        if (!entries) {
-          return entries;
-        }
+  return {
+    ...mutation,
+    mutate: (variables: { command: IUpsertEntryCommand }) =>
+      mutation.mutate(prepareVariables(variables.command)),
+    mutateAsync: (variables: { command: IUpsertEntryCommand }) =>
+      mutation.mutateAsync(prepareVariables(variables.command)),
+  };
 
-        return entries.map((e) =>
-          e.id === entryId ? createCacheEntry(e, command) : e,
-        );
-      },
-    );
-  }
-
-  function createCacheEntry(
-    entry: IEntry,
+  // Everything a replayed mutation needs must be captured here, in serializable variables - see
+  // entryMutationDefaults. This is also where entries get their client-generated id, so that an
+  // entry created offline has its definitive identity before ever reaching the server.
+  function prepareVariables(
     command: IUpsertEntryCommand,
-  ): IEntry {
+  ): IUpsertEntryVariables {
+    const preparedCommand: IUpsertEntryCommand = command.id
+      ? command
+      : { ...command, id: generateClientId(), isNew: true };
+
     return {
-      ...entry,
-      ...command,
-      // command.dateTime is a Date (or absent); IEntry.dateTime is an ISO
-      // string. Keep the date the user actually set instead of overwriting it
-      // with "now", and serialize as ISO to match what the server returns.
-      dateTime: command.dateTime
-        ? new Date(command.dateTime).toISOString()
-        : entry.dateTime,
-      editedOn: new Date().toISOString(),
+      command: preparedCommand,
+      journalType,
+      updatedJournal: journal
+        ? (getJournalWithNewAttributeValues(
+            journal,
+            preparedCommand.journalAttributeValues ?? {},
+          ) ?? undefined)
+        : undefined,
+      queuedOffline: !onlineManager.isOnline(),
     };
   }
 };

--- a/app/src/serverApi/reactQuery/queryKeysFactory.ts
+++ b/app/src/serverApi/reactQuery/queryKeysFactory.ts
@@ -7,6 +7,12 @@ export const queryKeysFactory = {
   prefixes: {
     journals: () => [journals],
     entities: () => ["search", "entities"],
+    // matches every cached entry list of the journal, across all filter variants
+    journalEntries: (journalId: string) => [journals, journalId, "entries"],
+    // mutation-key prefixes: mutation defaults (offline outbox replay) are registered on these,
+    // so they must be prefixes of updateEntries/deleteEntry below
+    upsertEntryMutations: () => ["entry-mutations", "upsert"],
+    deleteEntryMutations: () => ["entry-mutations", "delete"],
   },
 
   entry(entryId: string) {
@@ -61,11 +67,11 @@ export const queryKeysFactory = {
   },
 
   updateEntries(journalId: string, entryId: string) {
-    return [journals, journalId, "entry", "update", entryId];
+    return [...this.prefixes.upsertEntryMutations(), journalId, entryId];
   },
 
   deleteEntry(journalId: string, entryId: string) {
-    return [journals, journalId, "entry", "delete", entryId];
+    return [...this.prefixes.deleteEntryMutations(), journalId, entryId];
   },
 
   moveEntry(entryId: string, journalId: string) {

--- a/app/src/util/clientId.ts
+++ b/app/src/util/clientId.ts
@@ -1,0 +1,15 @@
+// Generates a Mongo-ObjectId-shaped id (24 hex chars: 4-byte unix timestamp + 8 random bytes) on
+// the client. This gives entries created while offline a stable identity before they ever reach
+// the server - the id in the outbox, in the optimistic cache and in the database is the same.
+export function generateClientId(): string {
+  const timestamp = Math.floor(Date.now() / 1000)
+    .toString(16)
+    .padStart(8, "0");
+
+  const randomBytes = crypto.getRandomValues(new Uint8Array(8));
+  const random = Array.from(randomBytes, (b) =>
+    b.toString(16).padStart(2, "0"),
+  ).join("");
+
+  return timestamp + random;
+}


### PR DESCRIPTION
Implements Phase 1 of #2933 with the descoped design discussed there: **no tombstones, no `changesSince` endpoint** — instead, commands carry create-vs-update intent and sync is a wholesale refetch on reconnect.

## What this does

Entry writes (counter, gauge, timer, logbook, scraps) now work offline: they are applied optimistically to the cached entry lists, queued in a durable outbox (React Query paused mutations persisted to IndexedDB alongside the Phase 0 query cache) and replayed on reconnect — or after the next app start if the app was closed in between.

## Backend

- `BaseUpsertEntryCommand.IsNew`: the client declares whether a command is a create (with a client-generated, ObjectId-shaped id) or an update.
- `BaseUpsertEntryCommandExecutor`: a command with an id whose entry exists is applied as an update (which doubles as the idempotent replay of a create); a missing entry + `IsNew` materializes it under the client id; a missing entry without `IsNew` means it was **deleted in the meantime → the command is discarded** (`CommandResult.Discarded`, journal untouched) instead of being resurrected by the previous blanket upsert. The discard decision runs before type-specific validation so a dead command cannot fail e.g. the log book's one-entry-per-day rule.
- **Timer: no behavioral change needed.** Commands with explicit dates already skip the server-side re-decide (`GetActiveEntry`) path; a new test pins that a replayed start keeps the client's start date and leaves an already-running entry alone ("at most one open timer" is eventually reconciled, not re-decided at replay time).

## Frontend

- `entryMutationDefaults.ts` (new): entry upsert/delete mutationFns registered as **mutation defaults**, so mutations restored from the persisted outbox after a reload can still run; everything a replay needs is captured as serializable variables at `mutate()` time (command incl. client id from `clientId.ts`, journal type, precomputed journal-attribute patch).
- `useUpsertEntryMutation` / `useDeleteEntryMutation`: optimistic cache updates in `onMutate`, "Saved offline — will be synced when reconnected" and "Entry does not exist anymore — change was discarded" alerts. Call-site signatures unchanged.
- `ReactQueryProviderWrapper`: mutation `gcTime` = one day (outlives the wait for reconnection), on restore → `resumePausedMutations()` then `invalidateQueries()`.
- Timer UI always sends explicit start/end dates (client decides start vs. stop over local state) and falls back to the cached entry list to find the active entry while offline.

## Verified

- `dotnet test`: 256 passed (incl. 4 new intent/discard tests + 1 timer replay test) · `tsc --noEmit` ✅ · `vitest`: 127 passed · `vite build` ✅
- Live against the e2e stack: offline create → optimistic entry, no network; **reload while queued → outbox replays from IndexedDB on startup**; reconnect without reload → replays on the online event; **discard round-trip** (edit offline, delete the entry via API as another device, reconnect → `discarded: true`, alert shown, entry stays deleted); timer start/stop.

## Known accepted edges (by design, see #2933 discussion)

- A discarded offline edit is dropped silently beyond the toast.
- A duplicate create-replay after a lost ack could resurrect a meanwhile-deleted entry (no tombstones).
- React Query only replays when the tab is focused *and* online — a backgrounded PWA replays on next foreground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)