### PR TITLE
Fix stale-chunk error after deploy by driving service-worker update

### DIFF
--- a/app/src/components/common/LazyLoadSuspender.tsx
+++ b/app/src/components/common/LazyLoadSuspender.tsx
@@ -1,6 +1,7 @@
 import SwitchAccessShortcutOutlined from "@mui/icons-material/SwitchAccessShortcutOutlined";
 import { CircularProgress, Dialog, styled, Typography } from "@mui/material";
 import React, { PropsWithChildren, ReactNode, Suspense, useState } from "react";
+import { applyNewVersion } from "../../serviceWorkerUpdater";
 
 export const LazyLoadSuspender: React.FC<PropsWithChildren> = ({
   children,
@@ -44,7 +45,7 @@ const ErrorOnLazyLoad: React.FC = () => {
 
   return (
     <Dialog open={isOpen} onClose={() => setIsOpen(false)}>
-      <Host onClick={() => location.reload()}>
+      <Host onClick={() => void applyNewVersion()}>
         <SwitchAccessShortcutOutlined
           sx={{ color: "primary.main" }}
           fontSize={"large"}

--- a/app/src/components/common/actions/ActionFactory.tsx
+++ b/app/src/components/common/actions/ActionFactory.tsx
@@ -41,6 +41,7 @@ import {
 } from "./searchParamHooks";
 import AirplanemodeActive from "@mui/icons-material/AirplanemodeActive";
 import { IAppAlert } from "../../errorHandling/IAppAlert";
+import { applyNewVersion } from "../../../serviceWorkerUpdater";
 
 export class ActionFactory {
   static cancel(onClick: () => void): IAction {
@@ -440,7 +441,7 @@ export class ActionFactory {
 
     return {
       icon: <SwitchAccessShortcutOutlined fontSize="small" />,
-      onClick: () => location.reload(),
+      onClick: () => void applyNewVersion(),
       label: "New version available - click to update.",
       key: "update-to-new-version",
       sx: {

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -7,6 +7,8 @@ import { Bootstrapper } from "./Bootstrapper";
 import { createRoot } from "react-dom/client";
 import { ThemeAndStylesProvider } from "./theming/ThemeAndStylesProvider";
 import { ServerApi } from "./serverApi/ServerApi";
+// side-effect import: registers the service worker at startup (immediate: true)
+import "./serviceWorkerUpdater";
 
 import("./util/appInsights").then((appInsights) => {
   appInsights.setUpAppInsights();

--- a/app/src/serviceWorkerUpdater.ts
+++ b/app/src/serviceWorkerUpdater.ts
@@ -1,0 +1,77 @@
+/// <reference types="vite-plugin-pwa/client" />
+import { registerSW } from "virtual:pwa-register";
+
+// The app is a PWA whose service worker precaches index.html and all hashed
+// chunks cache-first (see vite.config.js). Because of that, a plain
+// location.reload() after a deploy is unreliable: the reload navigation is
+// answered by the still-active worker from the OLD precache, so the page can
+// land right back on the stale version whose lazily imported chunks were
+// deleted by the deploy ("Failed to fetch dynamically imported module").
+//
+// To update deterministically we drive the service-worker lifecycle: make the
+// freshly deployed worker skipWaiting and only reload once it controls the page
+// (registerType is "prompt", so the new worker waits for our signal instead of
+// auto-activating and reloading the page out from under the user).
+
+// Only activate + reload after the user explicitly asks to update. Background
+// update checks must never reload the page on their own.
+let userRequestedUpdate = false;
+
+let swRegistration: ServiceWorkerRegistration | undefined;
+
+const updateServiceWorker = registerSW({
+  immediate: true,
+  onRegisteredSW: (_swScriptUrl, registration) => {
+    swRegistration = registration;
+  },
+  onNeedRefresh: () => {
+    // A newly deployed worker finished installing and is now waiting. If the
+    // user already clicked "update", activate it now; the plugin reloads the
+    // page once the new worker takes control.
+    if (userRequestedUpdate) {
+      void updateServiceWorker(true);
+    }
+  },
+  onRegisterError: (error) => {
+    console.warn("Service worker registration failed.", error);
+  },
+});
+
+/**
+ * Update the app to the freshly deployed version and reload once the new
+ * service worker controls the page. Safe to call even when service workers are
+ * unavailable (falls back to a plain reload).
+ */
+export async function applyNewVersion(): Promise<void> {
+  userRequestedUpdate = true;
+
+  const registration = swRegistration;
+
+  // No service worker in play (unsupported browser or registration failed):
+  // a normal reload is the best we can do.
+  if (!registration) {
+    location.reload();
+    return;
+  }
+
+  // A worker is already installed and waiting -> activate it + reload.
+  if (registration.waiting) {
+    await updateServiceWorker(true);
+    return;
+  }
+
+  // Otherwise ask the browser to look for the freshly deployed worker. If one
+  // is found it installs and fires onNeedRefresh above, which finishes the
+  // update (skipWaiting -> controllerchange -> reload).
+  try {
+    await registration.update();
+  } catch (error) {
+    console.warn("Service worker update check failed.", error);
+  }
+
+  // Fallback: if no new worker materialised (already up to date locally, or the
+  // update check failed), reload so the user is never stuck on the button.
+  if (!registration.waiting && !registration.installing) {
+    location.reload();
+  }
+}

--- a/app/src/test/virtualPwaRegisterStub.ts
+++ b/app/src/test/virtualPwaRegisterStub.ts
@@ -1,0 +1,6 @@
+// Test stub for the "virtual:pwa-register" module, which is only provided by
+// the VitePWA plugin at build time and is not available under vitest. Aliased
+// in vitest.config.ts. registerSW returns a no-op updateSW function.
+export function registerSW(): (reloadPage?: boolean) => Promise<void> {
+  return () => Promise.resolve();
+}

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -22,8 +22,16 @@ export default () => {
       }),
       checker({ typescript: true }),
       VitePWA({
-        registerType: "autoUpdate",
-        injectRegister: "auto",
+        // "prompt" (not "autoUpdate"): a freshly deployed worker waits instead
+        // of skipping-waiting on its own, so we control exactly when the app
+        // updates + reloads (src/serviceWorkerUpdater.ts, wired to the version
+        // button). This avoids reloading the page out from under the user and
+        // makes the "new version available" button deterministic.
+        registerType: "prompt",
+        // We register the worker ourselves via virtual:pwa-register in
+        // src/serviceWorkerUpdater.ts, so the plugin must not also inject a
+        // registration script (that would register the worker twice).
+        injectRegister: false,
         // Keep our hand-written public/manifest.json (linked from index.html)
         // rather than generating one.
         manifest: false,

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,6 +1,16 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // "virtual:pwa-register" is injected by the VitePWA plugin at build time
+      // and doesn't exist under vitest; point it at a no-op stub instead.
+      "virtual:pwa-register": fileURLToPath(
+        new URL("./src/test/virtualPwaRegisterStub.ts", import.meta.url),
+      ),
+    },
+  },
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## Problem

After a new version is deployed, users hit:

```
TypeError: Failed to fetch dynamically imported module: https://www.engraved.me/chunks/LazyMarkdown.<hash>.js
```

…and pressing the "new version available" refresh button didn't fix it.

**Root cause:** the refresh button and the lazy-load error dialog both called `location.reload()`. Because the PWA service worker precaches `index.html` and the hashed chunks **cache-first**, that reload was answered by the still-active old worker from its old cache — landing the user right back on the stale version, whose lazily imported chunk had been deleted by the deploy. On top of that, with `registerType: "autoUpdate"` the plugin's `updateSW()` is a no-op (guarded by `if (!auto)`), so a button could never deterministically activate the new worker.

## Fix

- Switch `registerType` to `"prompt"` and register the worker ourselves via `virtual:pwa-register` (`injectRegister: false` to avoid a double registration).
- New `serviceWorkerUpdater.ts` exposes `applyNewVersion()`: it forces an update check, tells the waiting worker to `skipWaiting`, and reloads **only once the new worker controls the page** — so the user always lands on the new `index.html` + chunks. Falls back to a plain reload when there's no service worker.
- Both `location.reload()` call sites (`ActionFactory.updateToNewVersion` and the `ErrorOnLazyLoad` dialog) now route through `applyNewVersion()`.
- Register the worker at startup via a side-effect import in `index.tsx`.
- Add a `virtual:pwa-register` stub aliased in `vitest.config.ts`, since that virtual module is only provided by VitePWA at build time.

## Behavior change

Previously (`autoUpdate`) a newly deployed worker could reload the page on its own in the background. Now updates happen only when the user clicks the version button (or the lazy-load error dialog) — more in line with having an explicit update button, but it does mean users no longer silently jump to the new version.

## Verification

- `tsc --noEmit`, eslint, and `npm run build` all pass.
- Confirmed generated `dist/sw.js` now gates `self.skipWaiting()` behind a `SKIP_WAITING` message (prompt mode), still precaches `index.html` + keeps `cleanupOutdatedCaches`, and no duplicate registration script is injected into `index.html`.
- All 127 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
