### PR TITLE
Simplify DeleteButtons to fix fallow complexity gate

### DIFF
--- a/app/src/components/common/DeleteButtons.tsx
+++ b/app/src/components/common/DeleteButtons.tsx
@@ -2,6 +2,12 @@ import React, { useState } from "react";
 import { DialogFormButtonContainer } from "./FormButtonContainer";
 import { Button, styled, TextField, Typography } from "@mui/material";
 
+const entityLabels: Record<"journal" | "entry" | "user", string> = {
+  journal: "journal",
+  entry: "scrap",
+  user: "user",
+};
+
 export const DeleteButtons: React.FC<{
   onDelete: () => void;
   onCancel: () => void;
@@ -18,6 +24,21 @@ export const DeleteButtons: React.FC<{
   const [isFirstYes, setIsFirstYes] = useState(false);
   const [isSecondYes, setIsSecondYes] = useState(false);
 
+  const handleYesClick = () => {
+    if (requiresConfirmation && !isSecondYes) {
+      setIsFirstYes(true);
+      return;
+    }
+
+    onDelete();
+  };
+
+  const handleConfirmationChange = (value: string) => {
+    setIsSecondYes(
+      value.toLowerCase().trim() === confirmationValue.toLowerCase().trim(),
+    );
+  };
+
   return (
     <>
       <DialogFormButtonContainer>
@@ -27,13 +48,7 @@ export const DeleteButtons: React.FC<{
         <Button
           variant="contained"
           disabled={isFirstYes && !isSecondYes}
-          onClick={() => {
-            if (requiresConfirmation && !isSecondYes) {
-              setIsFirstYes(true);
-            } else {
-              onDelete();
-            }
-          }}
+          onClick={handleYesClick}
         >
           Yes, delete!
         </Button>
@@ -41,25 +56,12 @@ export const DeleteButtons: React.FC<{
       {isFirstYes ? (
         <ExtraContainer>
           <Typography>
-            You want to delete a{" "}
-            <b>
-              {entityType === "journal"
-                ? "journal"
-                : entityType === "user"
-                  ? "user"
-                  : "scrap"}
-            </b>
-            . Just to be really sure, please type &quot;{confirmationValue}
-            &quot; to confirm.
+            You want to delete a <b>{entityLabels[entityType]}</b>. Just to be
+            really sure, please type &quot;{confirmationValue}&quot; to confirm.
           </Typography>
           <TextField
             autoFocus={true}
-            onChange={(event) => {
-              setIsSecondYes(
-                event.target.value?.toLowerCase().trim() ===
-                  confirmationValue.toLowerCase().trim(),
-              );
-            }}
+            onChange={(event) => handleConfirmationChange(event.target.value)}
           />
         </ExtraContainer>
       ) : null}


### PR DESCRIPTION
## Summary

Fixes the fallow audit failure on `main` after merging #2963: https://github.com/PzYon/engraved/actions/runs/29875203183

## Root cause

`DeleteButtons.tsx`'s complexity crossed fallow's threshold (5 cyclomatic, 10 cognitive, CRAP 30.0) after #2963 added the `"user"` entity type and a configurable `confirmationValue` prop to support the admin delete-user flow.

## Fix

Behavior-preserving simplification, no API change:
- Extracted the click/change handlers into named functions instead of inline closures.
- Replaced the nested `entityType` ternary with a plain label lookup object.

## Verification

- Reproduced the exact CI failure locally by downloading the `fallow` CLI and running `fallow audit --changed-since <previous main tip SHA>` against a checkout of `main` — confirmed it reports the same single complexity finding.
- Applied the fix and re-ran the same command: `✓ No issues in 41 changed files`.
- `npm run types:check`, `eslint`, `vitest run` (127 tests), and `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)