### PR TITLE
Sort admin user list by last login, newest first

### DIFF
--- a/api/Engraved.Core.Tests/Source/Application/Queries/Users/GetAdminOverview/GetAdminUsersOverviewQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Users/GetAdminOverview/GetAdminUsersOverviewQueryExecutorShould.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Engraved.Core.Application.Queries.Users.GetAdminOverview;
 using Engraved.Core.Domain.Entries;
@@ -12,6 +14,8 @@ namespace Engraved.Core.Tests.Application.Queries.Users.GetAdminOverview;
 public class GetAdminUsersOverviewQueryExecutorShould
 {
   private const string UserId = "60703c3b0000000000000001";
+  private const string OtherUserId = "60703c3b0000000000000004";
+  private const string ThirdUserId = "60703c3b0000000000000005";
   private const string JournalId = "60703c3b0000000000000002";
   private const string OtherJournalId = "60703c3b0000000000000003";
 
@@ -65,5 +69,30 @@ public class GetAdminUsersOverviewQueryExecutorShould
     result.Should().ContainSingle();
     result[0].JournalsCount.Should().Be(0);
     result[0].EntriesCount.Should().Be(0);
+  }
+
+  [Test]
+  public async Task Return_MostRecentlyLoggedInUsersFirst()
+  {
+    // given
+    await _repo.UpsertUser(
+      new User { Id = UserId, Name = "oldest@x.com", LastLoginDate = new DateTime(2026, 1, 1) }
+    );
+    await _repo.UpsertUser(
+      new User { Id = OtherUserId, Name = "newest@x.com", LastLoginDate = new DateTime(2026, 3, 1) }
+    );
+    await _repo.UpsertUser(
+      new User { Id = ThirdUserId, Name = "never-logged-in@x.com", LastLoginDate = null }
+    );
+
+    // when
+    AdminUserItem[] result = await new GetAdminUsersOverviewQueryExecutor(_repo).Execute(
+      new GetAdminUsersOverviewQuery()
+    );
+
+    // then
+    result.Select(i => i.Name)
+      .Should()
+      .Equal("newest@x.com", "oldest@x.com", "never-logged-in@x.com");
   }
 }

--- a/api/Engraved.Core/Source/Application/Queries/Users/GetAdminOverview/GetAdminUsersOverviewQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Users/GetAdminOverview/GetAdminUsersOverviewQueryExecutor.cs
@@ -31,6 +31,9 @@ public class GetAdminUsersOverviewQueryExecutor(IUnrestrictedRepository unrestri
       );
     }
 
-    return items.ToArray();
+    // most recently active users first; users who never logged in (LastLoginDate null) sort last
+    return items
+      .OrderByDescending(i => i.LastLoginDate ?? DateTime.MinValue)
+      .ToArray();
   }
 }

--- a/api/Engraved.Core/Source/Application/Queries/Users/GetAdminOverview/GetAdminUsersOverviewQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Users/GetAdminOverview/GetAdminUsersOverviewQueryExecutor.cs
@@ -31,7 +31,6 @@ public class GetAdminUsersOverviewQueryExecutor(IUnrestrictedRepository unrestri
       );
     }
 
-    // most recently active users first; users who never logged in (LastLoginDate null) sort last
     return items
       .OrderByDescending(i => i.LastLoginDate ?? DateTime.MinValue)
       .ToArray();


### PR DESCRIPTION
## Summary

Sorts the `/admin` user list by last login date descending (most recently active users on top), per feedback from testing #2963 on prod. Users who never logged in (null `LastLoginDate`) sort last.

## Test plan

- Added a test covering the new sort order (including the never-logged-in case).
- Full backend suite passes (46 Api + 106 Mongo + 114 Core).
- Frontend unaffected (backend-only change); types check, vitest (127 tests), and a local `fallow audit --changed-since origin/main` run all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)