### PR TITLE
Add file storage foundation for #2987

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,9 @@ You are a core teammate. Your goal is to improve the product, elevate code quali
 This is a monorepo:
 
 - **`/api` — .NET backend:** ASP.NET Core API targeting .NET 10.
-  - Solution projects: `Engraved.Api` (web layer), `Engraved.Core` (domain logic), `Engraved.Persistence.Mongo` (MongoDB persistence), plus matching `*.Tests` projects (NUnit).
+  - Solution projects: `Engraved.Api` (web layer), `Engraved.Core` (domain logic), `Engraved.Persistence.Mongo` (MongoDB persistence), `Engraved.Storage.Azure` (file bytes in Azure Blob Storage), plus matching `*.Tests` projects (NUnit).
   - Authentication: JWT with Google Auth integration.
+  - File storage: uploaded files live in blob storage, not the database, and the API only ever hands out short-lived SAS URLs. Locally this points at [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite) (`npx azurite-blob`), which needs to be running only when working on file features.
 - **`/app` — React frontend:** TypeScript, React 19, built with Vite 8.
   - Routing: TanStack Router. Server state: TanStack Query. UI: Material UI (MUI). Rich text editing: Tiptap. Charts: Chart.js. Unit tests: Vitest.
 - **`/tests` — end-to-end tests:** Playwright tests that run against a locally served app and API.

--- a/api/Engraved.Api.sln
+++ b/api/Engraved.Api.sln
@@ -19,6 +19,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engraved.Notifications.OneS
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engraved.TestUtils", "Engraved.TestUtils\Engraved.TestUtils.csproj", "{F726CA88-C34D-4D4E-BCD3-73FB186B53D1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engraved.Storage.Azure", "Engraved.Storage.Azure\Engraved.Storage.Azure.csproj", "{18F340B5-4906-4C31-8BA5-569BE6263DDD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engraved.Storage.Azure.Tests", "Engraved.Storage.Azure.Tests\Engraved.Storage.Azure.Tests.csproj", "{3DD9C978-708F-4A43-A314-E2602DD54929}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +61,14 @@ Global
 		{F726CA88-C34D-4D4E-BCD3-73FB186B53D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F726CA88-C34D-4D4E-BCD3-73FB186B53D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F726CA88-C34D-4D4E-BCD3-73FB186B53D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18F340B5-4906-4C31-8BA5-569BE6263DDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18F340B5-4906-4C31-8BA5-569BE6263DDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18F340B5-4906-4C31-8BA5-569BE6263DDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18F340B5-4906-4C31-8BA5-569BE6263DDD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3DD9C978-708F-4A43-A314-E2602DD54929}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3DD9C978-708F-4A43-A314-E2602DD54929}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3DD9C978-708F-4A43-A314-E2602DD54929}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3DD9C978-708F-4A43-A314-E2602DD54929}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/api/Engraved.Api/Engraved.Api.csproj
+++ b/api/Engraved.Api/Engraved.Api.csproj
@@ -10,6 +10,7 @@
         <ProjectReference Include="..\Engraved.Core\Engraved.Core.csproj"/>
         <ProjectReference Include="..\Engraved.Notifications.OneSignal\Engraved.Notifications.OneSignal.csproj"/>
         <ProjectReference Include="..\Engraved.Persistence.Mongo\Engraved.Persistence.Mongo.csproj"/>
+        <ProjectReference Include="..\Engraved.Storage.Azure\Engraved.Storage.Azure.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/api/Engraved.Api/Source/Bootstrap/FileStorageRegistration.cs
+++ b/api/Engraved.Api/Source/Bootstrap/FileStorageRegistration.cs
@@ -1,0 +1,63 @@
+using Azure.Storage.Blobs;
+using Engraved.Api.Settings;
+using Engraved.Core.Application.Files;
+using Engraved.Storage.Azure;
+
+namespace Engraved.Api.Bootstrap;
+
+public static class FileStorageRegistration
+{
+  public static void RegisterFileStorage(
+    IServiceCollection services,
+    IConfiguration configuration,
+    bool useDevelopmentStorage
+  )
+  {
+    BlobStorageSettings settings = CreateSettings(configuration, useDevelopmentStorage);
+
+    services.AddSingleton<IBlobStorageSettings>(settings);
+
+    // The blob clients hold the connection pool and, with managed identity, a cached token, so they
+    // are meant to live as long as the application rather than be rebuilt per request. The same
+    // applies to the file store, whose delegation key provider exists precisely to keep one key
+    // around instead of fetching one per URL.
+    services.AddSingleton(_ => BlobContainerClientFactory.CreateServiceClient(settings));
+
+    services.AddSingleton<IFileStore>(provider =>
+      {
+        var serviceClient = provider.GetRequiredService<BlobServiceClient>();
+        BlobContainerClient containerClient = serviceClient.GetBlobContainerClient(settings.ContainerName);
+
+        return new AzureBlobFileStore(
+          containerClient,
+          BlobContainerClientFactory.CreateUserDelegationKeyProvider(serviceClient, containerClient)
+        );
+      }
+    );
+  }
+
+  private static BlobStorageSettings CreateSettings(IConfiguration configuration, bool useDevelopmentStorage)
+  {
+    var settings = new BlobStorageSettings();
+
+    configuration.GetSection("FileStorage").Bind(settings);
+
+    if (!string.IsNullOrEmpty(settings.ConnectionString) || !string.IsNullOrEmpty(settings.BlobEndpoint))
+    {
+      return settings;
+    }
+
+    // Local development and e2e tests fall back to Azurite, whose well-known development credentials
+    // this connection string stands for. In Azure the blob endpoint comes from app service
+    // configuration and authentication from the managed identity, so a missing value there is a
+    // misconfiguration and has to fail loudly rather than quietly point at a local emulator.
+    if (!useDevelopmentStorage)
+    {
+      throw new InvalidOperationException("App Service Config: No file storage configuration available.");
+    }
+
+    settings.ConnectionString = "UseDevelopmentStorage=true";
+
+    return settings;
+  }
+}

--- a/api/Engraved.Api/Source/Controllers/FilesController.cs
+++ b/api/Engraved.Api/Source/Controllers/FilesController.cs
@@ -1,0 +1,41 @@
+using Engraved.Core.Application;
+using Engraved.Core.Application.Queries.Files.CreateUpload;
+using Engraved.Core.Application.Queries.Files.GetUrl;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Engraved.Api.Controllers;
+
+// File bytes never pass through the API: it hands out time-bound URLs and the browser talks to the
+// storage account directly. That is also what makes images work at all, as the browser will not put
+// the bearer token on an <img> request.
+[ApiController]
+[Route("api/files")]
+[Authorize]
+public class FilesController(Dispatcher dispatcher) : ControllerBase
+{
+  // Returns the file reference to put on the entry's Attachments, a URL to upload the bytes to, and
+  // a URL to read them back - the last one because until the entry is saved nothing references the
+  // file, and GetUrl resolves permissions through the owning entry.
+  [HttpPost]
+  public async Task<CreateFileUploadResult> CreateUpload([FromBody] CreateFileUploadQuery query)
+  {
+    return await dispatcher.Query<CreateFileUploadResult, CreateFileUploadQuery>(query);
+  }
+
+  [HttpGet]
+  [Route("{fileId}/url")]
+  public async Task<ActionResult<GetFileUrlResult>> GetUrl(string fileId)
+  {
+    GetFileUrlResult? result = await dispatcher.Query<GetFileUrlResult?, GetFileUrlQuery>(
+      new GetFileUrlQuery { FileId = fileId }
+    );
+
+    if (result == null)
+    {
+      return NotFound();
+    }
+
+    return result;
+  }
+}

--- a/api/Engraved.Api/Source/Controllers/FilesController.cs
+++ b/api/Engraved.Api/Source/Controllers/FilesController.cs
@@ -14,7 +14,7 @@ namespace Engraved.Api.Controllers;
 [Authorize]
 public class FilesController(Dispatcher dispatcher) : ControllerBase
 {
-  // Returns the file reference to put on the entry's Attachments, a URL to upload the bytes to, and
+  // Returns the file reference to put on the entry's Files, a URL to upload the bytes to, and
   // a URL to read them back - the last one because until the entry is saved nothing references the
   // file, and GetUrl resolves permissions through the owning entry.
   [HttpPost]

--- a/api/Engraved.Api/Source/Program.cs
+++ b/api/Engraved.Api/Source/Program.cs
@@ -98,6 +98,12 @@ builder.Services.AddHostedService<ScheduledNotificationJob>();
 
 PersistenceRegistration.RegisterPersistence(builder.Services, builder.Configuration, isE2ETests);
 
+FileStorageRegistration.RegisterFileStorage(
+  builder.Services,
+  builder.Configuration,
+  builder.Environment.IsDevelopment() || isE2ETests
+);
+
 builder.Services.AddSingleton(new E2ETestMode(isE2ETests));
 builder.Services.AddMemoryCache();
 builder.Services.AddTransient<QueryCache>();

--- a/api/Engraved.Api/Source/Settings/BlobStorageSettings.cs
+++ b/api/Engraved.Api/Source/Settings/BlobStorageSettings.cs
@@ -1,0 +1,12 @@
+using Engraved.Storage.Azure;
+
+namespace Engraved.Api.Settings;
+
+public class BlobStorageSettings : IBlobStorageSettings
+{
+  public string? ConnectionString { get; set; }
+
+  public string? BlobEndpoint { get; set; }
+
+  public string ContainerName { get; set; } = "files";
+}

--- a/api/Engraved.Api/appsettings.json
+++ b/api/Engraved.Api/appsettings.json
@@ -11,5 +11,8 @@
     "AccessTokenLifetimeMinutes": 15,
     "RefreshTokenLifetimeMinutes": 1440
   },
+  "FileStorage": {
+    "ContainerName": "files"
+  },
   "AllowedHosts": "*"
 }

--- a/api/Engraved.Core.Tests/Source/Application/Files/FileContentPolicyShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Files/FileContentPolicyShould.cs
@@ -1,0 +1,47 @@
+using Engraved.Core.Application.Files;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Engraved.Core.Tests.Application.Files;
+
+public class FileContentPolicyShould
+{
+  [TestCase("image/png")]
+  [TestCase("image/jpeg")]
+  [TestCase("IMAGE/PNG")]
+  [TestCase("application/pdf")]
+  public void Render_KnownSafeTypes_Inline(string contentType)
+  {
+    FileContentPolicy.GetDisposition(contentType).Should().Be(FileDisposition.Inline);
+  }
+
+  // An SVG can carry <script>, which would run if the browser navigated to it as a document. It
+  // still displays in scraps regardless, because an <img> renders SVG script-free and ignores the
+  // content disposition - only clicking through turns into a download.
+  [Test]
+  public void Force_Svg_ToDownload()
+  {
+    FileContentPolicy.GetDisposition("image/svg+xml").Should().Be(FileDisposition.Attachment);
+  }
+
+  [TestCase("text/html")]
+  [TestCase("application/zip")]
+  [TestCase("application/octet-stream")]
+  public void Force_EverythingElse_ToDownload(string contentType)
+  {
+    FileContentPolicy.GetDisposition(contentType).Should().Be(FileDisposition.Attachment);
+  }
+
+  // The file name ends up inside a quoted Content-Disposition header, so anything that could close
+  // the quotes or start a new header line has to go.
+  [TestCase("plain.png", "plain.png")]
+  [TestCase("with\"quote.png", "withquote.png")]
+  [TestCase("with\\backslash.png", "withbackslash.png")]
+  [TestCase("break\r\nX-Injected: 1.png", "breakX-Injected: 1.png")]
+  [TestCase("  padded.png  ", "padded.png")]
+  [TestCase("\"\"", "download")]
+  public void Sanitize_FileNames(string input, string expected)
+  {
+    FileContentPolicy.SanitizeFileName(input).Should().Be(expected);
+  }
+}

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Files/CreateFileUploadQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Files/CreateFileUploadQueryExecutorShould.cs
@@ -49,6 +49,19 @@ public class CreateFileUploadQueryExecutorShould
     result.ReadUrl.Should().Contain(result.File.Id);
   }
 
+  // UploadedOn is stamped when the file is accepted onto an entry, not here. A FileRef minted at
+  // upload travels out to the client and comes back at save, so a timestamp set now would be
+  // client-supplied by the time it is stored - which would make it worth less than no timestamp.
+  [Test]
+  public async Task Not_Stamp_UploadedOn()
+  {
+    var journalId = await AddJournal(_repo.CurrentUser.Value.Id!);
+
+    CreateFileUploadResult result = await Execute(journalId);
+
+    result.File.UploadedOn.Should().BeNull();
+  }
+
   [Test]
   public async Task Return_A_NewFileId_On_EveryCall()
   {

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Files/CreateFileUploadQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Files/CreateFileUploadQueryExecutorShould.cs
@@ -44,7 +44,7 @@ public class CreateFileUploadQueryExecutorShould
     result.File.Id.Should().NotBeNullOrEmpty();
     result.File.FileName.Should().Be("holiday.png");
     result.File.ContentType.Should().Be("image/png");
-    result.File.Length.Should().Be(1234);
+    result.File.ContentLength.Should().Be(1234);
     result.UploadUrl.Should().Contain(result.File.Id);
     result.ReadUrl.Should().Contain(result.File.Id);
   }
@@ -158,7 +158,7 @@ public class CreateFileUploadQueryExecutorShould
         JournalId = journalId,
         FileName = fileName,
         ContentType = "image/png",
-        Length = length
+        ContentLength = length
       }
     );
   }

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Files/CreateFileUploadQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Files/CreateFileUploadQueryExecutorShould.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Threading.Tasks;
+using Engraved.Core.Application.Persistence;
+using Engraved.Core.Application.Queries;
+using Engraved.Core.Application.Queries.Files.CreateUpload;
+using Engraved.Core.Domain.Journals;
+using Engraved.Core.Domain.Permissions;
+using Engraved.Core.Domain.Users;
+using Engraved.TestUtils;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Engraved.Core.Tests.Application.Queries.Files;
+
+public class CreateFileUploadQueryExecutorShould
+{
+  private const string UserName = "current@user.com";
+  private const string OtherUserName = "other@user.com";
+
+  private FakeFileStore _fileStore = null!;
+  private string _otherUserId = null!;
+  private TestUserRestrictedMongoRepository _repo = null!;
+  private TestMongoRepository _seedRepo = null!;
+
+  [SetUp]
+  public async Task SetUp()
+  {
+    _seedRepo = await Util.CreateMongoRepository();
+
+    var userId = (await _seedRepo.UpsertUser(new User { Name = UserName })).EntityId;
+    _otherUserId = (await _seedRepo.UpsertUser(new User { Name = OtherUserName })).EntityId;
+
+    _repo = await Util.CreateUserRestrictedMongoRepository(UserName, userId, true);
+    _fileStore = new FakeFileStore();
+  }
+
+  [Test]
+  public async Task Return_UploadAndReadUrl_For_OwnJournal()
+  {
+    var journalId = await AddJournal(_repo.CurrentUser.Value.Id!);
+
+    CreateFileUploadResult result = await Execute(journalId);
+
+    result.File.Id.Should().NotBeNullOrEmpty();
+    result.File.FileName.Should().Be("holiday.png");
+    result.File.ContentType.Should().Be("image/png");
+    result.File.Length.Should().Be(1234);
+    result.UploadUrl.Should().Contain(result.File.Id);
+    result.ReadUrl.Should().Contain(result.File.Id);
+  }
+
+  [Test]
+  public async Task Return_A_NewFileId_On_EveryCall()
+  {
+    var journalId = await AddJournal(_repo.CurrentUser.Value.Id!);
+
+    CreateFileUploadResult first = await Execute(journalId);
+    CreateFileUploadResult second = await Execute(journalId);
+
+    second.File.Id.Should().NotBe(first.File.Id);
+  }
+
+  [Test]
+  public async Task Return_UploadUrl_When_JournalIsSharedForWriting()
+  {
+    var journalId = await AddJournal(
+      _otherUserId,
+      new PermissionDefinition { Kind = PermissionKind.Write }
+    );
+
+    CreateFileUploadResult result = await Execute(journalId);
+
+    result.UploadUrl.Should().NotBeNullOrEmpty();
+  }
+
+  // Read access on the journal is not enough: uploading is a write, even though nothing is written
+  // to the database yet.
+  [Test]
+  public async Task Throw_When_JournalIsOnlyReadable()
+  {
+    var journalId = await AddJournal(
+      _otherUserId,
+      new PermissionDefinition { Kind = PermissionKind.Read }
+    );
+
+    Func<Task> act = async () => await Execute(journalId);
+
+    await act.Should().ThrowAsync<NotAllowedOperationException>();
+  }
+
+  [Test]
+  public async Task Throw_When_JournalIsNotSharedAtAll()
+  {
+    var journalId = await AddJournal(_otherUserId);
+
+    Func<Task> act = async () => await Execute(journalId);
+
+    await act.Should().ThrowAsync<NotAllowedOperationException>();
+  }
+
+  [Test]
+  public async Task Throw_When_JournalDoesNotExist()
+  {
+    Func<Task> act = async () => await Execute("60703c3b0000000000000099");
+
+    await act.Should().ThrowAsync<NotAllowedOperationException>();
+  }
+
+  [Test]
+  public async Task Throw_When_FileIsTooLarge()
+  {
+    var journalId = await AddJournal(_repo.CurrentUser.Value.Id!);
+
+    Func<Task> act = async () => await Execute(journalId, 50 * 1024 * 1024);
+
+    await act.Should().ThrowAsync<InvalidQueryException>();
+  }
+
+  [Test]
+  public async Task Sanitize_FileNamesThatCouldInjectHeaders()
+  {
+    var journalId = await AddJournal(_repo.CurrentUser.Value.Id!);
+
+    CreateFileUploadResult result = await Execute(journalId, fileName: "eo\"l\r\ninjected: yes.png");
+
+    result.File.FileName.Should().Be("eolinjected: yes.png");
+  }
+
+  private async Task<string> AddJournal(string ownerId, PermissionDefinition? permissionForCurrentUser = null)
+  {
+    var permissions = new UserPermissions();
+
+    if (permissionForCurrentUser != null)
+    {
+      permissions.Add(_repo.CurrentUser.Value.Id!, permissionForCurrentUser);
+    }
+
+    UpsertResult journal = await _seedRepo.UpsertJournal(
+      new ScrapsJournal
+      {
+        UserId = ownerId,
+        Permissions = permissions
+      }
+    );
+
+    return journal.EntityId;
+  }
+
+  private async Task<CreateFileUploadResult> Execute(
+    string journalId,
+    long length = 1234,
+    string fileName = "holiday.png"
+  )
+  {
+    return await new CreateFileUploadQueryExecutor(_repo, _fileStore, _repo.CurrentUser).Execute(
+      new CreateFileUploadQuery
+      {
+        JournalId = journalId,
+        FileName = fileName,
+        ContentType = "image/png",
+        Length = length
+      }
+    );
+  }
+}

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Files/FakeFileStore.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Files/FakeFileStore.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using Engraved.Core.Application.Files;
+using Engraved.Core.Domain.Files;
+
+namespace Engraved.Core.Tests.Application.Queries.Files;
+
+public class FakeFileStore : IFileStore
+{
+  public FileRef? LastReadUrlFile { get; private set; }
+
+  public Task<Uri> CreateUploadUrl(string fileId)
+  {
+    return Task.FromResult(new Uri($"https://files.example/{fileId}?upload"));
+  }
+
+  public Task<Uri> CreateReadUrl(FileRef file)
+  {
+    LastReadUrlFile = file;
+
+    return Task.FromResult(new Uri($"https://files.example/{file.Id}?read"));
+  }
+
+  public Task Delete(string fileId)
+  {
+    return Task.CompletedTask;
+  }
+}

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Files/GetFileUrlQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Files/GetFileUrlQueryExecutorShould.cs
@@ -1,0 +1,140 @@
+using System.Threading.Tasks;
+using Engraved.Core.Application.Persistence;
+using Engraved.Core.Application.Queries.Files.GetUrl;
+using Engraved.Core.Domain.Entries;
+using Engraved.Core.Domain.Files;
+using Engraved.Core.Domain.Journals;
+using Engraved.Core.Domain.Permissions;
+using Engraved.Core.Domain.Users;
+using Engraved.TestUtils;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Engraved.Core.Tests.Application.Queries.Files;
+
+public class GetFileUrlQueryExecutorShould
+{
+  private const string UserName = "current@user.com";
+  private const string OwnerUserName = "owner@user.com";
+  private const string FileId = "8a1d3f9c4b2e4a7f9c0d1e2f";
+
+  private FakeFileStore _fileStore = null!;
+  private string _ownerUserId = null!;
+  private TestUserRestrictedMongoRepository _repo = null!;
+  private TestMongoRepository _seedRepo = null!;
+  private string _userId = null!;
+
+  [SetUp]
+  public async Task SetUp()
+  {
+    _seedRepo = await Util.CreateMongoRepository();
+
+    _userId = (await _seedRepo.UpsertUser(new User { Name = UserName })).EntityId;
+    _ownerUserId = (await _seedRepo.UpsertUser(new User { Name = OwnerUserName })).EntityId;
+
+    _repo = await Util.CreateUserRestrictedMongoRepository(UserName, _userId, true);
+    _fileStore = new FakeFileStore();
+  }
+
+  [Test]
+  public async Task Return_Url_For_FileOnOwnEntry()
+  {
+    await AddScrapWithAttachment(_userId);
+
+    GetFileUrlResult? result = await Execute();
+
+    result.Should().NotBeNull();
+    result!.Url.Should().Contain(FileId);
+  }
+
+  // The read URL is built from what we stored, not from whatever the client uploaded - that is what
+  // makes the content type (and with it the download-vs-render decision) ours to enforce.
+  [Test]
+  public async Task Pass_TheStoredFile_To_TheStore()
+  {
+    await AddScrapWithAttachment(_userId);
+
+    await Execute();
+
+    _fileStore.LastReadUrlFile.Should().NotBeNull();
+    _fileStore.LastReadUrlFile!.FileName.Should().Be("diagram.svg");
+    _fileStore.LastReadUrlFile.ContentType.Should().Be("image/svg+xml");
+  }
+
+  // No entry references the file, so nobody can read it. This is why the upload response hands out a
+  // read URL directly: between uploading and saving the entry, there is nothing to resolve against.
+  [Test]
+  public async Task Return_Null_When_FileIsNotAttachedToAnyEntry()
+  {
+    GetFileUrlResult? result = await Execute();
+
+    result.Should().BeNull();
+  }
+
+  [Test]
+  public async Task Return_Null_When_UserMayNotReadTheJournal()
+  {
+    await AddScrapWithAttachment(_ownerUserId);
+
+    GetFileUrlResult? result = await Execute();
+
+    result.Should().BeNull();
+  }
+
+  [Test]
+  public async Task Return_Url_When_JournalIsSharedReadOnly()
+  {
+    await AddScrapWithAttachment(
+      _ownerUserId,
+      new PermissionDefinition { Kind = PermissionKind.Read }
+    );
+
+    GetFileUrlResult? result = await Execute();
+
+    result.Should().NotBeNull();
+  }
+
+  private async Task<GetFileUrlResult?> Execute()
+  {
+    return await new GetFileUrlQueryExecutor(_repo, _repo, _fileStore).Execute(
+      new GetFileUrlQuery { FileId = FileId }
+    );
+  }
+
+  private async Task AddScrapWithAttachment(string ownerId, PermissionDefinition? permissionForCurrentUser = null)
+  {
+    var permissions = new UserPermissions();
+
+    if (permissionForCurrentUser != null)
+    {
+      permissions.Add(_userId, permissionForCurrentUser);
+    }
+
+    UpsertResult journal = await _seedRepo.UpsertJournal(
+      new ScrapsJournal
+      {
+        UserId = ownerId,
+        Permissions = permissions
+      }
+    );
+
+    await _seedRepo.UpsertEntry(
+      new ScrapsEntry
+      {
+        UserId = ownerId,
+        ParentId = journal.EntityId,
+        Title = "with attachment",
+        Attachments =
+        [
+          new FileRef
+          {
+            Id = FileId,
+            FileName = "diagram.svg",
+            ContentType = "image/svg+xml",
+            Length = 42
+          }
+        ]
+      }
+    );
+  }
+}

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Files/GetFileUrlQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Files/GetFileUrlQueryExecutorShould.cs
@@ -39,7 +39,7 @@ public class GetFileUrlQueryExecutorShould
   [Test]
   public async Task Return_Url_For_FileOnOwnEntry()
   {
-    await AddScrapWithAttachment(_userId);
+    await AddScrapWithFile(_userId);
 
     GetFileUrlResult? result = await Execute();
 
@@ -52,7 +52,7 @@ public class GetFileUrlQueryExecutorShould
   [Test]
   public async Task Pass_TheStoredFile_To_TheStore()
   {
-    await AddScrapWithAttachment(_userId);
+    await AddScrapWithFile(_userId);
 
     await Execute();
 
@@ -64,7 +64,7 @@ public class GetFileUrlQueryExecutorShould
   // No entry references the file, so nobody can read it. This is why the upload response hands out a
   // read URL directly: between uploading and saving the entry, there is nothing to resolve against.
   [Test]
-  public async Task Return_Null_When_FileIsNotAttachedToAnyEntry()
+  public async Task Return_Null_When_FileIsNotOnAnyEntry()
   {
     GetFileUrlResult? result = await Execute();
 
@@ -74,7 +74,7 @@ public class GetFileUrlQueryExecutorShould
   [Test]
   public async Task Return_Null_When_UserMayNotReadTheJournal()
   {
-    await AddScrapWithAttachment(_ownerUserId);
+    await AddScrapWithFile(_ownerUserId);
 
     GetFileUrlResult? result = await Execute();
 
@@ -84,7 +84,7 @@ public class GetFileUrlQueryExecutorShould
   [Test]
   public async Task Return_Url_When_JournalIsSharedReadOnly()
   {
-    await AddScrapWithAttachment(
+    await AddScrapWithFile(
       _ownerUserId,
       new PermissionDefinition { Kind = PermissionKind.Read }
     );
@@ -101,7 +101,7 @@ public class GetFileUrlQueryExecutorShould
     );
   }
 
-  private async Task AddScrapWithAttachment(string ownerId, PermissionDefinition? permissionForCurrentUser = null)
+  private async Task AddScrapWithFile(string ownerId, PermissionDefinition? permissionForCurrentUser = null)
   {
     var permissions = new UserPermissions();
 
@@ -123,8 +123,8 @@ public class GetFileUrlQueryExecutorShould
       {
         UserId = ownerId,
         ParentId = journal.EntityId,
-        Title = "with attachment",
-        Attachments =
+        Title = "with file",
+        Files =
         [
           new FileRef
           {

--- a/api/Engraved.Core.Tests/Source/Application/Queries/Files/GetFileUrlQueryExecutorShould.cs
+++ b/api/Engraved.Core.Tests/Source/Application/Queries/Files/GetFileUrlQueryExecutorShould.cs
@@ -131,7 +131,7 @@ public class GetFileUrlQueryExecutorShould
             Id = FileId,
             FileName = "diagram.svg",
             ContentType = "image/svg+xml",
-            Length = 42
+            ContentLength = 42
           }
         ]
       }

--- a/api/Engraved.Core/Source/Application/ExecutorRegistration.cs
+++ b/api/Engraved.Core/Source/Application/ExecutorRegistration.cs
@@ -24,6 +24,8 @@ using Engraved.Core.Application.Queries.Entries.GetActive;
 using Engraved.Core.Application.Queries.Entries.Search;
 using Engraved.Core.Application.Queries.Entries.GetAllJournal;
 using Engraved.Core.Application.Queries.Export;
+using Engraved.Core.Application.Queries.Files.CreateUpload;
+using Engraved.Core.Application.Queries.Files.GetUrl;
 using Engraved.Core.Application.Queries.Journals.Get;
 using Engraved.Core.Application.Queries.Journals.GetAll;
 using Engraved.Core.Application.Queries.Search.Entities;
@@ -81,6 +83,8 @@ public static class ExecutorRegistration
     RegisterQuery<SystemInfo, GetSystemInfoQuery, GetSystemInfoQueryExecutor>(services);
     RegisterQuery<ExportedDataResult, ExportDataQuery, ExportDataQueryExecutor>(services);
     RegisterQuery<AdminUserItem[], GetAdminUsersOverviewQuery, GetAdminUsersOverviewQueryExecutor>(services);
+    RegisterQuery<CreateFileUploadResult, CreateFileUploadQuery, CreateFileUploadQueryExecutor>(services);
+    RegisterQuery<GetFileUrlResult?, GetFileUrlQuery, GetFileUrlQueryExecutor>(services);
   }
 
   private static void RegisterQuery<TResult, TQuery, TQueryExecutor>(IServiceCollection services)

--- a/api/Engraved.Core/Source/Application/Files/FileContentPolicy.cs
+++ b/api/Engraved.Core/Source/Application/Files/FileContentPolicy.cs
@@ -1,0 +1,40 @@
+using System.Text.RegularExpressions;
+
+namespace Engraved.Core.Application.Files;
+
+// Decides how a file may be presented to the browser. Any file type can be stored - the point of
+// attachments is that arbitrary documents can be attached - but only a known-safe set is allowed to
+// render in place; everything else downloads.
+public static class FileContentPolicy
+{
+  // Types the browser renders without executing anything. SVG is deliberately absent: it is an XML
+  // document that can carry <script>, and a navigation to it would run that script in the storage
+  // account's origin. It still displays fine in scraps, because an <img> renders SVG script-free and
+  // ignores the content disposition entirely - only clicking through turns into a download.
+  private static readonly HashSet<string> InlineContentTypes = new(StringComparer.OrdinalIgnoreCase)
+  {
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "image/avif",
+    "application/pdf"
+  };
+
+  // Control characters would let a crafted file name inject additional header lines into the
+  // Content-Disposition the store writes; quotes and backslashes would break out of the quoted
+  // string. Neither is worth trying to encode - file names are cosmetic.
+  private static readonly Regex UnsafeFileNameCharacters = new(@"[\p{C}""\\]", RegexOptions.Compiled);
+
+  public static FileDisposition GetDisposition(string contentType)
+  {
+    return InlineContentTypes.Contains(contentType) ? FileDisposition.Inline : FileDisposition.Attachment;
+  }
+
+  public static string SanitizeFileName(string fileName)
+  {
+    var sanitized = UnsafeFileNameCharacters.Replace(fileName, "").Trim();
+
+    return string.IsNullOrEmpty(sanitized) ? "download" : sanitized;
+  }
+}

--- a/api/Engraved.Core/Source/Application/Files/FileContentPolicy.cs
+++ b/api/Engraved.Core/Source/Application/Files/FileContentPolicy.cs
@@ -2,9 +2,9 @@ using System.Text.RegularExpressions;
 
 namespace Engraved.Core.Application.Files;
 
-// Decides how a file may be presented to the browser. Any file type can be stored - the point of
-// attachments is that arbitrary documents can be attached - but only a known-safe set is allowed to
-// render in place; everything else downloads.
+// Decides how a file may be presented to the browser. Any file type can be stored - the point is
+// that arbitrary documents can be put on an entry - but only a known-safe set is allowed to render
+// in place; everything else downloads.
 public static class FileContentPolicy
 {
   // Types the browser renders without executing anything. SVG is deliberately absent: it is an XML

--- a/api/Engraved.Core/Source/Application/Files/FileDisposition.cs
+++ b/api/Engraved.Core/Source/Application/Files/FileDisposition.cs
@@ -1,0 +1,7 @@
+namespace Engraved.Core.Application.Files;
+
+public enum FileDisposition
+{
+  Inline,
+  Attachment
+}

--- a/api/Engraved.Core/Source/Application/Files/FileSizeLimits.cs
+++ b/api/Engraved.Core/Source/Application/Files/FileSizeLimits.cs
@@ -1,0 +1,8 @@
+namespace Engraved.Core.Application.Files;
+
+public static class FileSizeLimits
+{
+  // Deliberately a constant rather than configuration: there is one deployment, and the value only
+  // ever changes as a considered decision about storage cost.
+  public const long MaxFileSizeBytes = 10 * 1024 * 1024;
+}

--- a/api/Engraved.Core/Source/Application/Files/IFileStore.cs
+++ b/api/Engraved.Core/Source/Application/Files/IFileStore.cs
@@ -1,0 +1,23 @@
+using Engraved.Core.Domain.Files;
+
+namespace Engraved.Core.Application.Files;
+
+// Bytes live outside the database: storing them in mongo/cosmos would spend request units (and, on
+// cosmos, the shared throughput budget of the whole application) on data that never needs querying.
+// The application only ever hands out time-bound URLs and lets the browser talk to the store
+// directly, so no file content passes through the API.
+public interface IFileStore
+{
+  // URL the client may PUT the bytes to. Deliberately short-lived: it is used immediately after
+  // being issued. Note that it constrains who may write, not what: neither the content type nor the
+  // size of the upload can be pinned by the URL, which is why the read URL sets the content type
+  // itself and why the stored size has to be verified when the owning entry is saved.
+  Task<Uri> CreateUploadUrl(string fileId);
+
+  // URL the browser may GET the bytes from. The file's name and content type are pinned onto the
+  // response by the store rather than taken from whatever the client happened to upload, which is
+  // what makes FileContentPolicy's disposition decision enforceable.
+  Task<Uri> CreateReadUrl(FileRef file);
+
+  Task Delete(string fileId);
+}

--- a/api/Engraved.Core/Source/Application/Persistence/Repositories/IEntryRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/Repositories/IEntryRepository.cs
@@ -37,5 +37,5 @@ public interface IEntryRepository
 
   // Resolves the entry that owns a file. Like GetEntry this is an unscoped primitive: the caller
   // enforces read access on the parent journal (see GetFileUrlQueryExecutor).
-  Task<IEntry?> GetEntryByAttachmentId(string fileId);
+  Task<IEntry?> GetEntryByFileId(string fileId);
 }

--- a/api/Engraved.Core/Source/Application/Persistence/Repositories/IEntryRepository.cs
+++ b/api/Engraved.Core/Source/Application/Persistence/Repositories/IEntryRepository.cs
@@ -34,4 +34,8 @@ public interface IEntryRepository
   Task DeleteEntriesForJournal(string journalId);
 
   Task<IEntry?> GetEntry(string entryId);
+
+  // Resolves the entry that owns a file. Like GetEntry this is an unscoped primitive: the caller
+  // enforces read access on the parent journal (see GetFileUrlQueryExecutor).
+  Task<IEntry?> GetEntryByAttachmentId(string fileId);
 }

--- a/api/Engraved.Core/Source/Application/Queries/Files/CreateUpload/CreateFileUploadQuery.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Files/CreateUpload/CreateFileUploadQuery.cs
@@ -11,7 +11,7 @@ public class CreateFileUploadQuery : IQuery
 
   public string? ContentType { get; set; }
 
-  public long Length { get; set; }
+  public long ContentLength { get; set; }
 
   public int? Width { get; set; }
 

--- a/api/Engraved.Core/Source/Application/Queries/Files/CreateUpload/CreateFileUploadQuery.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Files/CreateUpload/CreateFileUploadQuery.cs
@@ -1,0 +1,19 @@
+namespace Engraved.Core.Application.Queries.Files.CreateUpload;
+
+// A query, not a command, because nothing is persisted: it mints time-bound URLs for a file id the
+// caller has not uploaded yet. The FileRef only reaches the database once the client puts it on an
+// entry and saves that entry.
+public class CreateFileUploadQuery : IQuery
+{
+  public string? JournalId { get; set; }
+
+  public string? FileName { get; set; }
+
+  public string? ContentType { get; set; }
+
+  public long Length { get; set; }
+
+  public int? Width { get; set; }
+
+  public int? Height { get; set; }
+}

--- a/api/Engraved.Core/Source/Application/Queries/Files/CreateUpload/CreateFileUploadQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Files/CreateUpload/CreateFileUploadQueryExecutor.cs
@@ -36,7 +36,7 @@ public class CreateFileUploadQueryExecutor(
       Id = Guid.NewGuid().ToString("N"),
       FileName = FileContentPolicy.SanitizeFileName(query.FileName!),
       ContentType = query.ContentType!,
-      Length = query.Length,
+      ContentLength = query.ContentLength,
       Width = query.Width,
       Height = query.Height
     };
@@ -69,15 +69,15 @@ public class CreateFileUploadQueryExecutor(
       throw new InvalidQueryException(query, $"{nameof(CreateFileUploadQuery.ContentType)} must be specified.");
     }
 
-    if (query.Length <= 0)
+    if (query.ContentLength <= 0)
     {
-      throw new InvalidQueryException(query, $"{nameof(CreateFileUploadQuery.Length)} must be greater than zero.");
+      throw new InvalidQueryException(query, $"{nameof(CreateFileUploadQuery.ContentLength)} must be greater than zero.");
     }
 
     // This is the size the client claims it is about to upload. A SAS cannot cap the size of the
     // put, so a client that lies gets a signed URL anyway; the actual size has to be verified
     // against the stored blob when the owning entry is saved.
-    if (query.Length > FileSizeLimits.MaxFileSizeBytes)
+    if (query.ContentLength > FileSizeLimits.MaxFileSizeBytes)
     {
       throw new InvalidQueryException(
         query,

--- a/api/Engraved.Core/Source/Application/Queries/Files/CreateUpload/CreateFileUploadQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Files/CreateUpload/CreateFileUploadQueryExecutor.cs
@@ -1,0 +1,88 @@
+using Engraved.Core.Application.Files;
+using Engraved.Core.Application.Persistence;
+using Engraved.Core.Application.Persistence.Repositories;
+using Engraved.Core.Domain.Files;
+using Engraved.Core.Domain.Journals;
+using Engraved.Core.Domain.Permissions;
+using Engraved.Core.Domain.Users;
+
+namespace Engraved.Core.Application.Queries.Files.CreateUpload;
+
+public class CreateFileUploadQueryExecutor(
+  IJournalRepository journalRepository,
+  IFileStore fileStore,
+  Lazy<IUser> currentUser
+) : IQueryExecutor<CreateFileUploadResult, CreateFileUploadQuery>
+{
+  // Every call mints a new file id and a URL that expires, so a cached result would hand the same
+  // (eventually dead) upload target to every upload.
+  public bool DisableCache => true;
+
+  public async Task<CreateFileUploadResult> Execute(CreateFileUploadQuery query)
+  {
+    EnsureIsValid(query);
+
+    // The file is uploaded before the entry that will own it exists (or before an existing entry is
+    // saved again), so access is decided on the journal the file is destined for. Read access on the
+    // file afterwards is decided by the entry that ends up holding it - see GetFileUrlQueryExecutor.
+    IJournal? journal = await journalRepository.GetJournal(query.JournalId!);
+    if (!JournalAccessPolicy.HasAccess(journal, currentUser.Value.Id, PermissionKind.Write))
+    {
+      throw new NotAllowedOperationException("Journal doesn't exist or you do not have permissions.");
+    }
+
+    var file = new FileRef
+    {
+      Id = Guid.NewGuid().ToString("N"),
+      FileName = FileContentPolicy.SanitizeFileName(query.FileName!),
+      ContentType = query.ContentType!,
+      Length = query.Length,
+      Width = query.Width,
+      Height = query.Height
+    };
+
+    Uri uploadUrl = await fileStore.CreateUploadUrl(file.Id);
+    Uri readUrl = await fileStore.CreateReadUrl(file);
+
+    return new CreateFileUploadResult
+    {
+      File = file,
+      UploadUrl = uploadUrl.ToString(),
+      ReadUrl = readUrl.ToString()
+    };
+  }
+
+  private static void EnsureIsValid(CreateFileUploadQuery query)
+  {
+    if (string.IsNullOrEmpty(query.JournalId))
+    {
+      throw new InvalidQueryException(query, $"{nameof(CreateFileUploadQuery.JournalId)} must be specified.");
+    }
+
+    if (string.IsNullOrEmpty(query.FileName))
+    {
+      throw new InvalidQueryException(query, $"{nameof(CreateFileUploadQuery.FileName)} must be specified.");
+    }
+
+    if (string.IsNullOrEmpty(query.ContentType))
+    {
+      throw new InvalidQueryException(query, $"{nameof(CreateFileUploadQuery.ContentType)} must be specified.");
+    }
+
+    if (query.Length <= 0)
+    {
+      throw new InvalidQueryException(query, $"{nameof(CreateFileUploadQuery.Length)} must be greater than zero.");
+    }
+
+    // This is the size the client claims it is about to upload. A SAS cannot cap the size of the
+    // put, so a client that lies gets a signed URL anyway; the actual size has to be verified
+    // against the stored blob when the owning entry is saved.
+    if (query.Length > FileSizeLimits.MaxFileSizeBytes)
+    {
+      throw new InvalidQueryException(
+        query,
+        $"Files must not be larger than {FileSizeLimits.MaxFileSizeBytes / 1024 / 1024} MB."
+      );
+    }
+  }
+}

--- a/api/Engraved.Core/Source/Application/Queries/Files/CreateUpload/CreateFileUploadResult.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Files/CreateUpload/CreateFileUploadResult.cs
@@ -4,7 +4,7 @@ namespace Engraved.Core.Application.Queries.Files.CreateUpload;
 
 public class CreateFileUploadResult
 {
-  // To be put on the entry's Attachments by the client and saved with the entry.
+  // To be put on the entry's Files by the client and saved with the entry.
   public FileRef File { get; set; } = null!;
 
   public string UploadUrl { get; set; } = null!;

--- a/api/Engraved.Core/Source/Application/Queries/Files/CreateUpload/CreateFileUploadResult.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Files/CreateUpload/CreateFileUploadResult.cs
@@ -1,0 +1,16 @@
+using Engraved.Core.Domain.Files;
+
+namespace Engraved.Core.Application.Queries.Files.CreateUpload;
+
+public class CreateFileUploadResult
+{
+  // To be put on the entry's Attachments by the client and saved with the entry.
+  public FileRef File { get; set; } = null!;
+
+  public string UploadUrl { get; set; } = null!;
+
+  // Handed out together with the upload URL so the client can display the file immediately. Asking
+  // for it via GetFileUrlQuery would not work yet: nothing references the file until the entry is
+  // saved, and that query resolves permissions through the owning entry.
+  public string ReadUrl { get; set; } = null!;
+}

--- a/api/Engraved.Core/Source/Application/Queries/Files/GetUrl/GetFileUrlQuery.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Files/GetUrl/GetFileUrlQuery.cs
@@ -1,0 +1,6 @@
+namespace Engraved.Core.Application.Queries.Files.GetUrl;
+
+public class GetFileUrlQuery : IQuery
+{
+  public string? FileId { get; set; }
+}

--- a/api/Engraved.Core/Source/Application/Queries/Files/GetUrl/GetFileUrlQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Files/GetUrl/GetFileUrlQueryExecutor.cs
@@ -26,13 +26,13 @@ public class GetFileUrlQueryExecutor(
     // journal, and the journal already answers "may this user read this". An unreferenced file is
     // therefore unreadable by anyone, which is what makes handing the read URL out at upload time
     // (see CreateFileUploadResult.ReadUrl) necessary.
-    IEntry? entry = await entryRepository.GetEntryByAttachmentId(query.FileId);
+    IEntry? entry = await entryRepository.GetEntryByFileId(query.FileId);
     if (entry == null)
     {
       return null;
     }
 
-    // GetEntryByAttachmentId is unscoped; the scoped journal repository returns null when the
+    // GetEntryByFileId is unscoped; the scoped journal repository returns null when the
     // current user may not read the parent journal, in which case the file stays hidden.
     IJournal? journal = await journalRepository.GetJournal(entry.ParentId);
     if (journal == null)
@@ -40,7 +40,7 @@ public class GetFileUrlQueryExecutor(
       return null;
     }
 
-    FileRef file = entry.Attachments.Single(a => a.Id == query.FileId);
+    FileRef file = entry.Files.Single(f => f.Id == query.FileId);
 
     Uri url = await fileStore.CreateReadUrl(file);
 

--- a/api/Engraved.Core/Source/Application/Queries/Files/GetUrl/GetFileUrlQueryExecutor.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Files/GetUrl/GetFileUrlQueryExecutor.cs
@@ -1,0 +1,49 @@
+using Engraved.Core.Application.Files;
+using Engraved.Core.Application.Persistence.Repositories;
+using Engraved.Core.Domain.Entries;
+using Engraved.Core.Domain.Files;
+using Engraved.Core.Domain.Journals;
+
+namespace Engraved.Core.Application.Queries.Files.GetUrl;
+
+public class GetFileUrlQueryExecutor(
+  IEntryRepository entryRepository,
+  IJournalRepository journalRepository,
+  IFileStore fileStore
+) : IQueryExecutor<GetFileUrlResult?, GetFileUrlQuery>
+{
+  // The URL expires, so caching it would eventually hand out a dead one.
+  public bool DisableCache => true;
+
+  public async Task<GetFileUrlResult?> Execute(GetFileUrlQuery query)
+  {
+    if (string.IsNullOrEmpty(query.FileId))
+    {
+      throw new InvalidQueryException(query, $"{nameof(GetFileUrlQuery.FileId)} must be specified.");
+    }
+
+    // Files have no permissions of their own: a file belongs to an entry, an entry belongs to a
+    // journal, and the journal already answers "may this user read this". An unreferenced file is
+    // therefore unreadable by anyone, which is what makes handing the read URL out at upload time
+    // (see CreateFileUploadResult.ReadUrl) necessary.
+    IEntry? entry = await entryRepository.GetEntryByAttachmentId(query.FileId);
+    if (entry == null)
+    {
+      return null;
+    }
+
+    // GetEntryByAttachmentId is unscoped; the scoped journal repository returns null when the
+    // current user may not read the parent journal, in which case the file stays hidden.
+    IJournal? journal = await journalRepository.GetJournal(entry.ParentId);
+    if (journal == null)
+    {
+      return null;
+    }
+
+    FileRef file = entry.Attachments.Single(a => a.Id == query.FileId);
+
+    Uri url = await fileStore.CreateReadUrl(file);
+
+    return new GetFileUrlResult { Url = url.ToString() };
+  }
+}

--- a/api/Engraved.Core/Source/Application/Queries/Files/GetUrl/GetFileUrlResult.cs
+++ b/api/Engraved.Core/Source/Application/Queries/Files/GetUrl/GetFileUrlResult.cs
@@ -1,0 +1,6 @@
+namespace Engraved.Core.Application.Queries.Files.GetUrl;
+
+public class GetFileUrlResult
+{
+  public string Url { get; set; } = null!;
+}

--- a/api/Engraved.Core/Source/Domain/Entries/BaseEntry.cs
+++ b/api/Engraved.Core/Source/Domain/Entries/BaseEntry.cs
@@ -1,4 +1,5 @@
-﻿using Engraved.Core.Domain.Schedules;
+﻿using Engraved.Core.Domain.Files;
+using Engraved.Core.Domain.Schedules;
 
 namespace Engraved.Core.Domain.Entries;
 
@@ -15,6 +16,8 @@ public abstract class BaseEntry : IEntry
   public DateTime? DateTime { get; set; }
 
   public DateTime? EditedOn { get; set; }
+
+  public FileRef[] Attachments { get; set; } = [];
 
   public Dictionary<string, string[]> JournalAttributeValues { get; set; } = new();
 

--- a/api/Engraved.Core/Source/Domain/Entries/BaseEntry.cs
+++ b/api/Engraved.Core/Source/Domain/Entries/BaseEntry.cs
@@ -17,7 +17,7 @@ public abstract class BaseEntry : IEntry
 
   public DateTime? EditedOn { get; set; }
 
-  public FileRef[] Attachments { get; set; } = [];
+  public FileRef[] Files { get; set; } = [];
 
   public Dictionary<string, string[]> JournalAttributeValues { get; set; } = new();
 

--- a/api/Engraved.Core/Source/Domain/Entries/IEntry.cs
+++ b/api/Engraved.Core/Source/Domain/Entries/IEntry.cs
@@ -11,10 +11,11 @@ public interface IEntry : IUserOwned, IEntity
 
   DateTime? DateTime { get; set; }
 
-  // Every file the entry owns, whether listed as an attachment or placed inline in the notes. One
-  // list means one lifecycle: deletion, quota accounting and orphan detection all read this instead
-  // of parsing the notes to work out which files are referenced.
-  FileRef[] Attachments { get; set; }
+  // Every file the entry owns. Deliberately says nothing about placement: a file listed below the
+  // entry and one placed inline in the notes are the same thing here, and where it appears is the
+  // markdown's business. One list means one lifecycle - deletion, quota accounting and orphan
+  // detection all read this instead of parsing the notes to work out which files are referenced.
+  FileRef[] Files { get; set; }
 
   Dictionary<string, string[]> JournalAttributeValues { get; set; }
 

--- a/api/Engraved.Core/Source/Domain/Entries/IEntry.cs
+++ b/api/Engraved.Core/Source/Domain/Entries/IEntry.cs
@@ -1,4 +1,6 @@
-﻿namespace Engraved.Core.Domain.Entries;
+﻿using Engraved.Core.Domain.Files;
+
+namespace Engraved.Core.Domain.Entries;
 
 // Values declared as IEntry are serialized polymorphically; see DomainPolymorphism.
 public interface IEntry : IUserOwned, IEntity
@@ -8,6 +10,11 @@ public interface IEntry : IUserOwned, IEntity
   string? Notes { get; set; }
 
   DateTime? DateTime { get; set; }
+
+  // Every file the entry owns, whether listed as an attachment or placed inline in the notes. One
+  // list means one lifecycle: deletion, quota accounting and orphan detection all read this instead
+  // of parsing the notes to work out which files are referenced.
+  FileRef[] Attachments { get; set; }
 
   Dictionary<string, string[]> JournalAttributeValues { get; set; }
 

--- a/api/Engraved.Core/Source/Domain/Files/FileRef.cs
+++ b/api/Engraved.Core/Source/Domain/Files/FileRef.cs
@@ -1,0 +1,27 @@
+namespace Engraved.Core.Domain.Files;
+
+// A file owned by an entry. Denormalized onto the entry (rather than kept in its own collection) so
+// rendering a list of entries never needs a second lookup to show file names and sizes.
+//
+// Id is also the blob's name in the file store, and it is the only thing the blob knows about
+// itself: the blob path must contain nothing that can change, because blob storage has no rename -
+// what looks like a move is copy-then-delete. Every mutable relationship (which entry, which
+// journal) lives here in the database instead.
+public class FileRef
+{
+  public string Id { get; set; } = null!;
+
+  public string FileName { get; set; } = null!;
+
+  public string ContentType { get; set; } = null!;
+
+  public long Length { get; set; }
+
+  // Intrinsic image dimensions, when the file is an image. Known for free at upload time (the client
+  // already decodes the image to downscale it) and used to reserve the correct box before the image
+  // loads, so entries below it don't jump. Backfilling them later would mean downloading and
+  // decoding every existing blob.
+  public int? Width { get; set; }
+
+  public int? Height { get; set; }
+}

--- a/api/Engraved.Core/Source/Domain/Files/FileRef.cs
+++ b/api/Engraved.Core/Source/Domain/Files/FileRef.cs
@@ -22,6 +22,12 @@ public class FileRef
 
   public long ContentLength { get; set; }
 
+  // Stamped by the server when the file is accepted onto an entry - never taken from the client. A
+  // FileRef travels out to the client at upload and comes back at save, so anything on it is
+  // client-supplied by the time it is persisted, and a timestamp that can be set by the caller is
+  // worse than none at all. Nullable because files stored before that stamping exists have no value.
+  public DateTime? UploadedOn { get; set; }
+
   // Intrinsic image dimensions, when the file is an image. Known for free at upload time (the client
   // already decodes the image to downscale it) and used to reserve the correct box before the image
   // loads, so entries below it don't jump. Backfilling them later would mean downloading and

--- a/api/Engraved.Core/Source/Domain/Files/FileRef.cs
+++ b/api/Engraved.Core/Source/Domain/Files/FileRef.cs
@@ -1,7 +1,12 @@
 namespace Engraved.Core.Domain.Files;
 
-// A file owned by an entry. Denormalized onto the entry (rather than kept in its own collection) so
-// rendering a list of entries never needs a second lookup to show file names and sizes.
+// A reference to a file owned by an entry - the metadata, not the bytes, which live in the file
+// store. Denormalized onto the entry (rather than kept in its own collection) so rendering a list of
+// entries never needs a second lookup to show file names and sizes.
+//
+// Named FileRef rather than File both because that is what it is, and because a domain type called
+// File cannot compile here: ImplicitUsings pulls in System.IO, so the name is ambiguous. The same
+// reason JournalAttribute is not called Attribute.
 //
 // Id is also the blob's name in the file store, and it is the only thing the blob knows about
 // itself: the blob path must contain nothing that can change, because blob storage has no rename -
@@ -15,7 +20,7 @@ public class FileRef
 
   public string ContentType { get; set; } = null!;
 
-  public long Length { get; set; }
+  public long ContentLength { get; set; }
 
   // Intrinsic image dimensions, when the file is an image. Known for free at upload time (the client
   // already decodes the image to downscale it) and used to reserve the correct box before the image

--- a/api/Engraved.Persistence.Mongo.Tests/Source/UnrestrictedMongoRepository_Attachments_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/UnrestrictedMongoRepository_Attachments_Should.cs
@@ -1,0 +1,105 @@
+using System.Threading.Tasks;
+using Engraved.Core.Application.Persistence;
+using Engraved.Core.Domain.Entries;
+using Engraved.Core.Domain.Files;
+using Engraved.Core.Domain.Journals;
+using Engraved.TestUtils;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Engraved.Persistence.Mongo.Tests;
+
+public class UnrestrictedMongoRepository_Attachments_Should
+{
+  private const string FileId = "8a1d3f9c4b2e4a7f9c0d1e2f";
+
+  private TestMongoRepository _repo = null!;
+
+  [SetUp]
+  public async Task SetUp()
+  {
+    _repo = await Util.CreateMongoRepository();
+  }
+
+  [Test]
+  public async Task RoundTrip_Attachments()
+  {
+    var entryId = await AddScrapWithAttachment();
+
+    IEntry entry = (await _repo.GetEntry(entryId))!;
+
+    entry.Attachments.Should().HaveCount(1);
+    entry.Attachments[0].Id.Should().Be(FileId);
+    entry.Attachments[0].FileName.Should().Be("holiday.png");
+    entry.Attachments[0].ContentType.Should().Be("image/png");
+    entry.Attachments[0].Length.Should().Be(1234);
+    entry.Attachments[0].Width.Should().Be(800);
+    entry.Attachments[0].Height.Should().Be(600);
+  }
+
+  // Entries written before attachments existed have no such field at all, and must keep loading.
+  [Test]
+  public async Task Return_EmptyAttachments_For_EntriesWithoutAny()
+  {
+    UpsertResult journal = await _repo.UpsertJournal(new ScrapsJournal());
+    UpsertResult entry = await _repo.UpsertEntry(
+      new ScrapsEntry
+      {
+        ParentId = journal.EntityId,
+        Title = "no files here"
+      }
+    );
+
+    IEntry loaded = (await _repo.GetEntry(entry.EntityId))!;
+
+    loaded.Attachments.Should().BeEmpty();
+  }
+
+  [Test]
+  public async Task Find_TheOwningEntry_By_AttachmentId()
+  {
+    var entryId = await AddScrapWithAttachment();
+
+    IEntry? entry = await _repo.GetEntryByAttachmentId(FileId);
+
+    entry.Should().NotBeNull();
+    entry!.Id.Should().Be(entryId);
+  }
+
+  [Test]
+  public async Task Return_Null_When_NoEntryHasTheAttachment()
+  {
+    await AddScrapWithAttachment();
+
+    IEntry? entry = await _repo.GetEntryByAttachmentId("8a1d3f9c4b2e4a7f9c0d1e2e");
+
+    entry.Should().BeNull();
+  }
+
+  private async Task<string> AddScrapWithAttachment()
+  {
+    UpsertResult journal = await _repo.UpsertJournal(new ScrapsJournal());
+
+    UpsertResult entry = await _repo.UpsertEntry(
+      new ScrapsEntry
+      {
+        ParentId = journal.EntityId,
+        Title = "with attachment",
+        Attachments =
+        [
+          new FileRef
+          {
+            Id = FileId,
+            FileName = "holiday.png",
+            ContentType = "image/png",
+            Length = 1234,
+            Width = 800,
+            Height = 600
+          }
+        ]
+      }
+    );
+
+    return entry.EntityId;
+  }
+}

--- a/api/Engraved.Persistence.Mongo.Tests/Source/UnrestrictedMongoRepository_Files_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/UnrestrictedMongoRepository_Files_Should.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Engraved.Core.Application.Persistence;
 using Engraved.Core.Domain.Entries;
@@ -12,6 +13,8 @@ namespace Engraved.Persistence.Mongo.Tests;
 public class UnrestrictedMongoRepository_Files_Should
 {
   private const string FileId = "8a1d3f9c4b2e4a7f9c0d1e2f";
+
+  private static readonly DateTime UploadedOn = new(2026, 7, 27, 14, 30, 0, DateTimeKind.Utc);
 
   private TestMongoRepository _repo = null!;
 
@@ -33,6 +36,7 @@ public class UnrestrictedMongoRepository_Files_Should
     entry.Files[0].FileName.Should().Be("holiday.png");
     entry.Files[0].ContentType.Should().Be("image/png");
     entry.Files[0].ContentLength.Should().Be(1234);
+    entry.Files[0].UploadedOn.Should().BeCloseTo(UploadedOn, TimeSpan.FromMilliseconds(1));
     entry.Files[0].Width.Should().Be(800);
     entry.Files[0].Height.Should().Be(600);
   }
@@ -93,6 +97,7 @@ public class UnrestrictedMongoRepository_Files_Should
             FileName = "holiday.png",
             ContentType = "image/png",
             ContentLength = 1234,
+            UploadedOn = UploadedOn,
             Width = 800,
             Height = 600
           }

--- a/api/Engraved.Persistence.Mongo.Tests/Source/UnrestrictedMongoRepository_Files_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/UnrestrictedMongoRepository_Files_Should.cs
@@ -6,6 +6,8 @@ using Engraved.Core.Domain.Files;
 using Engraved.Core.Domain.Journals;
 using Engraved.TestUtils;
 using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver;
 using NUnit.Framework;
 
 namespace Engraved.Persistence.Mongo.Tests;
@@ -41,20 +43,26 @@ public class UnrestrictedMongoRepository_Files_Should
     entry.Files[0].Height.Should().Be(600);
   }
 
-  // Entries written before files existed have no such field at all, and must keep loading.
+  // Every entry already in the database was written before this field existed and has no Files
+  // element at all - deploying must not make them unreadable. Deliberately inserted as raw BSON:
+  // going through UpsertEntry would write "Files: []" and quietly test nothing.
   [Test]
-  public async Task Return_EmptyFiles_For_EntriesWithoutAny()
+  public async Task Load_EntriesStoredWithoutTheFilesElement()
   {
-    UpsertResult journal = await _repo.UpsertJournal(new ScrapsJournal());
-    UpsertResult entry = await _repo.UpsertEntry(
-      new ScrapsEntry
-      {
-        ParentId = journal.EntityId,
-        Title = "no files here"
-      }
-    );
+    var entryId = ObjectId.GenerateNewId();
 
-    IEntry loaded = (await _repo.GetEntry(entry.EntityId))!;
+    await _repo.Entries.Database.GetCollection<BsonDocument>("entries")
+      .InsertOneAsync(
+        new BsonDocument
+        {
+          { "_id", entryId },
+          { "_t", new BsonArray { "EntryDocument", "ScrapsEntryDocument" } },
+          { "ParentId", "60703c3b0000000000000001" },
+          { "Title", "written before files existed" }
+        }
+      );
+
+    IEntry loaded = (await _repo.GetEntry(entryId.ToString()))!;
 
     loaded.Files.Should().BeEmpty();
   }

--- a/api/Engraved.Persistence.Mongo.Tests/Source/UnrestrictedMongoRepository_Files_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/UnrestrictedMongoRepository_Files_Should.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 
 namespace Engraved.Persistence.Mongo.Tests;
 
-public class UnrestrictedMongoRepository_Attachments_Should
+public class UnrestrictedMongoRepository_Files_Should
 {
   private const string FileId = "8a1d3f9c4b2e4a7f9c0d1e2f";
 
@@ -22,24 +22,24 @@ public class UnrestrictedMongoRepository_Attachments_Should
   }
 
   [Test]
-  public async Task RoundTrip_Attachments()
+  public async Task RoundTrip_Files()
   {
-    var entryId = await AddScrapWithAttachment();
+    var entryId = await AddScrapWithFile();
 
     IEntry entry = (await _repo.GetEntry(entryId))!;
 
-    entry.Attachments.Should().HaveCount(1);
-    entry.Attachments[0].Id.Should().Be(FileId);
-    entry.Attachments[0].FileName.Should().Be("holiday.png");
-    entry.Attachments[0].ContentType.Should().Be("image/png");
-    entry.Attachments[0].Length.Should().Be(1234);
-    entry.Attachments[0].Width.Should().Be(800);
-    entry.Attachments[0].Height.Should().Be(600);
+    entry.Files.Should().HaveCount(1);
+    entry.Files[0].Id.Should().Be(FileId);
+    entry.Files[0].FileName.Should().Be("holiday.png");
+    entry.Files[0].ContentType.Should().Be("image/png");
+    entry.Files[0].Length.Should().Be(1234);
+    entry.Files[0].Width.Should().Be(800);
+    entry.Files[0].Height.Should().Be(600);
   }
 
-  // Entries written before attachments existed have no such field at all, and must keep loading.
+  // Entries written before files existed have no such field at all, and must keep loading.
   [Test]
-  public async Task Return_EmptyAttachments_For_EntriesWithoutAny()
+  public async Task Return_EmptyFiles_For_EntriesWithoutAny()
   {
     UpsertResult journal = await _repo.UpsertJournal(new ScrapsJournal());
     UpsertResult entry = await _repo.UpsertEntry(
@@ -52,31 +52,31 @@ public class UnrestrictedMongoRepository_Attachments_Should
 
     IEntry loaded = (await _repo.GetEntry(entry.EntityId))!;
 
-    loaded.Attachments.Should().BeEmpty();
+    loaded.Files.Should().BeEmpty();
   }
 
   [Test]
-  public async Task Find_TheOwningEntry_By_AttachmentId()
+  public async Task Find_TheOwningEntry_By_FileId()
   {
-    var entryId = await AddScrapWithAttachment();
+    var entryId = await AddScrapWithFile();
 
-    IEntry? entry = await _repo.GetEntryByAttachmentId(FileId);
+    IEntry? entry = await _repo.GetEntryByFileId(FileId);
 
     entry.Should().NotBeNull();
     entry!.Id.Should().Be(entryId);
   }
 
   [Test]
-  public async Task Return_Null_When_NoEntryHasTheAttachment()
+  public async Task Return_Null_When_NoEntryHasTheFile()
   {
-    await AddScrapWithAttachment();
+    await AddScrapWithFile();
 
-    IEntry? entry = await _repo.GetEntryByAttachmentId("8a1d3f9c4b2e4a7f9c0d1e2e");
+    IEntry? entry = await _repo.GetEntryByFileId("8a1d3f9c4b2e4a7f9c0d1e2e");
 
     entry.Should().BeNull();
   }
 
-  private async Task<string> AddScrapWithAttachment()
+  private async Task<string> AddScrapWithFile()
   {
     UpsertResult journal = await _repo.UpsertJournal(new ScrapsJournal());
 
@@ -84,8 +84,8 @@ public class UnrestrictedMongoRepository_Attachments_Should
       new ScrapsEntry
       {
         ParentId = journal.EntityId,
-        Title = "with attachment",
-        Attachments =
+        Title = "with file",
+        Files =
         [
           new FileRef
           {

--- a/api/Engraved.Persistence.Mongo.Tests/Source/UnrestrictedMongoRepository_Files_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/UnrestrictedMongoRepository_Files_Should.cs
@@ -32,7 +32,7 @@ public class UnrestrictedMongoRepository_Files_Should
     entry.Files[0].Id.Should().Be(FileId);
     entry.Files[0].FileName.Should().Be("holiday.png");
     entry.Files[0].ContentType.Should().Be("image/png");
-    entry.Files[0].Length.Should().Be(1234);
+    entry.Files[0].ContentLength.Should().Be(1234);
     entry.Files[0].Width.Should().Be(800);
     entry.Files[0].Height.Should().Be(600);
   }
@@ -92,7 +92,7 @@ public class UnrestrictedMongoRepository_Files_Should
             Id = FileId,
             FileName = "holiday.png",
             ContentType = "image/png",
-            Length = 1234,
+            ContentLength = 1234,
             Width = 800,
             Height = 600
           }

--- a/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/EntryDocument.cs
+++ b/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/EntryDocument.cs
@@ -21,6 +21,8 @@ public abstract class EntryDocument : IUserOwnedDocument, IScheduledDocument
 
   public DateTime? EditedOn { get; set; }
 
+  public FileRefSubDocument[] Attachments { get; set; } = [];
+
   public Dictionary<string, string[]> JournalAttributeValues { get; set; } = new();
 
   public Dictionary<string, ScheduleSubDocument> Schedules { get; set; } = new();

--- a/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/EntryDocument.cs
+++ b/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/EntryDocument.cs
@@ -21,7 +21,7 @@ public abstract class EntryDocument : IUserOwnedDocument, IScheduledDocument
 
   public DateTime? EditedOn { get; set; }
 
-  public FileRefSubDocument[] Attachments { get; set; } = [];
+  public FileRefSubDocument[] Files { get; set; } = [];
 
   public Dictionary<string, string[]> JournalAttributeValues { get; set; } = new();
 

--- a/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/EntryDocumentMapper.cs
+++ b/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/EntryDocumentMapper.cs
@@ -57,6 +57,7 @@ public static class EntryDocumentMapper
     document.Notes = entry.Notes;
     document.DateTime = entry.DateTime;
     document.EditedOn = entry.EditedOn;
+    document.Attachments = FileRefMapper.MapAttachments(entry.Attachments);
     document.JournalAttributeValues = entry.JournalAttributeValues;
     document.Schedules = ScheduleMapper.MapSchedules(entry.Schedules);
 
@@ -117,6 +118,7 @@ public static class EntryDocumentMapper
     entry.Notes = document.Notes;
     entry.DateTime = document.DateTime;
     entry.EditedOn = document.EditedOn;
+    entry.Attachments = FileRefMapper.MapAttachmentsFromDocument(document.Attachments);
     entry.JournalAttributeValues = document.JournalAttributeValues;
     entry.Schedules = ScheduleMapper.MapSchedulesFromDocument(document.Schedules);
 

--- a/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/EntryDocumentMapper.cs
+++ b/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/EntryDocumentMapper.cs
@@ -57,7 +57,7 @@ public static class EntryDocumentMapper
     document.Notes = entry.Notes;
     document.DateTime = entry.DateTime;
     document.EditedOn = entry.EditedOn;
-    document.Attachments = FileRefMapper.MapAttachments(entry.Attachments);
+    document.Files = FileRefMapper.MapFiles(entry.Files);
     document.JournalAttributeValues = entry.JournalAttributeValues;
     document.Schedules = ScheduleMapper.MapSchedules(entry.Schedules);
 
@@ -118,7 +118,7 @@ public static class EntryDocumentMapper
     entry.Notes = document.Notes;
     entry.DateTime = document.DateTime;
     entry.EditedOn = document.EditedOn;
-    entry.Attachments = FileRefMapper.MapAttachmentsFromDocument(document.Attachments);
+    entry.Files = FileRefMapper.MapFilesFromDocument(document.Files);
     entry.JournalAttributeValues = document.JournalAttributeValues;
     entry.Schedules = ScheduleMapper.MapSchedulesFromDocument(document.Schedules);
 

--- a/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/FileRefMapper.cs
+++ b/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/FileRefMapper.cs
@@ -1,0 +1,38 @@
+using Engraved.Core.Domain.Files;
+
+namespace Engraved.Persistence.Mongo.DocumentTypes.Entries;
+
+public static class FileRefMapper
+{
+  public static FileRefSubDocument[] MapAttachments(FileRef[] attachments)
+  {
+    return attachments
+      .Select(a => new FileRefSubDocument
+        {
+          Id = a.Id,
+          FileName = a.FileName,
+          ContentType = a.ContentType,
+          Length = a.Length,
+          Width = a.Width,
+          Height = a.Height
+        }
+      )
+      .ToArray();
+  }
+
+  public static FileRef[] MapAttachmentsFromDocument(FileRefSubDocument[] attachments)
+  {
+    return attachments
+      .Select(a => new FileRef
+        {
+          Id = a.Id,
+          FileName = a.FileName,
+          ContentType = a.ContentType,
+          Length = a.Length,
+          Width = a.Width,
+          Height = a.Height
+        }
+      )
+      .ToArray();
+  }
+}

--- a/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/FileRefMapper.cs
+++ b/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/FileRefMapper.cs
@@ -13,6 +13,7 @@ public static class FileRefMapper
           FileName = f.FileName,
           ContentType = f.ContentType,
           ContentLength = f.ContentLength,
+          UploadedOn = f.UploadedOn,
           Width = f.Width,
           Height = f.Height
         }
@@ -29,6 +30,7 @@ public static class FileRefMapper
           FileName = f.FileName,
           ContentType = f.ContentType,
           ContentLength = f.ContentLength,
+          UploadedOn = f.UploadedOn,
           Width = f.Width,
           Height = f.Height
         }

--- a/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/FileRefMapper.cs
+++ b/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/FileRefMapper.cs
@@ -4,33 +4,33 @@ namespace Engraved.Persistence.Mongo.DocumentTypes.Entries;
 
 public static class FileRefMapper
 {
-  public static FileRefSubDocument[] MapAttachments(FileRef[] attachments)
+  public static FileRefSubDocument[] MapFiles(FileRef[] files)
   {
-    return attachments
-      .Select(a => new FileRefSubDocument
+    return files
+      .Select(f => new FileRefSubDocument
         {
-          Id = a.Id,
-          FileName = a.FileName,
-          ContentType = a.ContentType,
-          Length = a.Length,
-          Width = a.Width,
-          Height = a.Height
+          Id = f.Id,
+          FileName = f.FileName,
+          ContentType = f.ContentType,
+          Length = f.Length,
+          Width = f.Width,
+          Height = f.Height
         }
       )
       .ToArray();
   }
 
-  public static FileRef[] MapAttachmentsFromDocument(FileRefSubDocument[] attachments)
+  public static FileRef[] MapFilesFromDocument(FileRefSubDocument[] files)
   {
-    return attachments
-      .Select(a => new FileRef
+    return files
+      .Select(f => new FileRef
         {
-          Id = a.Id,
-          FileName = a.FileName,
-          ContentType = a.ContentType,
-          Length = a.Length,
-          Width = a.Width,
-          Height = a.Height
+          Id = f.Id,
+          FileName = f.FileName,
+          ContentType = f.ContentType,
+          Length = f.Length,
+          Width = f.Width,
+          Height = f.Height
         }
       )
       .ToArray();

--- a/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/FileRefMapper.cs
+++ b/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/FileRefMapper.cs
@@ -12,7 +12,7 @@ public static class FileRefMapper
           Id = f.Id,
           FileName = f.FileName,
           ContentType = f.ContentType,
-          Length = f.Length,
+          ContentLength = f.ContentLength,
           Width = f.Width,
           Height = f.Height
         }
@@ -28,7 +28,7 @@ public static class FileRefMapper
           Id = f.Id,
           FileName = f.FileName,
           ContentType = f.ContentType,
-          Length = f.Length,
+          ContentLength = f.ContentLength,
           Width = f.Width,
           Height = f.Height
         }

--- a/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/FileRefSubDocument.cs
+++ b/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/FileRefSubDocument.cs
@@ -10,6 +10,8 @@ public class FileRefSubDocument
 
   public long ContentLength { get; set; }
 
+  public DateTime? UploadedOn { get; set; }
+
   public int? Width { get; set; }
 
   public int? Height { get; set; }

--- a/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/FileRefSubDocument.cs
+++ b/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/FileRefSubDocument.cs
@@ -1,0 +1,16 @@
+namespace Engraved.Persistence.Mongo.DocumentTypes.Entries;
+
+public class FileRefSubDocument
+{
+  public string Id { get; set; } = null!;
+
+  public string FileName { get; set; } = null!;
+
+  public string ContentType { get; set; } = null!;
+
+  public long Length { get; set; }
+
+  public int? Width { get; set; }
+
+  public int? Height { get; set; }
+}

--- a/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/FileRefSubDocument.cs
+++ b/api/Engraved.Persistence.Mongo/Source/DocumentTypes/Entries/FileRefSubDocument.cs
@@ -8,7 +8,7 @@ public class FileRefSubDocument
 
   public string ContentType { get; set; } = null!;
 
-  public long Length { get; set; }
+  public long ContentLength { get; set; }
 
   public int? Width { get; set; }
 

--- a/api/Engraved.Persistence.Mongo/Source/Repositories/MongoEntryRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Repositories/MongoEntryRepository.cs
@@ -206,6 +206,24 @@ public class MongoEntryRepository(MongoDatabaseClient mongoDatabaseClient, Mongo
       : EntryDocumentMapper.FromDocument(document);
   }
 
+  // Unscoped primitive, for the same reason as GetEntry above: the caller (GetFileUrlQueryExecutor)
+  // enforces read access on the parent journal. Needs an index on "Attachments.Id".
+  public async Task<IEntry?> GetEntryByAttachmentId(string fileId)
+  {
+    if (string.IsNullOrEmpty(fileId))
+    {
+      throw new ArgumentNullException(nameof(fileId), "File id must be specified.");
+    }
+
+    EntryDocument? document = await EntriesCollection
+      .Find(Builders<EntryDocument>.Filter.ElemMatch(d => d.Attachments, a => a.Id == fileId))
+      .FirstOrDefaultAsync();
+
+    return document == null
+      ? null
+      : EntryDocumentMapper.FromDocument(document);
+  }
+
   private async Task<IEntry[]> LoadData(
     int? limit,
     ScheduleMode? scheduleMode,

--- a/api/Engraved.Persistence.Mongo/Source/Repositories/MongoEntryRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Repositories/MongoEntryRepository.cs
@@ -207,8 +207,8 @@ public class MongoEntryRepository(MongoDatabaseClient mongoDatabaseClient, Mongo
   }
 
   // Unscoped primitive, for the same reason as GetEntry above: the caller (GetFileUrlQueryExecutor)
-  // enforces read access on the parent journal. Needs an index on "Attachments.Id".
-  public async Task<IEntry?> GetEntryByAttachmentId(string fileId)
+  // enforces read access on the parent journal. Needs an index on "Files.Id".
+  public async Task<IEntry?> GetEntryByFileId(string fileId)
   {
     if (string.IsNullOrEmpty(fileId))
     {
@@ -216,7 +216,7 @@ public class MongoEntryRepository(MongoDatabaseClient mongoDatabaseClient, Mongo
     }
 
     EntryDocument? document = await EntriesCollection
-      .Find(Builders<EntryDocument>.Filter.ElemMatch(d => d.Attachments, a => a.Id == fileId))
+      .Find(Builders<EntryDocument>.Filter.ElemMatch(d => d.Files, a => a.Id == fileId))
       .FirstOrDefaultAsync();
 
     return document == null

--- a/api/Engraved.Persistence.Mongo/Source/Repositories/UnrestrictedMongoRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Repositories/UnrestrictedMongoRepository.cs
@@ -150,6 +150,11 @@ public class UnrestrictedMongoRepository : IUnrestrictedRepository
     return _entryRepository.GetEntry(entryId);
   }
 
+  public Task<IEntry?> GetEntryByAttachmentId(string fileId)
+  {
+    return _entryRepository.GetEntryByAttachmentId(fileId);
+  }
+
   public async Task WakeMeUp()
   {
     await _mongoDatabaseClient.UsersCollection.FindAsync(MongoUtil.GetDocumentByIdFilter<UserDocument>(RandomDocId));

--- a/api/Engraved.Persistence.Mongo/Source/Repositories/UnrestrictedMongoRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Repositories/UnrestrictedMongoRepository.cs
@@ -150,9 +150,9 @@ public class UnrestrictedMongoRepository : IUnrestrictedRepository
     return _entryRepository.GetEntry(entryId);
   }
 
-  public Task<IEntry?> GetEntryByAttachmentId(string fileId)
+  public Task<IEntry?> GetEntryByFileId(string fileId)
   {
-    return _entryRepository.GetEntryByAttachmentId(fileId);
+    return _entryRepository.GetEntryByFileId(fileId);
   }
 
   public async Task WakeMeUp()

--- a/api/Engraved.Persistence.Mongo/Source/Repositories/UserRestricted/UserRestrictedEntryRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Repositories/UserRestricted/UserRestrictedEntryRepository.cs
@@ -53,9 +53,9 @@ public class UserRestrictedEntryRepository(MongoEntryRepository entryRepository,
     return entryRepository.GetEntry(entryId);
   }
 
-  public Task<IEntry?> GetEntryByAttachmentId(string fileId)
+  public Task<IEntry?> GetEntryByFileId(string fileId)
   {
-    return entryRepository.GetEntryByAttachmentId(fileId);
+    return entryRepository.GetEntryByFileId(fileId);
   }
 
   public async Task<UpsertResult> UpsertEntry<TEntry>(TEntry entry)

--- a/api/Engraved.Persistence.Mongo/Source/Repositories/UserRestricted/UserRestrictedEntryRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Repositories/UserRestricted/UserRestrictedEntryRepository.cs
@@ -53,6 +53,11 @@ public class UserRestrictedEntryRepository(MongoEntryRepository entryRepository,
     return entryRepository.GetEntry(entryId);
   }
 
+  public Task<IEntry?> GetEntryByAttachmentId(string fileId)
+  {
+    return entryRepository.GetEntryByAttachmentId(fileId);
+  }
+
   public async Task<UpsertResult> UpsertEntry<TEntry>(TEntry entry)
     where TEntry : IEntry
   {

--- a/api/Engraved.Storage.Azure.Tests/Engraved.Storage.Azure.Tests.csproj
+++ b/api/Engraved.Storage.Azure.Tests/Engraved.Storage.Azure.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Engraved.Storage.Azure\Engraved.Storage.Azure.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1"/>
+        <PackageReference Include="FluentAssertions" Version="8.10.0"/>
+        <PackageReference Include="NUnit" Version="4.6.1"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0"/>
+        <PackageReference Include="NUnit.Analyzers" Version="4.14.0"/>
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+</Project>

--- a/api/Engraved.Storage.Azure.Tests/Engraved.Storage.Azure.Tests.csproj.DotSettings
+++ b/api/Engraved.Storage.Azure.Tests/Engraved.Storage.Azure.Tests.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=source/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/api/Engraved.Storage.Azure.Tests/Source/SasExpiryShould.cs
+++ b/api/Engraved.Storage.Azure.Tests/Source/SasExpiryShould.cs
@@ -1,0 +1,55 @@
+using System;
+using Engraved.Storage.Azure;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Engraved.Storage.Azure.Tests;
+
+// The rounding is what makes a signed URL cacheable: if the expiry moved with every request, the
+// signature - and therefore the whole URL - would differ each time, and the browser would re-download
+// every image on every render.
+public class SasExpiryShould
+{
+  [Test]
+  public void Round_UpToTheNextFullHour()
+  {
+    DateTimeOffset expiry = SasExpiry.GetReadExpiry(At(10, 05));
+
+    expiry.Should().Be(At(11, 00));
+  }
+
+  [Test]
+  public void Return_TheSameExpiry_For_RequestsWithinTheSameWindow()
+  {
+    SasExpiry.GetReadExpiry(At(10, 01))
+      .Should()
+      .Be(SasExpiry.GetReadExpiry(At(10, 44)));
+  }
+
+  [Test]
+  public void Never_Return_AnExpiryThatIsAlmostUp()
+  {
+    // 10:59 + the 15 minute minimum lands in the next hour, so it rounds to 12:00 rather than
+    // handing out a URL with one minute of life left
+    DateTimeOffset expiry = SasExpiry.GetReadExpiry(At(10, 59));
+
+    expiry.Should().Be(At(12, 00));
+    (expiry - At(10, 59)).Should().BeGreaterThan(TimeSpan.FromMinutes(15));
+  }
+
+  [Test]
+  public void Return_AnExpiry_AtLeast_FifteenMinutesAway_ForEveryMinuteOfTheHour()
+  {
+    for (var minute = 0; minute < 60; minute++)
+    {
+      DateTimeOffset now = At(10, minute);
+
+      (SasExpiry.GetReadExpiry(now) - now).Should().BeGreaterThanOrEqualTo(TimeSpan.FromMinutes(15));
+    }
+  }
+
+  private static DateTimeOffset At(int hour, int minute)
+  {
+    return new DateTimeOffset(2026, 7, 27, hour, minute, 0, TimeSpan.Zero);
+  }
+}

--- a/api/Engraved.Storage.Azure/Engraved.Storage.Azure.csproj
+++ b/api/Engraved.Storage.Azure/Engraved.Storage.Azure.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Engraved.Core\Engraved.Core.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Azure.Identity" Version="1.17.0"/>
+        <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0"/>
+    </ItemGroup>
+
+</Project>

--- a/api/Engraved.Storage.Azure/Engraved.Storage.Azure.csproj.DotSettings
+++ b/api/Engraved.Storage.Azure/Engraved.Storage.Azure.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=source/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/api/Engraved.Storage.Azure/Source/AzureBlobFileStore.cs
+++ b/api/Engraved.Storage.Azure/Source/AzureBlobFileStore.cs
@@ -1,0 +1,103 @@
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+using Engraved.Core.Application.Files;
+using Engraved.Core.Domain.Files;
+
+namespace Engraved.Storage.Azure;
+
+// Blob names are the bare file id and nothing else: blob storage has no rename (what looks like a
+// move is copy-then-delete, per blob, non-atomic), so anything that can change - which entry, which
+// journal - would turn an ordinary edit into a data migration. Those relationships live in the
+// database.
+//
+// Times come from the wall clock rather than IDateService: SAS lifetimes are validated by the
+// storage service against real time, so a shifted clock would only produce URLs Azure rejects. The
+// part worth testing is the expiry rounding, which lives in SasExpiry as a pure function.
+public class AzureBlobFileStore(
+  BlobContainerClient containerClient,
+  UserDelegationKeyProvider? userDelegationKeyProvider
+) : IFileStore
+{
+  public async Task<Uri> CreateUploadUrl(string fileId)
+  {
+    return await CreateSasUri(
+      fileId,
+      BlobSasPermissions.Create | BlobSasPermissions.Write,
+      DateTimeOffset.UtcNow.Add(SasExpiry.UploadValidity),
+      _ => { }
+    );
+  }
+
+  public async Task<Uri> CreateReadUrl(FileRef file)
+  {
+    FileDisposition disposition = FileContentPolicy.GetDisposition(file.ContentType);
+    var fileName = FileContentPolicy.SanitizeFileName(file.FileName);
+
+    return await CreateSasUri(
+      file.Id,
+      BlobSasPermissions.Read,
+      SasExpiry.GetReadExpiry(DateTimeOffset.UtcNow),
+      builder =>
+      {
+        // Pinned onto the response by us rather than taken from whatever the client uploaded. This
+        // is what makes the disposition decision stick: an SVG downloads instead of rendering as a
+        // live document, no matter which headers were sent when it was put.
+        builder.ContentType = file.ContentType;
+        builder.ContentDisposition = disposition == FileDisposition.Inline
+          ? $"inline; filename=\"{fileName}\""
+          : $"attachment; filename=\"{fileName}\"";
+
+        // A file id always refers to the same bytes, so the response can be cached indefinitely. The
+        // URL changes when the signature window rolls over, which simply makes the next request a
+        // miss - it never serves stale content.
+        builder.CacheControl = "private, max-age=31536000, immutable";
+      }
+    );
+  }
+
+  public async Task Delete(string fileId)
+  {
+    await containerClient.GetBlobClient(fileId).DeleteIfExistsAsync();
+  }
+
+  private async Task<Uri> CreateSasUri(
+    string fileId,
+    BlobSasPermissions permissions,
+    DateTimeOffset expiresOn,
+    Action<BlobSasBuilder> configure
+  )
+  {
+    BlobClient blobClient = containerClient.GetBlobClient(fileId);
+
+    var builder = new BlobSasBuilder
+    {
+      BlobContainerName = containerClient.Name,
+      BlobName = fileId,
+      Resource = "b",
+
+      // Deliberately no StartsOn: it would have to sit slightly in the past to tolerate clock skew,
+      // which would put a per-request timestamp into the URL and defeat the stable-URL caching that
+      // SasExpiry.GetReadExpiry exists for.
+      ExpiresOn = expiresOn
+    };
+
+    builder.SetPermissions(permissions);
+
+    configure(builder);
+
+    // Signing with the account key is only possible when the client was built from a connection
+    // string carrying one, which is the local Azurite setup. In Azure the credential is a managed
+    // identity with no key to sign with, so a user delegation key is used instead.
+    if (userDelegationKeyProvider == null)
+    {
+      return blobClient.GenerateSasUri(builder);
+    }
+
+    UserDelegationKey key = await userDelegationKeyProvider.Get();
+
+    var query = builder.ToSasQueryParameters(key, containerClient.AccountName).ToString();
+
+    return new UriBuilder(blobClient.Uri) { Query = query }.Uri;
+  }
+}

--- a/api/Engraved.Storage.Azure/Source/BlobContainerClientFactory.cs
+++ b/api/Engraved.Storage.Azure/Source/BlobContainerClientFactory.cs
@@ -1,0 +1,38 @@
+using Azure.Identity;
+using Azure.Storage.Blobs;
+
+namespace Engraved.Storage.Azure;
+
+public static class BlobContainerClientFactory
+{
+  public static BlobServiceClient CreateServiceClient(IBlobStorageSettings settings)
+  {
+    if (!string.IsNullOrEmpty(settings.ConnectionString))
+    {
+      return new BlobServiceClient(settings.ConnectionString);
+    }
+
+    if (string.IsNullOrEmpty(settings.BlobEndpoint))
+    {
+      throw new InvalidOperationException(
+        $"File storage: either {nameof(IBlobStorageSettings.ConnectionString)} or "
+        + $"{nameof(IBlobStorageSettings.BlobEndpoint)} must be configured."
+      );
+    }
+
+    // No secret to configure or rotate: in Azure this resolves to the app service's managed
+    // identity, locally to the developer's Azure login.
+    return new BlobServiceClient(new Uri(settings.BlobEndpoint), new DefaultAzureCredential());
+  }
+
+  // Signing SAS tokens with the account key is only possible when the client was built from a
+  // connection string that carries one - i.e. local Azurite. Everywhere else a user delegation key
+  // is needed, and that provider must be shared so the key is fetched once rather than per URL.
+  public static UserDelegationKeyProvider? CreateUserDelegationKeyProvider(
+    BlobServiceClient serviceClient,
+    BlobContainerClient containerClient
+  )
+  {
+    return containerClient.CanGenerateSasUri ? null : new UserDelegationKeyProvider(serviceClient);
+  }
+}

--- a/api/Engraved.Storage.Azure/Source/IBlobStorageSettings.cs
+++ b/api/Engraved.Storage.Azure/Source/IBlobStorageSettings.cs
@@ -1,0 +1,14 @@
+namespace Engraved.Storage.Azure;
+
+public interface IBlobStorageSettings
+{
+  // Set for local development only, where Azurite is addressed with its well-known account key
+  // ("UseDevelopmentStorage=true"). In Azure this stays empty and the managed identity is used
+  // instead, so there is no secret to configure or rotate.
+  string? ConnectionString { get; }
+
+  // e.g. https://engravedfiles.blob.core.windows.net - used when no connection string is set.
+  string? BlobEndpoint { get; }
+
+  string ContainerName { get; }
+}

--- a/api/Engraved.Storage.Azure/Source/SasExpiry.cs
+++ b/api/Engraved.Storage.Azure/Source/SasExpiry.cs
@@ -1,0 +1,32 @@
+namespace Engraved.Storage.Azure;
+
+public static class SasExpiry
+{
+  // An upload URL is used immediately by the client that asked for it, so it does not need to
+  // survive long and is never worth caching.
+  public static readonly TimeSpan UploadValidity = TimeSpan.FromMinutes(15);
+
+  private static readonly TimeSpan MinimumReadValidity = TimeSpan.FromMinutes(15);
+
+  // Read URLs are rounded up to a full hour so that everyone asking for the same file within the
+  // same window gets a byte-identical URL. Without that, every request would produce a new signature,
+  // the URL would differ on every render, and the browser (and the service worker) could never reuse
+  // a response - each view of a scrap would re-download every image in it.
+  //
+  // The minimum offset keeps a request made just before the hour from receiving a URL that is
+  // already about to expire.
+  public static DateTimeOffset GetReadExpiry(DateTimeOffset now)
+  {
+    DateTimeOffset earliest = now.Add(MinimumReadValidity);
+
+    return new DateTimeOffset(
+      earliest.Year,
+      earliest.Month,
+      earliest.Day,
+      earliest.Hour,
+      0,
+      0,
+      earliest.Offset
+    ).AddHours(1);
+  }
+}

--- a/api/Engraved.Storage.Azure/Source/UserDelegationKeyProvider.cs
+++ b/api/Engraved.Storage.Azure/Source/UserDelegationKeyProvider.cs
@@ -1,0 +1,57 @@
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+
+namespace Engraved.Storage.Azure;
+
+// A user delegation key is what lets the managed identity sign SAS tokens without an account key.
+// Fetching one is a network call, so it is kept and reused: without this, every rendered image would
+// cost an extra round trip to the storage service before the URL could even be handed out.
+//
+// Uses the wall clock rather than IDateService on purpose - these lifetimes are validated by the
+// storage service against real time, so a shifted clock would only produce keys Azure rejects.
+public class UserDelegationKeyProvider(BlobServiceClient serviceClient)
+{
+  private static readonly TimeSpan KeyLifetime = TimeSpan.FromHours(24);
+
+  // Renew before the key actually expires, so a request never picks up a key that dies between being
+  // read here and being used by the browser.
+  private static readonly TimeSpan RenewBefore = TimeSpan.FromHours(2);
+
+  private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+  private UserDelegationKey? _key;
+
+  public async Task<UserDelegationKey> Get()
+  {
+    if (IsUsable(_key))
+    {
+      return _key!;
+    }
+
+    await _semaphore.WaitAsync();
+
+    try
+    {
+      // Another caller may have refreshed it while we waited.
+      if (IsUsable(_key))
+      {
+        return _key!;
+      }
+
+      DateTimeOffset now = DateTimeOffset.UtcNow;
+
+      _key = await serviceClient.GetUserDelegationKeyAsync(now.AddMinutes(-5), now.Add(KeyLifetime));
+
+      return _key;
+    }
+    finally
+    {
+      _semaphore.Release();
+    }
+  }
+
+  private static bool IsUsable(UserDelegationKey? key)
+  {
+    return key != null && key.SignedExpiresOn - DateTimeOffset.UtcNow > RenewBefore;
+  }
+}

--- a/api/Engraved.TestUtils/Source/TestUserRestrictedMongoRepository.cs
+++ b/api/Engraved.TestUtils/Source/TestUserRestrictedMongoRepository.cs
@@ -107,9 +107,9 @@ public class TestUserRestrictedMongoRepository : IUserRepository, IJournalReposi
     return _entryRepository.GetEntry(entryId);
   }
 
-  public Task<IEntry?> GetEntryByAttachmentId(string fileId)
+  public Task<IEntry?> GetEntryByFileId(string fileId)
   {
-    return _entryRepository.GetEntryByAttachmentId(fileId);
+    return _entryRepository.GetEntryByFileId(fileId);
   }
 
   public Task<IJournal[]> GetAllJournals(

--- a/api/Engraved.TestUtils/Source/TestUserRestrictedMongoRepository.cs
+++ b/api/Engraved.TestUtils/Source/TestUserRestrictedMongoRepository.cs
@@ -107,6 +107,11 @@ public class TestUserRestrictedMongoRepository : IUserRepository, IJournalReposi
     return _entryRepository.GetEntry(entryId);
   }
 
+  public Task<IEntry?> GetEntryByAttachmentId(string fileId)
+  {
+    return _entryRepository.GetEntryByAttachmentId(fileId);
+  }
+
   public Task<IJournal[]> GetAllJournals(
     string? searchText = null,
     ScheduleMode? scheduleMode = null,


### PR DESCRIPTION
Increment 1 of the file support plan discussed in #2987: the storage layer that files and inline images will build on. No UI yet — this adds the endpoints, the domain model and the store.

## Why blob storage and not the database

The obvious "no new service" answer was GridFS in the existing database. On the Cosmos free tier that turns out to be the wrong call, and the reason is throughput rather than bytes: the free tier is 1000 RU/s shared by the whole application, GridFS splits a file into 255 KB chunks, and RU cost scales with document size. Serving one 2 MB image is order-of-hundreds of RUs, so a scrap list with a few images could consume the per-second budget and start 429-ing **unrelated journal and entry queries**. Escaping that ceiling costs roughly $58/month per extra 1000 RU/s, against about $1.50/year for blob storage.

Blob storage also removes work rather than adding it: SAS URLs mean a plain `<img src>` works (the browser will not put a bearer token on an image request), bytes never pass through the app service, and a managed identity signs the tokens so there is no secret to configure or rotate.

## What is here

**`IFileStore` in `Engraved.Core`, implemented by the new `Engraved.Storage.Azure` project.** Core stays free of Azure types, matching the existing persistence split.

**Blob names are the bare file id.** Blob storage has no rename — what looks like a move is copy-then-delete, per blob, non-atomic — so anything mutable in the path (`journalId`, `entryId`) would turn an ordinary scrap move into a data migration. Every mutable relationship stays in the database, and `MoveEntryCommand` keeps touching nothing but `ParentId`.

**`Files` on `BaseEntry` holds every file an entry owns**, inline images included. One list means one lifecycle: deletion, quota accounting and orphan detection read this array instead of parsing the notes to work out which files are referenced.

**Two endpoints:**
- `POST /api/files` → `FileRef` + upload URL + read URL. Gated on **write** permission for the target journal, because the owning entry may not exist yet.
- `GET /api/files/{fileId}/url` → read URL. Resolves permission through the entry that owns the file, so files need no ACL of their own.

**Read URLs pin content type and disposition**, rather than trusting whatever was uploaded. That is what makes the SVG decision from #2987 enforceable: an SVG downloads instead of rendering as a live document, while still displaying inline in scraps, because `<img>` renders SVG script-free and ignores `Content-Disposition`.

**Expiry is rounded up to the next full hour.** Without this every request would produce a new signature, so the URL would differ on every render and the browser could never reuse a response — each view of a scrap would re-download every image in it.

**Local development and e2e fall back to Azurite** (`UseDevelopmentStorage=true`). Outside development a missing configuration throws rather than quietly pointing at a local emulator, mirroring how the mongo connection string behaves.

## Decisions worth a look during review

- **Both endpoints are queries, not commands.** `CommandResult` only carries an entity id, and nothing is persisted — a file id and a signed URL are minted, and the `FileRef` only reaches the database when the client saves the entry. Both set `DisableCache => true`.
- **`POST` hands back a read URL too.** Read permission resolves through the owning entry, so between uploading and saving there is nothing to resolve against and the client could not preview what it just uploaded.
- **The Azure store uses the wall clock, not `IDateService`.** `DateService.UtcNow` is captured at construction, so injecting it into a singleton store would freeze SAS expiry permanently. Azure validates these against real time anyway; the rounding logic lives in `SasExpiry` as a pure function with its own tests.

## Known limitations

- **The 10 MB limit is advisory.** A SAS cannot cap the size of a PUT, so a client that lies about `Length` still receives a signed URL. Real enforcement means verifying the stored blob size when the owning entry is saved, which belongs in increment 2. The code comment says this rather than implying a guarantee.
- **`GetEntryByFileId` needs an index on `Files.Id`.** No index-creation code was added because this repository has none anywhere — this is an operational step.
- **No frontend types yet.** An unused `IFileRef` would trip knip; they belong in increment 2 where something consumes them.

## Infrastructure this needs before the endpoints work

A storage account (StorageV2, LRS, hot, public network access on, hierarchical namespace **off** — blob index tags are needed for orphan cleanup later and are unsupported with it), a private `files` container, a system-assigned identity on **both** app services with `Storage Blob Data Contributor`, and CORS for the app origin. Locally, `npx azurite-blob`.

## Verification

`dotnet build` and `dotnet test` clean — **301 tests pass**, including permission paths for both endpoints, the SVG and file-name sanitisation rules, SAS expiry rounding, and the file round-trip through mongo (with a case pinning that entries written before the field existed still load).

Note unrelated to this branch: `npm run knip` exits 1 on `main` too — three unused exports in `searchJournalAttributes.ts` and `journalUtils.ts`.

Refs #2987

🤖 Generated with [Claude Code](https://claude.com/claude-code)
